### PR TITLE
Fix #65 unselect individual

### DIFF
--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -138,7 +138,7 @@ namespace Marlin {
                     state |= widget.get_state_flags ();
 
                     var bg = style_context.get_property ("background-color", state);
-                    
+
                     if (bg.holds (typeof (Gdk.RGBA))) {
                         var color = (Gdk.RGBA) bg;
 
@@ -180,6 +180,7 @@ namespace Marlin {
 
                     var nicon = Marlin.IconInfo.lookup_from_name (special_icon_name, helper_size);
                     Gdk.Pixbuf? pix = null;
+
                     if (nicon != null) {
                         pix = nicon.get_pixbuf_nodefault ();
                     }
@@ -291,7 +292,7 @@ namespace Marlin {
                pixbuf */
 
             int s = int.max (pixbuf_width, pixbuf_height);
-            scale = double.min (1.0, (double)icon_size / s); /* scaling to make pix required icon_size (not taking into account screen scaling) */ 
+            scale = double.min (1.0, (double)icon_size / s); /* scaling to make pix required icon_size (not taking into account screen scaling) */
 
             width = (int)(calc_width * scale);
             height = (int)(calc_height * scale);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2900,7 +2900,6 @@ namespace FM {
                 return true;
 
             click_zone = get_event_position_info ((Gdk.EventButton)event, out path, false);
-            GOF.File? file = path != null ? model.file_for_path (path) : null;
 
             if (click_zone != previous_click_zone) {
                 var win = view.get_window ();
@@ -2931,6 +2930,8 @@ namespace FM {
                 if (slot.directory.is_local || NetworkMonitor.get_default ().get_network_available ()) {
                     /* cannot get file info while network disconnected. */
                     GOF.File? target_file;
+                    GOF.File? file = path != null ? model.file_for_path (path) : null;
+
                     if (file != null && slot.directory.is_recent) {
                         target_file = GOF.File.get_by_uri (file.get_display_target_uri ());
                         target_file.ensure_query_info ();
@@ -3556,7 +3557,7 @@ namespace FM {
         protected new abstract void thaw_child_notify ();
         protected abstract void connect_tree_signals ();
         protected abstract void disconnect_tree_signals ();
-        protected abstract bool is_on_icon (int x, int y, int orig_x, int orig_y, ref bool on_helper);
+        protected abstract bool is_on_icon (int x, int y, Gdk.Rectangle area, Gdk.Pixbuf pix, ref bool on_helper);
 
 /** Unimplemented methods
  *  fm_directory_view_parent_set ()  - purpose unclear

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -457,7 +457,6 @@ namespace FM {
             int x_offset = x - area.x;
             int y_offset = y - area.y;
 
-            /* Area.height includes name as well. Assume area for icon is square */
             int pix_x_offset = (area.width - pix.width) / 2;
             int pix_y_offset = (area.height - pix.height) / 2;
 


### PR DESCRIPTION
Fixes #65.

The code determining what part of the fileitem was clicked on is reworked and no longer relies on helper coordinates obtained from iconrenderer (which may not refer to the current item when there is a multiple selection).