### PR TITLE
Fix #76 - Compile with option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,40 +33,28 @@ find_package (PkgConfig)
 OPTION (WITH_UNITY "Add Unity launcher support" ON)
 pkg_check_modules (UNITY unity>=4.0.0)
 
+set(COMMON_DEPS
+    granite>=0.3.0
+    glib-2.0>=2.29.0
+    gthread-2.0
+    gio-2.0
+    gio-unix-2.0
+    pango>=1.1.2
+    gtk+-3.0>=3.14
+    gmodule-2.0
+    gail-3.0
+    gee-0.8
+    sqlite3
+    dbus-glib-1
+    libcanberra>=0.30
+    zeitgeist-2.0
+)
+
 if (WITH_UNITY AND UNITY_FOUND)
-    pkg_check_modules (DEPS REQUIRED
-        granite>=0.3.0
-        glib-2.0>=2.29.0
-        gthread-2.0
-        gio-2.0
-        gio-unix-2.0
-        pango>=1.1.2
-        gtk+-3.0>=3.14
-        gmodule-2.0
-        gail-3.0
-        gee-0.8
-        sqlite3
-        dbus-glib-1
-        libcanberra>=0.30
-        zeitgeist-2.0
-        plank)
-else (WITH_UNITY AND UNITY_FOUND)
-    pkg_check_modules (DEPS REQUIRED
-        granite>=0.3.0
-        glib-2.0>=2.29.0
-        gthread-2.0
-        gio-2.0
-        gio-unix-2.0
-        pango>=1.1.2
-        gtk+-3.0>=3.14
-        gmodule-2.0
-        gail-3.0
-        gee-0.8
-        sqlite3
-        dbus-glib-1
-        libcanberra>=0.30
-        zeitgeist-2.0)
-endif (WITH_UNITY AND UNITY_FOUND)
+    pkg_check_modules (DEPS REQUIRED ${COMMON_DEPS} plank)
+else ()
+    pkg_check_modules (DEPS REQUIRED ${COMMON_DEPS})
+endif ()
 
 if (MODULE_ONLY)
     add_subdirectory (filechooser-module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package (PkgConfig)
 OPTION (WITH_UNITY "Add Unity launcher support" ON)
 pkg_check_modules (UNITY unity>=4.0.0)
 
-set(COMMON_DEPS
+set (COMMON_DEPS
     granite>=0.3.0
     glib-2.0>=2.29.0
     gthread-2.0
@@ -58,10 +58,10 @@ endif ()
 
 if (MODULE_ONLY)
     add_subdirectory (filechooser-module)
-ELSEIF (LIB_ONLY)
+elseif (LIB_ONLY)
     add_subdirectory (libcore)
     add_subdirectory (libwidgets)
-ELSE ()
+else ()
     add_subdirectory (src)
     add_subdirectory (data)
     add_subdirectory (pantheon-files-daemon)
@@ -69,5 +69,4 @@ ELSE ()
     add_subdirectory (libwidgets)
     add_subdirectory (plugins)
     add_subdirectory (filechooser-module)
-    add_subdirectory (po)
-ENDIF ()
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,46 @@ include (ValaVersion)
 ensure_vala_version ("0.34.0" MINIMUM)
 include (ValaPrecompile)
 
+find_package (PkgConfig)
+
+OPTION (WITH_UNITY "Add Unity launcher support" ON)
+pkg_check_modules (UNITY unity>=4.0.0)
+
+if (WITH_UNITY AND UNITY_FOUND)
+    pkg_check_modules (DEPS REQUIRED
+        granite>=0.3.0
+        glib-2.0>=2.29.0
+        gthread-2.0
+        gio-2.0
+        gio-unix-2.0
+        pango>=1.1.2
+        gtk+-3.0>=3.14
+        gmodule-2.0
+        gail-3.0
+        gee-0.8
+        sqlite3
+        dbus-glib-1
+        libcanberra>=0.30
+        zeitgeist-2.0
+        plank)
+else (WITH_UNITY AND UNITY_FOUND)
+    pkg_check_modules (DEPS REQUIRED
+        granite>=0.3.0
+        glib-2.0>=2.29.0
+        gthread-2.0
+        gio-2.0
+        gio-unix-2.0
+        pango>=1.1.2
+        gtk+-3.0>=3.14
+        gmodule-2.0
+        gail-3.0
+        gee-0.8
+        sqlite3
+        dbus-glib-1
+        libcanberra>=0.30
+        zeitgeist-2.0)
+endif (WITH_UNITY AND UNITY_FOUND)
+
 if (MODULE_ONLY)
     add_subdirectory (filechooser-module)
 ELSEIF (LIB_ONLY)

--- a/filechooser-module/CMakeLists.txt
+++ b/filechooser-module/CMakeLists.txt
@@ -5,7 +5,16 @@ include_directories (${CMAKE_SOURCE_DIR}/libcore/)
 include_directories (${CMAKE_BINARY_DIR}/libcore/)
 include_directories (${CMAKE_BINARY_DIR}/libwidgets/)
 
+if (MODULE_ONLY)
+    include_directories (${CMAKE_INSTALL_PREFIX}/include/pantheon-files-widgets/)
+    include_directories (${CMAKE_INSTALL_PREFIX}/include/pantheon-files-core/)
+endif ()
+
 pkg_check_modules (DEPS REQUIRED glib-2.0 gthread-2.0 gtk+-3.0>=3.10 granite gee-0.8)
+
+if (MODULE_ONLY)
+    pkg_check_modules (DEPS REQUIRED pantheon-files-widgets pantheon-files-core)
+endif ()
 
 add_definitions (${DEPS_CFLAGS})
 link_directories (${DEPS_LIBRARY_DIRS})
@@ -29,8 +38,7 @@ OPTIONS
 
 link_libraries(${DEPS_LIBRARIES})
 add_library (${MODULE_NAME} MODULE ${VALA_C})
-target_link_libraries (${MODULE_NAME} ${DEPS_LIBRARIES} pantheon-files-widgets pantheon-files-core
-)
+target_link_libraries (${MODULE_NAME} ${DEPS_LIBRARIES} pantheon-files-widgets pantheon-files-core)
 
 # Installation
 install (TARGETS ${MODULE_NAME} DESTINATION "${MODULE_LIBDIR}")

--- a/libcore/CMakeLists.txt
+++ b/libcore/CMakeLists.txt
@@ -34,6 +34,7 @@ PACKAGES
     libcanberra
     pantheon-files-core-C
     posix
+    zeitgeist-2.0
 OPTIONS
     --vapidir=${CMAKE_CURRENT_SOURCE_DIR}/
     --thread
@@ -148,4 +149,3 @@ target_link_libraries (${PKGNAME} m ${DEPS_LIBRARIES})
 install (TARGETS ${PKGNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 add_subdirectory (tests)
-

--- a/libcore/tests/MarlinIconInfoTests/CMakeLists.txt
+++ b/libcore/tests/MarlinIconInfoTests/CMakeLists.txt
@@ -26,6 +26,8 @@ vala_precompile (VALA_TEST_C ${TEST_NAME}
   MarlinIconInfoTests.vala
   PACKAGES
     gtk+-3.0
+    granite
+    gee-0.8
     posix
     pantheon-files-core
     pantheon-files-core-C

--- a/libcore/tests/MarlinIconInfoTests/CMakeLists.txt
+++ b/libcore/tests/MarlinIconInfoTests/CMakeLists.txt
@@ -28,9 +28,10 @@ vala_precompile (VALA_TEST_C ${TEST_NAME}
     gtk+-3.0
     posix
     pantheon-files-core
+    pantheon-files-core-C
   OPTIONS
-    --vapidir=${CMAKE_CURRENT_SOURCE_DIR}/
     --vapidir=${CMAKE_SOURCE_DIR}/libcore/
+    --vapidir=${CMAKE_BINARY_DIR}/libcore/
     --thread
     --target-glib=2.32 # Needed for new thread API
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,44 +13,6 @@ include_directories (${CMAKE_BINARY_DIR}/libwidgets/)
 
 find_package (PkgConfig)
 
-OPTION (WITH_UNITY "Add Unity launcher support" ON)
-pkg_check_modules (UNITY unity>=4.0.0)
-
-if (WITH_UNITY AND UNITY_FOUND)
-    pkg_check_modules (DEPS REQUIRED
-        granite>=0.3.0
-        glib-2.0>=2.29.0
-        gthread-2.0
-        gio-2.0
-        gio-unix-2.0
-        pango>=1.1.2
-        gtk+-3.0>=3.14
-        gmodule-2.0
-        gail-3.0
-        gee-0.8
-        sqlite3
-        dbus-glib-1
-        libcanberra>=0.30
-        zeitgeist-2.0
-        plank)
-else (WITH_UNITY AND UNITY_FOUND)
-    pkg_check_modules (DEPS REQUIRED
-        granite>=0.3.0
-        glib-2.0>=2.29.0
-        gthread-2.0
-        gio-2.0
-        gio-unix-2.0
-        pango>=1.1.2
-        gtk+-3.0>=3.14
-        gmodule-2.0
-        gail-3.0
-        gee-0.8
-        sqlite3
-        dbus-glib-1
-        libcanberra>=0.30
-        zeitgeist-2.0)
-endif (WITH_UNITY AND UNITY_FOUND)
-
 pkg_check_modules(PLANK011 QUIET plank>=0.10.9)
 if (PLANK011_FOUND)
   set (PLANK_OPTIONS --define=HAVE_PLANK_0_11)


### PR DESCRIPTION
The compile options "MODULE_ONLY" and "LIB_ONLY" were previously provided but now fail to compile.  This branch modifies some CMakeLists to allow compilation to complete.

Some missing lines from the CMakeLists.txt for MarlinIconInfoTests.vala were also inserted (although under normal circumstances this did not lead to failure to build, e.g. in Travis CI, the linked issue indicated that failure was possible under some circumstance).

Fixes #76 (to be confirmed on a system where failure occurs)