### PR TITLE
Check for zero tabs when tab removed by dragging.

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -71,7 +71,7 @@ namespace Marlin.View {
         public signal void loading_uri (string location);
         public signal void folder_deleted (GLib.File location);
         public signal void free_space_change ();
-        
+
         [Signal (action=true)]
         public virtual signal void go_back() {
             current_tab.go_back ();
@@ -198,7 +198,7 @@ namespace Marlin.View {
             top_menu.set_show_close_button (true);
             top_menu.set_custom_title (new Gtk.Label (null));
         }
-                
+
         private void construct_info_bar () {
             info_bar = new Gtk.InfoBar ();
 
@@ -342,6 +342,8 @@ namespace Marlin.View {
                 });
             });
 
+            tabs.tab_removed.connect (on_tab_removed);
+
             sidebar.request_focus.connect (() => {
                 return !current_tab.locked_focus && !top_menu.locked_focus;
             });
@@ -391,6 +393,12 @@ namespace Marlin.View {
                     break;
             }
             return result;
+        }
+
+        private void on_tab_removed () {
+            if (tabs.n_tabs == 0) {
+                add_tab ();
+            }
         }
 
         private void on_go_forward (int n = 1) {
@@ -911,6 +919,8 @@ namespace Marlin.View {
                 save_tabs ();
             }
 
+            tabs.tab_removed.disconnect (on_tab_removed); /* Avoid infinite loop */
+
             foreach (var tab in tabs.tabs) {
                 current_tab = null;
                 (tab.page as Marlin.View.ViewContainer).close ();
@@ -995,7 +1005,7 @@ namespace Marlin.View {
 
                 /* We do not check valid location here because it may cause the interface to hang
                  * before the window appears (e.g. if trying to connect to a server that has become unavailable)
-                 * Leave it to GOF.Directory.Async to deal with invalid locations asynchronously. 
+                 * Leave it to GOF.Directory.Async to deal with invalid locations asynchronously.
                  */
 
                 add_tab_by_uri (root_uri, mode);
@@ -1127,9 +1137,9 @@ namespace Marlin.View {
 
             if (flag == Marlin.OpenFlag.DEFAULT) {
                 grab_focus ();
-                /* Focus_location will not unnecessarily load the current directory if location is 
+                /* Focus_location will not unnecessarily load the current directory if location is
                  * normal file in the current directory, otherwise it will call user_path_change_request
-                 */  
+                 */
                 current_tab.focus_location (loc);
             } else {
                 new_container_request (loc, flag);


### PR DESCRIPTION
* When a tab is dragged out of the notebook, the tab_removed signal is generated.
* This signal is handled to create a new home tab if the removed tab was the last.
* The handler is disconnected before quitting the window to avoid an infinite loop.

Fixes #49 