### PR TITLE
Allow user interaction property

### DIFF
--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -99,6 +99,7 @@ public class Async : Object {
     public bool can_load {get; private set;}
     public bool can_open_files {get; private set;}
     public bool can_stream_files {get; private set;}
+    public bool allow_user_interaction {get; set; default = true;}
 
     private bool is_ready = false;
 
@@ -282,7 +283,7 @@ public class Async : Object {
     private async bool mount_mountable () {
         debug ("mount_mountable");
         bool res = false;
-        var mount_op = new Gtk.MountOperation (null);
+        Gtk.MountOperation? mount_op = null;
         cancellable = new Cancellable ();
 
         try {
@@ -304,15 +305,19 @@ public class Async : Object {
                 }
             });
 
-            mount_op.ask_password.connect (() => {
-                debug ("Asking for password");
-                asking_password = true;
-            });
+            if (allow_user_interaction) {
+                mount_op = new Gtk.MountOperation (null);
 
-            mount_op.reply.connect (() => {
-                debug ("Password dialog finished");
-                asking_password = false;
-            });
+                mount_op.ask_password.connect (() => {
+                    debug ("Asking for password");
+                    asking_password = true;
+                });
+
+                mount_op.reply.connect (() => {
+                    debug ("Password dialog finished");
+                    asking_password = false;
+                });
+            }
 
             debug ("mounting ....");
             res =yield location.mount_enclosing_volume (GLib.MountMountFlags.NONE, mount_op, cancellable);

--- a/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
+++ b/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
@@ -45,6 +45,7 @@ void run_load_folder_test (LoadFolderTest test) {
     string test_dir_path = "/tmp/marlin-test-" + get_real_time ().to_string ();
 
     var dir = test (test_dir_path, loop);
+    dir.allow_user_interaction = false;
 
     assert (dir.state == Async.State.NOT_LOADED);
 


### PR DESCRIPTION
* Add allow_user_interaction property to GOF.Directory.Async; default true.
* Do not use MountOperation (ask for password) unless this property is true.
* Set this property to false during ctesting.

This should fix a failure of Travis CI.