### PR TITLE
Check for null file in get_event_position_info () (issue #89)

### DIFF
--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -135,14 +135,14 @@ namespace FM {
 
         /* Avoid using this function with "cursor_follows = true" to select large numbers of files one by one
          * It would take an exponentially long time. Use "select_files" function in parent class.
-         */  
+         */
         public override void select_path (Gtk.TreePath? path, bool cursor_follows = false) {
             if (path != null) {
                 var selection = tree.get_selection ();
                 selection.select_path (path);
                 if (cursor_follows) {
                     /* Unlike for IconView, set_cursor unselects previously selected paths (Gtk bug?),
-                     * so we have to remember them and reselect afterwards */ 
+                     * so we have to remember them and reselect afterwards */
                     GLib.List<Gtk.TreePath> selected_paths = null;
                     selection.selected_foreach ((m, p, i) => {
                         selected_paths.prepend (p);
@@ -234,7 +234,9 @@ namespace FM {
             if (p != null && c != null && c == name_column) {
                 GOF.File? file = model.file_for_path (p);
 
-                if (x < rect.x + ICON_XPAD + icon_size) { /* cannot be on name */
+                if (file == null) {
+                    zone = ClickZone.INVALID;
+                } else if (x < rect.x + ICON_XPAD + icon_size) { /* cannot be on name */
                     bool on_helper = false;
                     bool on_icon = is_on_icon (x, y, rect, file.pix, ref on_helper);
 
@@ -295,7 +297,7 @@ namespace FM {
             } else {
                 select_path (path);
             }
-            
+
             set_cursor_on_cell (path, name_renderer, start_editing, scroll_to_top);
 
             if (!select) {

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -246,18 +246,21 @@ namespace FM {
                 } else {
                     bool on_helper = false;
                     GOF.File? file = model.file_for_path (p);
+                    if (file != null) {
+                        bool on_icon = is_on_icon (x, y, rect, file.pix, ref on_helper);
 
-                    bool on_icon = is_on_icon (x, y, rect, file.pix, ref on_helper);
-
-                    if (on_helper) {
-                        zone = ClickZone.HELPER;
-                    } else if (on_icon) {
-                        zone = ClickZone.ICON;
-                    } else if (rubberband) {
-                        /* Fake location outside centre top of item for rubberbanding */
-                        event.x = rect.x + rect.width / 2;
-                        event.y = rect.y - 10 + (int)(get_vadjustment ().value);
-                        zone = ClickZone.BLANK_NO_PATH;
+                        if (on_helper) {
+                            zone = ClickZone.HELPER;
+                        } else if (on_icon) {
+                            zone = ClickZone.ICON;
+                        } else if (rubberband) {
+                            /* Fake location outside centre top of item for rubberbanding */
+                            event.x = rect.x + rect.width / 2;
+                            event.y = rect.y - 10 + (int)(get_vadjustment ().value);
+                            zone = ClickZone.BLANK_NO_PATH;
+                        }
+                    } else {
+                        zone = ClickZone.INVALID;
                     }
                 }
             }


### PR DESCRIPTION
Fixes #89. Caused by referencing a null file being returned from the dummy blank row representing an expanded empty directory when determining event position.

Fixed by checking if file is null first. 