### PR TITLE
add po folder to cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,3 +70,5 @@ else ()
     add_subdirectory (plugins)
     add_subdirectory (filechooser-module)
 endif ()
+
+add_subdirectory (po)


### PR DESCRIPTION
Adds the `po` directory to cmake, enabling translations again.