### PR TITLE
Remove unused debugging code; Correct some signatures; Code format.

### DIFF
--- a/libcore/gof-file.c
+++ b/libcore/gof-file.c
@@ -685,6 +685,10 @@ gof_file_get_icon_pixbuf (GOFFile *file, gint size, gboolean force_size, GOFFile
     if (nicon) {
         g_object_unref (nicon);
     }
+
+    /* pantheon-files-core-C.vapi file indicates this function always returns non-null value */
+    g_assert (pix != NULL);
+
     return pix;
 }
 

--- a/libcore/marlin-icon-info.c
+++ b/libcore/marlin-icon-info.c
@@ -51,7 +51,7 @@ G_DEFINE_TYPE (MarlinIconInfo, marlin_icon_info, G_TYPE_OBJECT);
 /** This is required for testing themed icon functions under ctest when there is no default screen and
   * we have to set the icon theme manually.  We assume that any system being used for testing will have
   * the "hicolor" theme.
-  */   
+  */
 static GtkIconTheme *
 marlin_icon_info_get_gtk_icon_theme () {
     GtkIconTheme *theme;
@@ -273,30 +273,6 @@ schedule_reap_cache (void)
                                                          reap_cache,
                                                          NULL, NULL);
     }
-}
-
-void
-marlin_icon_info_infos_caches (void)
-{
-    /*if (loadable_icon_cache) {
-        g_warning (">>> %s loadable_icon_cache %u", G_STRFUNC,
-                   g_hash_table_size (loadable_icon_cache));
-    }
-    if (themed_icon_cache) {
-        g_warning (">>> %s themed_icon_cache %u", G_STRFUNC,
-                   g_hash_table_size (themed_icon_cache));
-    }*/
-
-    /*GList *l, *p;
-    GList *list = g_hash_table_get_keys (loadable_icon_cache);
-    GList *lvals = g_hash_table_get_values (loadable_icon_cache);
-    for (l = list, p = lvals; l!= NULL && p!=NULL; l= l->next, p = p->next) {
-        LoadableIconKey *key = l->data;
-        MarlinIconInfo *icon_info = MARLIN_ICON_INFO (p->data);
-        char *str_icon = g_icon_to_string (key->icon);
-        g_message ("reamining key %d %s val ref_count %u", key->size, str_icon, G_OBJECT (icon_info)->ref_count);
-        g_free (str_icon);
-    }*/
 }
 
 void

--- a/libcore/marlin-icon-info.h
+++ b/libcore/marlin-icon-info.h
@@ -64,7 +64,6 @@ GdkPixbuf *         marlin_icon_info_get_pixbuf_at_size         (MarlinIconInfo 
                                                                  gsize          forced_size);
 
 void                marlin_icon_info_clear_caches               (void);
-void                marlin_icon_info_infos_caches               (void);
 void                marlin_icon_info_remove_cache               (const char *path, int size);
 
 G_END_DECLS

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -160,11 +160,10 @@ namespace Marlin
     public class IconInfo : GLib.Object {
         public static IconInfo? lookup (GLib.Icon icon, int size);
         public static IconInfo? lookup_from_name (string icon_name, int size);
-        public Gdk.Pixbuf? get_pixbuf_nodefault();
-        public Gdk.Pixbuf? get_pixbuf_at_size(int size);
+        public Gdk.Pixbuf? get_pixbuf_nodefault ();
+        public Gdk.Pixbuf? get_pixbuf_at_size (int size);
         public static void clear_caches ();
         public static void remove_cache (string path, int size);
-        public static void infos_caches ();
     }
     [CCode (cheader_filename = "marlin-trash-monitor.h")]
     public abstract class TrashMonitor : GLib.Object
@@ -278,7 +277,7 @@ namespace GOF {
         public string formated_modified;
         public string formated_type;
         public string tagstype;
-        public Gdk.Pixbuf pix;
+        public Gdk.Pixbuf? pix;
         public int pix_size;
         public int width;
         public int height;

--- a/libcore/tests/MarlinIconInfoTests/marlincore-tests-icon-info.c
+++ b/libcore/tests/MarlinIconInfoTests/marlincore-tests-icon-info.c
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA.
- * 
+ *
  */
 
 #include <stdlib.h>
@@ -33,33 +33,18 @@ static gboolean fatal_handler(const gchar* log_domain,
     return FALSE;
 }
 
-static gboolean
-show_infos (gpointer data)
-{
-    marlin_icon_info_infos_caches ();
-    g_main_loop_quit (loop);
-
-    return FALSE;
-}
-
 void marlincore_tests_icon_info (void)
 {
     GOFFile* file;
     g_test_log_set_fatal_handler (fatal_handler, NULL);
-    /* The URI is valid, the target exists */
+    /* The URI is valid, the target must exist on Travis CI */
     file = gof_file_get_by_uri ("file:///usr/share/icons/hicolor/16x16/apps/system-file-manager.svg");
     g_assert(file != NULL);
     gof_file_query_update (file);
     g_assert(file->pix == NULL);
-    file->flags = 2;
+    file->flags = 2; /* ThumbState.READY */
     gof_file_update_icon (file, 128);
     g_assert(file->pix != NULL);
     gof_file_update_icon (file, 32);
-    /*gof_file_update_icon (file, 16);*/
-    g_message ("pix ref count %u", G_OBJECT (file->pix)->ref_count);
     g_object_unref (file->pix);
-    g_timeout_add_seconds_full (0, 2, show_infos, NULL, NULL);
-
-    loop = g_main_loop_new(NULL, FALSE);
-    g_main_loop_run(loop);
 }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -241,7 +241,7 @@ namespace FM {
 
                     /* Fix problems when navigating away from directory with large number
                      * of selected files (e.g. OverlayBar critical errors)
-                     */  
+                     */
                     disconnect_tree_signals ();
 
                     size_allocate.disconnect (on_size_allocate);
@@ -619,7 +619,7 @@ namespace FM {
             dir.file_changed.connect (on_directory_file_changed);
             dir.file_deleted.connect (on_directory_file_deleted);
             dir.icon_changed.connect (on_directory_file_icon_changed);
-            dir.thumbs_loaded.connect (on_directory_thumbs_loaded);
+//~             dir.thumbs_loaded.connect (on_directory_thumbs_loaded);
             connect_directory_loading_handlers (dir);
         }
 
@@ -646,7 +646,7 @@ namespace FM {
             dir.file_deleted.disconnect (on_directory_file_deleted);
             dir.icon_changed.disconnect (on_directory_file_icon_changed);
             dir.done_loading.disconnect (on_directory_done_loading);
-            dir.thumbs_loaded.disconnect (on_directory_thumbs_loaded);
+//~             dir.thumbs_loaded.disconnect (on_directory_thumbs_loaded);
         }
 
         public void change_directory (GOF.Directory.Async old_dir, GOF.Directory.Async new_dir) {
@@ -1347,9 +1347,9 @@ namespace FM {
             schedule_thumbnail_timeout ();
         }
 
-        private void on_directory_thumbs_loaded (GOF.Directory.Async dir) {
-            Marlin.IconInfo.infos_caches ();
-        }
+//~         private void on_directory_thumbs_loaded (GOF.Directory.Async dir) {
+//~             Marlin.IconInfo.infos_caches ();
+//~         }
 
     /** Handle zoom level change */
         private void on_zoom_level_changed (Marlin.ZoomLevel zoom) {
@@ -1964,7 +1964,7 @@ namespace FM {
             }
 
             if (!in_network_root) {
-                /* If something is pastable in the clipboard, show the option even if it is not enabled */ 
+                /* If something is pastable in the clipboard, show the option even if it is not enabled */
                 if (clipboard != null && clipboard.can_paste) {
                     menu.append_section (null, builder.get_object ("paste") as GLib.MenuModel);
                 }
@@ -2181,7 +2181,7 @@ namespace FM {
                            (file.get_ftype () != null && file.get_ftype () == "inode/directory") ||
                            file.is_smb_server ());
 
-            can_copy = file.is_readable (); 
+            can_copy = file.is_readable ();
             can_open = can_open_file (file);
             can_show_properties = !(in_recent && selection_count > 1);
 
@@ -2393,7 +2393,7 @@ namespace FM {
 
             /* In order to improve performance of the Icon View when there are a large number of files,
              * we freeze child notifications while the view is being scrolled or resized.
-             * The timeout is restarted for each scroll or size allocate event */  
+             * The timeout is restarted for each scroll or size allocate event */
             cancel_timeout (ref freeze_source_id);
             freeze_child_notify ();
             freeze_source_id = Timeout.add (100, () => {
@@ -2406,7 +2406,7 @@ namespace FM {
             });
 
             /* Views with a large number of files take longer to redraw (especially IconView) so
-             * we wait longer for scrolling to stop before updating the thumbnails */ 
+             * we wait longer for scrolling to stop before updating the thumbnails */
             uint delay = uint.min (50 + slot.directory.files_count / 10, 500);
             thumbnail_source_id = GLib.Timeout.add (delay, () => {
 
@@ -2425,7 +2425,7 @@ namespace FM {
 
                     /* To improve performance for large folders we thumbnail files on either side of visible region
                      * as well.  The delay is mainly in redrawing the view and this reduces the number of updates and
-                     * redraws necessary when scrolling */ 
+                     * redraws necessary when scrolling */
                     int count = 50;
                     while (start_path.prev () && count > 0) {
                         count--;
@@ -2461,7 +2461,7 @@ namespace FM {
                     }
                 }
 
-                /* This is the only place that new thumbnail files are created */ 
+                /* This is the only place that new thumbnail files are created */
                 /* Do not trigger a thumbnail request unless there are unthumbnailed files actually visible
                  * and there has not been another event (which would zero the thumbnail_source_if) */
                 if (actually_visible > 0 && thumbnail_source_id > 0) {
@@ -2602,7 +2602,7 @@ namespace FM {
             update_menu_actions ();
             selection_changed (get_selected_files ());
         }
- 
+
 /** Keyboard event handling **/
 
         /** Returns true if the code parameter matches the keycode of the keyval parameter for
@@ -2792,7 +2792,7 @@ namespace FM {
                         /* Only open a single selected folder */
                         unowned GLib.List<GOF.File> selection = get_selected_files ();
                         if (selection != null &&
-                            selection.length () == 1 && 
+                            selection.length () == 1 &&
                             selection.data.is_folder ()) {
 
                             load_location (selection.data.location);
@@ -2804,7 +2804,7 @@ namespace FM {
 
                     if (linear_select_required) { /* Only true for Icon View */
                         Gtk.TreePath? path = get_path_at_cursor ();
-            
+
                         if (path != null) {
                             Gtk.TreePath old_path = path;
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -619,7 +619,6 @@ namespace FM {
             dir.file_changed.connect (on_directory_file_changed);
             dir.file_deleted.connect (on_directory_file_deleted);
             dir.icon_changed.connect (on_directory_file_icon_changed);
-//~             dir.thumbs_loaded.connect (on_directory_thumbs_loaded);
             connect_directory_loading_handlers (dir);
         }
 
@@ -646,7 +645,6 @@ namespace FM {
             dir.file_deleted.disconnect (on_directory_file_deleted);
             dir.icon_changed.disconnect (on_directory_file_icon_changed);
             dir.done_loading.disconnect (on_directory_done_loading);
-//~             dir.thumbs_loaded.disconnect (on_directory_thumbs_loaded);
         }
 
         public void change_directory (GOF.Directory.Async old_dir, GOF.Directory.Async new_dir) {
@@ -1346,10 +1344,6 @@ namespace FM {
 
             schedule_thumbnail_timeout ();
         }
-
-//~         private void on_directory_thumbs_loaded (GOF.Directory.Async dir) {
-//~             Marlin.IconInfo.infos_caches ();
-//~         }
 
     /** Handle zoom level change */
         private void on_zoom_level_changed (Marlin.ZoomLevel zoom) {


### PR DESCRIPTION
* Function for printing out the contents of the icon caches removed, as not useful for CI.
* Remove message in test not useful for CI. (to be replaced with test)
* Correct signatures of some functions returning Pixbufs.
* Insert some missing spaces.