### PR TITLE
Fix async test 2

### DIFF
--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -108,6 +108,8 @@ public class Async : Object {
 
     public string last_error_message {get; private set; default = "";}
 
+    public bool loaded_from_cache {get; private set; default = false;}
+
     private Async (GLib.File _file) {
         /* Ensure uri is correctly escaped and has scheme */
         var escaped_uri = PF.FileUtils.escape_uri (_file.get_uri ());
@@ -159,6 +161,7 @@ public class Async : Object {
         }
 
         var previous_state = state;
+        loaded_from_cache = false;
 
         cancellable.cancel ();
         cancellable = new Cancellable ();
@@ -536,6 +539,7 @@ public class Async : Object {
         can_load = false;
 
         state = State.NOT_LOADED;
+        loaded_from_cache = false;
     }
 
     private void list_cached_files (GOFFileLoadedFunc? file_loaded_func = null) {
@@ -552,7 +556,10 @@ public class Async : Object {
                 after_load_file (gof, show_hidden, file_loaded_func);
             }
         }
+
         state = State.LOADED;
+        loaded_from_cache = true;
+
         after_loading (file_loaded_func);
     }
 
@@ -657,6 +664,7 @@ public class Async : Object {
             }
         } finally {
             cancel_timeout (ref load_timeout_id);
+            loaded_from_cache = false;
             after_loading (file_loaded_func);
         }
     }

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -519,7 +519,6 @@ public class Async : Object {
         }
 
         clear_directory_info ();
-        state = State.NOT_LOADED;
         init ();
     }
 
@@ -535,6 +534,8 @@ public class Async : Object {
         files_count = 0;
         is_ready = false;
         can_load = false;
+
+        state = State.NOT_LOADED;
     }
 
     private void list_cached_files (GOFFileLoadedFunc? file_loaded_func = null) {
@@ -680,12 +681,12 @@ public class Async : Object {
             can_load = false;
         }
 
-        if (file_loaded_func == null) {
-            done_loading ();
-        }
-
         if (state != State.LOADED) {
             clear_directory_info ();
+        }
+
+        if (file_loaded_func == null) {
+            done_loading ();
         }
     }
 

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -23,12 +23,6 @@ private HashTable<GLib.File,GOF.Directory.Async> directory_cache;
 private Mutex dir_cache_lock;
 
 namespace GOF.Directory {
-namespace TestMessages {
-    public const string FAIL_PREPARE_FILEINFO = "Failed to get file info while preparing directory";
-    public const string CANNOT_LOAD = "Unable to load after preparing directory";
-    public const string LOAD_FILE = "Loading children from directory file";
-    public const string LOAD_CACHE = "Loading children from cache";
-}
 
 public class Async : Object {
     public delegate void GOFFileLoadedFunc (GOF.File file);
@@ -163,6 +157,7 @@ public class Async : Object {
             debug ("Directory Init re-entered - already loading");
             return; /* Do not re-enter */
         }
+
         var previous_state = state;
 
         cancellable.cancel ();
@@ -204,13 +199,12 @@ public class Async : Object {
                     success = false;
                 }
             }
-        } else {
-            debug (TestMessages.FAIL_PREPARE_FILEINFO);
         }
 
         if (success) {
             file.update ();
         }
+
         debug ("success %s; enclosing mount %s", success.to_string (), file.mount != null ? file.mount.get_name () : "null");
         yield make_ready (is_no_info || success, file_loaded_func); /* Only place that should call this function */
     }
@@ -402,7 +396,6 @@ public class Async : Object {
         can_load = ready;
 
         if (!can_load) {
-            debug (TestMessages.CANNOT_LOAD);
             debug ("Cannot load %s.  Connected %s, Mounted %s, Exists %s", file.uri,
                                                                            file.is_connected.to_string (),
                                                                            file.is_mounted.to_string (),
@@ -551,8 +544,6 @@ public class Async : Object {
             return;
         }
 
-        debug (TestMessages.LOAD_CACHE);
-
         state = State.LOADING;
         bool show_hidden = is_trash || Preferences.get_default ().show_hidden_files;
         foreach (GOF.File gof in file_hash.get_values ()) {
@@ -594,8 +585,6 @@ public class Async : Object {
         state = State.LOADING;
         bool show_hidden = is_trash || Preferences.get_default ().show_hidden_files;
         bool server_responding = false;
-
-        debug (TestMessages.LOAD_FILE);
 
         try {
             /* This may hang for a long time if the connection was closed but is still mounted so we

--- a/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
+++ b/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
@@ -80,6 +80,10 @@ Async load_empty_local_test (string test_dir_path, MainLoop loop) {
     dir.done_loading.connect (() => {
         assert (dir.files_count == 0);
         assert (dir.can_load);
+        assert (dir.file.is_connected);
+        assert (!dir.file.is_mounted);
+        assert (dir.file.exists);
+        assert (dir.state == Async.State.LOADED);
         loop.quit ();
     });
 

--- a/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
+++ b/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
@@ -46,6 +46,8 @@ void run_load_folder_test (LoadFolderTest test) {
 
     var dir = test (test_dir_path, loop);
 
+    assert (dir.state == Async.State.NOT_LOADED);
+
     dir.init ();
     loop.run ();
 
@@ -62,12 +64,8 @@ Async load_non_existent_local_test (string test_dir_path, MainLoop loop) {
     dir.done_loading.connect (() => {
         assert (dir.files_count == 0);
         assert (!dir.can_load);
-        Test.assert_expected_messages ();
         loop.quit ();
     });
-
-    Test.expect_message (null, GLib.LogLevelFlags.LEVEL_DEBUG, "*" + TestMessages.FAIL_PREPARE_FILEINFO);
-    Test.expect_message (null, GLib.LogLevelFlags.LEVEL_DEBUG, "*" + TestMessages.CANNOT_LOAD);
 
     return dir;
 }
@@ -102,12 +100,9 @@ Async load_populated_local_test (string test_dir_path, MainLoop loop) {
         assert (dir.state == Async.State.LOADED);
         assert (file_loaded_signal_count == n_files);
 
-        Test.assert_expected_messages ();
-
         loop.quit ();
     });
 
-    Test.expect_message (null, GLib.LogLevelFlags.LEVEL_DEBUG, "*" + TestMessages.LOAD_FILE);
     return dir;
 }
 
@@ -125,14 +120,12 @@ Async load_cached_local_test (string test_dir_path, MainLoop loop) {
                 file_loaded_signal_count++;
             });
 
-            Test.expect_message (null, GLib.LogLevelFlags.LEVEL_DEBUG, "*" + TestMessages.LOAD_CACHE);
             dir.init ();
         } else {
             assert (dir.files_count == n_files);
             assert (dir.can_load);
             assert (dir.state == Async.State.LOADED);
             assert (file_loaded_signal_count == n_files);
-            Test.assert_expected_messages ();
 
             loop.quit ();
         }
@@ -164,8 +157,6 @@ Async reload_populated_local_test (string test_dir_path, MainLoop loop) {
             assert (dir.state == Async.State.LOADED);
             assert (dir.ref_count == ref_count_before_reload);
 
-            Test.assert_expected_messages ();
-
             tear_down_file (tmp_pth);
 
             /* Test for problem with toggle ref after reloading (lp:1665620) */
@@ -176,7 +167,6 @@ Async reload_populated_local_test (string test_dir_path, MainLoop loop) {
         }
     });
 
-    Test.expect_message (null, GLib.LogLevelFlags.LEVEL_DEBUG, "*" + TestMessages.LOAD_FILE);
     return dir;
 }
 
@@ -223,6 +213,7 @@ void tear_down_file (string path) {
     Posix.system ("rm -f " + path);
 }
 }
+
 
 int main (string[] args) {
     Test.init (ref args);

--- a/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
+++ b/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
@@ -64,6 +64,10 @@ Async load_non_existent_local_test (string test_dir_path, MainLoop loop) {
     dir.done_loading.connect (() => {
         assert (dir.files_count == 0);
         assert (!dir.can_load);
+        assert (!dir.file.is_connected);
+        assert (!dir.file.is_mounted);
+        assert (!dir.file.exists);
+        assert (dir.state == Async.State.NOT_LOADED);
         loop.quit ();
     });
 

--- a/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
+++ b/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
@@ -128,13 +128,14 @@ Async load_cached_local_test (string test_dir_path, MainLoop loop) {
                 file_loaded_signal_count++;
             });
 
+            assert (!dir.loaded_from_cache);
             dir.init ();
         } else {
             assert (dir.files_count == n_files);
             assert (dir.can_load);
             assert (dir.state == Async.State.LOADED);
             assert (file_loaded_signal_count == n_files);
-
+            assert (dir.loaded_from_cache);
             loop.quit ();
         }
     });
@@ -151,10 +152,12 @@ Async reload_populated_local_test (string test_dir_path, MainLoop loop) {
     var dir = setup_temp_async (test_dir_path, n_files, "txt", tmp_pth);
 
     dir.done_loading.connect (() => {
+        assert (!dir.loaded_from_cache);
+
         if (loads == 0) {
             ref_count_before_reload = dir.ref_count;
-
         }
+
         if (loads < n_loads) {
             loads++;
             dir.cancel ();


### PR DESCRIPTION
Abandon Test.assert_expected_messages () - now deprecated - in favour of other assertions.