### PR TITLE
Mount and browse compressed files as read-only folders

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -327,6 +327,7 @@ namespace PF.FileUtils {
     }
 
     public string construct_archive_uri (string _uri) {
+        /* Need to add extra escaping to mount with gvfs-archive */
         string uri = _uri;
         if (!uri.has_prefix ("archive")) {
             uri = escape_uri (uri);
@@ -347,12 +348,17 @@ namespace PF.FileUtils {
         return uri;
     }
 
-    public string strip_archive_prefix (string uri) {
+    public string strip_archive_prefix (string _uri) {
+        /* Convert special archive uri to "normal" uri */
+        string uri = unescape_uri (_uri); /* Remove special escaping */
         if (uri.has_prefix ("archive://")) {
-            return unescape_uri (uri.slice ("archive://".length, -1));
-        } else {
-            return Uri.unescape_string (uri);
+            uri = uri.slice ("archive://".length, uri.length);
+            if (uri.has_prefix ("/file:")) { /* Do not assume 2 or 3 slashes after archive */
+                uri = uri.slice (1, uri.length); /* Remove third slash if present */
+            }
         }
+
+        return uri;
     }
 
     public string get_smb_share_from_uri (string uri) {

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -207,7 +207,7 @@ namespace PF.FileUtils {
         split_protocol_from_path (unescaped_p, out scheme, out path);
         path = path.strip ().replace ("//", "/");
         StringBuilder sb = new StringBuilder (path);
-        if (cp != null) {ri =
+        if (cp != null) {
             split_protocol_from_path (cp, out current_scheme, out current_path);
             /* current_path is assumed already sanitized */
                 if (scheme == "" && path.has_prefix ("/./")) {

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -21,6 +21,9 @@ namespace PF.FileUtils {
      **/
     const string reserved_chars = (GLib.Uri.RESERVED_CHARS_GENERIC_DELIMITERS + GLib.Uri.RESERVED_CHARS_SUBCOMPONENT_DELIMITERS + " ");
 
+    /* Selection of extensions of file types mountable with gvfs-archive */
+    const string[] archive_types = {".zip", ".deb", ".xz", ".gz", ".tar", ".tar.Z", ".bz2"};
+
     public File? get_file_for_path (string? path) {
         string? new_path = sanitize_path (path);
 
@@ -292,6 +295,20 @@ namespace PF.FileUtils {
             return false;
         }
         return true;
+    }
+
+    public bool is_archive_from_extension (string uri) {
+        foreach (string extension in archive_types) {
+            if (uri.has_suffix (extension)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public string construct_archive_uri (string uri) {
+        return "archive://" + uri.replace (Path.DIR_SEPARATOR_S, "%2F").replace (":", "%3A").replace ("%", "%25");
     }
 
     public string get_smb_share_from_uri (string uri) {

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -403,9 +403,10 @@ namespace PF.FileUtils {
             }
         }
 
-        Uri.escape_string (remainder);
+        remainder = escape_uri (remainder);
 
         var u = prefix.concat (archive_uri, sep, remainder);
+
         return u;
 
     }

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -175,10 +175,17 @@ namespace PF.FileUtils {
             return cp ?? "";
         }
 
+        if (p.has_prefix ("archive")) {
+            /* Do not mess with special archive url format for now */
+            return p;
+        }
+
         string? unescaped_p = Uri.unescape_string (p, null);
         if (unescaped_p == null) {
             unescaped_p = p;
         }
+
+
 
         split_protocol_from_path (unescaped_p, out scheme, out path);
         path = path.strip ().replace ("//", "/");
@@ -244,6 +251,7 @@ namespace PF.FileUtils {
             new_path = "";
             return;
         }
+
         if (explode_protocol.length > 1) {
             if (explode_protocol[0] == "mtp") {
                 string[] explode_path = explode_protocol[1].split ("]", 2);
@@ -412,7 +420,7 @@ namespace PF.FileUtils {
 
         string default_date_format = Granite.DateTime.get_default_date_format (false, true, true);
 
-        if (disp_year < now_year) {  
+        if (disp_year < now_year) {
             return dt.format (default_date_format);
         }
 

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -112,14 +112,20 @@ public class Async : Object {
     public bool loaded_from_cache {get; private set; default = false;}
 
     private Async (GLib.File _file) {
-        /* Ensure uri is correctly escaped and has scheme */
-        var escaped_uri = PF.FileUtils.escape_uri (_file.get_uri ());
-        scheme = Uri.parse_scheme (escaped_uri);
-        if (scheme == null) {
-            scheme = Marlin.ROOT_FS_URI;
-            escaped_uri = scheme + escaped_uri;
+        var u = _file.get_uri ();
+
+        if (!u.has_prefix ("archive")) {
+            /* Assume archive urls to be in required format already for now */
+            /* else ensure uri is correctly escaped and has scheme */
+            u = PF.FileUtils.escape_uri (u);
+            scheme = Uri.parse_scheme (u);
+            if (scheme == null) {
+                scheme = Marlin.ROOT_FS_URI;
+                u = scheme + u;
+            }
         }
-        location = GLib.File.new_for_uri (escaped_uri);
+
+        location = GLib.File.new_for_uri (u);
         file = GOF.File.get (location);
         selected_file = null;
 

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -88,7 +88,7 @@ public class Async : Object {
         }
     }
 
-    public string scheme {get; private set;}
+    public string? scheme {get; private set;}
     public bool is_local {get; private set;}
     public bool is_trash {get; private set;}
     public bool is_network {get; private set;}
@@ -114,12 +114,15 @@ public class Async : Object {
 
     private Async (GLib.File _file) {
         var u = _file.get_uri ();
-        scheme = _file.get_uri_scheme ();
+
+        scheme = _file.get_uri_scheme () ?? "file";
         is_trash = (scheme == "trash");
         is_recent = (scheme == "recent");
         is_local = is_trash || is_recent || (scheme == "file");
 
-        is_archive = is_local && PF.FileUtils.is_archive_from_extension (u);
+        string? archive_uri = null;
+        string? remainder = null;
+        is_archive = is_local && PF.FileUtils.inside_archive (u, out archive_uri, out remainder);
 
         if (!u.has_prefix ("archive")) {
             /* Assume archive urls to be in required format already for now */
@@ -133,7 +136,7 @@ public class Async : Object {
         }
 
         if (is_archive) {
-            u = PF.FileUtils.construct_archive_uri (u);
+            u = PF.FileUtils.construct_archive_uri (archive_uri, remainder);
         }
 
         location = GLib.File.new_for_uri (u);

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -114,7 +114,12 @@ public class Async : Object {
 
     private Async (GLib.File _file) {
         var u = _file.get_uri ();
-        is_archive = PF.FileUtils.is_archive_from_extension (u);
+        scheme = _file.get_uri_scheme ();
+        is_trash = (scheme == "trash");
+        is_recent = (scheme == "recent");
+        is_local = is_trash || is_recent || (scheme == "file");
+
+        is_archive = is_local && PF.FileUtils.is_archive_from_extension (u);
 
         if (!u.has_prefix ("archive")) {
             /* Assume archive urls to be in required format already for now */
@@ -139,11 +144,8 @@ public class Async : Object {
         state = State.NOT_LOADED;
         can_load = false;
 
-        scheme = location.get_uri_scheme ();
-        is_trash = (scheme == "trash");
-        is_recent = (scheme == "recent");
         is_no_info = ("cdda mtp ssh sftp afp dav davs".contains (scheme)); //Try lifting requirement for info on remote connections
-        is_local = is_trash || is_recent || (scheme == "file");
+
         is_network = !is_local && ("ftp sftp afp dav davs".contains (scheme));
         can_open_files = !("mtp".contains (scheme));
         can_stream_files = !("ftp sftp mtp dav davs".contains (scheme));

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -100,6 +100,7 @@ public class Async : Object {
     public bool can_open_files {get; private set;}
     public bool can_stream_files {get; private set;}
     public bool allow_user_interaction {get; set; default = true;}
+    public bool is_archive {get; private set;}
 
     private bool is_ready = false;
 
@@ -123,6 +124,12 @@ public class Async : Object {
                 scheme = Marlin.ROOT_FS_URI;
                 u = scheme + u;
             }
+        }
+
+        is_archive = PF.FileUtils.is_archive_from_extension (u);
+
+        if (is_archive) {
+            u = PF.FileUtils.construct_archive_uri (u);
         }
 
         location = GLib.File.new_for_uri (u);
@@ -198,6 +205,7 @@ public class Async : Object {
         if (success) {
             if (!is_no_info && !file.is_folder () && !file.is_root_network_folder ()) {
                 debug ("Trying to load a non-folder - finding parent");
+                warning ("Trying to load a non-folder - finding parent");
                 var parent = file.is_connected ? location.get_parent () : null;
                 if (parent != null) {
                     file = GOF.File.get (parent);

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -114,6 +114,7 @@ public class Async : Object {
 
     private Async (GLib.File _file) {
         var u = _file.get_uri ();
+        is_archive = PF.FileUtils.is_archive_from_extension (u);
 
         if (!u.has_prefix ("archive")) {
             /* Assume archive urls to be in required format already for now */
@@ -125,8 +126,6 @@ public class Async : Object {
                 u = scheme + u;
             }
         }
-
-        is_archive = PF.FileUtils.is_archive_from_extension (u);
 
         if (is_archive) {
             u = PF.FileUtils.construct_archive_uri (u);

--- a/libcore/gof-file.c
+++ b/libcore/gof-file.c
@@ -2537,14 +2537,19 @@ gof_file_is_folder (GOFFile *file)
 
     if (file->file_type == G_FILE_TYPE_MOUNTABLE &&
         file->info != NULL &&
-        g_file_info_get_attribute_boolean (file->info, G_FILE_ATTRIBUTE_MOUNTABLE_CAN_MOUNT))
+        g_file_info_get_attribute_boolean (file->info, G_FILE_ATTRIBUTE_MOUNTABLE_CAN_MOUNT)) {
 
         return TRUE;
+    }
 
     if (file->target_gof &&
         file->target_gof->is_directory &&
         gof_file_is_network_uri_scheme (file->target_gof)) {
             return TRUE;
+    }
+
+    if (pf_file_utils_is_archive_from_extension (file->uri)) {
+        return TRUE;
     }
 
     return FALSE;

--- a/libcore/gof-file.c
+++ b/libcore/gof-file.c
@@ -2549,6 +2549,15 @@ gof_file_is_folder (GOFFile *file)
     }
 
     if (pf_file_utils_is_archive_from_extension (file->uri)) {
+        GOFDirectoryAsync *dir = NULL;
+        dir = gof_directory_async_cache_lookup (file->directory);
+        if (dir != NULL) {
+            gboolean arch;
+            arch = gof_directory_async_get_is_archive (dir);
+            g_object_unref (dir);
+            return !arch;
+        }
+
         return TRUE;
     }
 

--- a/libcore/tests/UtilTests/UtilTests.vala
+++ b/libcore/tests/UtilTests/UtilTests.vala
@@ -46,9 +46,19 @@ void add_file_utils_tests () {
         assert (PF.FileUtils.get_file_for_path ("") == null);
     });
 
+    /** Sanitize should (at least) unescape archive path **/
     Test.add_func ("/FileUtils/sanitize_archive_path", () => {
-        string res = PF.FileUtils.sanitize_path ("archive://file%3A%2F%2F%2Fhome%2Ftest.zip");
-        assert (res == "archive://file%3A%2F%2F%2Fhome%2Ftest.zip");
+        /* Expect only remove special escaping */
+        string res = PF.FileUtils.sanitize_path ("archive://file%3A%2F%2F%2Fhome%2F%252523test.zip");
+        assert (res == "archive://file:///home/#test.zip");
+    });
+
+    /** Test construction of difficult archive path **/
+    Test.add_func ("/FileUtils/construct_archive_path", () => {
+        /* Expect only remove special escaping */
+        string res = PF.FileUtils.construct_archive_uri ("archive://file:///home/#test.zip", "folder/file.txt");
+        message ("res %s", res);
+        assert (res == "archive://file%253A%252F%252F%252Fhome%252F%252523test.zip/folder/file.txt");
     });
 }
 

--- a/libcore/tests/UtilTests/UtilTests.vala
+++ b/libcore/tests/UtilTests/UtilTests.vala
@@ -18,15 +18,18 @@
 *
 * Authored by: Jeremy Wootten <jeremy@elementaryos.org>
 */
-const string archive_normal = "/home/#test archive.zip";
-const string archive_archive_unescaped = "archive://file:///home/#test archive.zip";
-const string archive_archive_escaped = "archive://file%253A%252F%252F%252Fhome%252F%252523test%252520archive.zip";
-const string file_inside_archive_relative = "/folder#/file";
-const string file_inside_archive_relative_escaped = "/folder%23/file";
 
-const string file_inside_archive_normal = archive_normal + file_inside_archive_relative;
-const string file_inside_archive_archive_unescaped = archive_archive_unescaped + file_inside_archive_relative;
-const string file_inside_archive_archive_escaped = archive_archive_escaped + file_inside_archive_relative_escaped;
+const string archive_normal = "/home/#testこ ?archive%.zip";
+const string archive_archive_unescaped = "archive://file:///home/#testこ ?archive%.zip";
+
+const string archive_archive_escaped = "archive://file%253A%252F%252F%252Fhome%252F%252523test%2525E3%252581%252593%252520%25253Farchive%252525.zip";
+
+const string file_inside_archive_relative = "#testこ ?folder%";
+const string file_inside_archive_relative_escaped = "%23test%E3%81%93%20%3Ffolder%25";
+
+const string file_inside_archive_normal = archive_normal + Path.DIR_SEPARATOR_S + file_inside_archive_relative;
+const string file_inside_archive_archive_unescaped = archive_archive_unescaped + Path.DIR_SEPARATOR_S + file_inside_archive_relative;
+const string file_inside_archive_archive_escaped = archive_archive_escaped + Path.DIR_SEPARATOR_S + file_inside_archive_relative_escaped;
 
 void add_file_utils_tests () {
     /* Sanitize path */
@@ -63,9 +66,24 @@ void add_file_utils_tests () {
 
     /** Test construction of difficult archive path **/
     Test.add_func ("/FileUtils/construct_archive_path", () => {
-        /* Expect only remove special escaping */
+        /* Expect construct valid uri for gvfs-archive to mount*/
         string res = PF.FileUtils.construct_archive_uri (archive_normal, file_inside_archive_relative);
         assert (res == file_inside_archive_archive_escaped);
+    });
+    Test.add_func ("/FileUtils/construct_archive_path2", () => {
+        /* Check copes with extra separators in parameters */
+        string res = PF.FileUtils.construct_archive_uri (archive_normal + Path.DIR_SEPARATOR_S, Path.DIR_SEPARATOR_S + file_inside_archive_relative);
+        assert (res == file_inside_archive_archive_escaped);
+    });
+    Test.add_func ("/FileUtils/construct_archive_path3", () => {
+        /* Check copes with archive uri already escaped */
+        string res = PF.FileUtils.construct_archive_uri (archive_archive_escaped, file_inside_archive_relative);
+        assert (res == file_inside_archive_archive_escaped);
+    });
+    Test.add_func ("/FileUtils/construct_archive_path4", () => {
+        /* Check copes with null remainder */
+        string res = PF.FileUtils.construct_archive_uri (archive_normal, null);
+        assert (res == archive_archive_escaped);
     });
 }
 

--- a/libcore/tests/UtilTests/UtilTests.vala
+++ b/libcore/tests/UtilTests/UtilTests.vala
@@ -18,7 +18,15 @@
 *
 * Authored by: Jeremy Wootten <jeremy@elementaryos.org>
 */
+const string archive_normal = "/home/#test archive.zip";
+const string archive_archive_unescaped = "archive://file:///home/#test archive.zip";
+const string archive_archive_escaped = "archive://file%253A%252F%252F%252Fhome%252F%252523test%252520archive.zip";
+const string file_inside_archive_relative = "/folder#/file";
+const string file_inside_archive_relative_escaped = "/folder%23/file";
 
+const string file_inside_archive_normal = archive_normal + file_inside_archive_relative;
+const string file_inside_archive_archive_unescaped = archive_archive_unescaped + file_inside_archive_relative;
+const string file_inside_archive_archive_escaped = archive_archive_escaped + file_inside_archive_relative_escaped;
 
 void add_file_utils_tests () {
     /* Sanitize path */
@@ -49,16 +57,15 @@ void add_file_utils_tests () {
     /** Sanitize should (at least) unescape archive path **/
     Test.add_func ("/FileUtils/sanitize_archive_path", () => {
         /* Expect only remove special escaping */
-        string res = PF.FileUtils.sanitize_path ("archive://file%3A%2F%2F%2Fhome%2F%252523test.zip");
-        assert (res == "archive://file:///home/#test.zip");
+        string res = PF.FileUtils.sanitize_path (file_inside_archive_archive_escaped);
+        assert (res == file_inside_archive_archive_unescaped);
     });
 
     /** Test construction of difficult archive path **/
     Test.add_func ("/FileUtils/construct_archive_path", () => {
         /* Expect only remove special escaping */
-        string res = PF.FileUtils.construct_archive_uri ("archive://file:///home/#test.zip", "folder/file.txt");
-        message ("res %s", res);
-        assert (res == "archive://file%253A%252F%252F%252Fhome%252F%252523test.zip/folder/file.txt");
+        string res = PF.FileUtils.construct_archive_uri (archive_normal, file_inside_archive_relative);
+        assert (res == file_inside_archive_archive_escaped);
     });
 }
 

--- a/libcore/tests/UtilTests/UtilTests.vala
+++ b/libcore/tests/UtilTests/UtilTests.vala
@@ -45,11 +45,16 @@ void add_file_utils_tests () {
     Test.add_func ("/FileUtils/file_for_zero_length_path", () => {
         assert (PF.FileUtils.get_file_for_path ("") == null);
     });
+
+    Test.add_func ("/FileUtils/sanitize_archive_path", () => {
+        string res = PF.FileUtils.sanitize_path ("archive://file%3A%2F%2F%2Fhome%2Ftest.zip");
+        assert (res == "archive://file%3A%2F%2F%2Fhome%2Ftest.zip");
+    });
 }
 
 int main (string[] args) {
     Test.init (ref args);
-    
+
     add_file_utils_tests ();
     return Test.run ();
 }

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -470,11 +470,12 @@ namespace Marlin.View.Chrome {
             string newpath = "";
 
             foreach (BreadcrumbElement element in elements) {
-                    string s = element.text;  /* element text should be an escaped string */
-                    newpath += (s + Path.DIR_SEPARATOR_S);
+                string s = element.text;  /* element text should be an escaped string */
+                newpath += (s + Path.DIR_SEPARATOR_S);
 
-                    if (el != null && element == el)
-                        break;
+                if (el != null && element == el) {
+                    break;
+                }
             }
 
             return PF.FileUtils.sanitize_path (newpath);
@@ -485,14 +486,22 @@ namespace Marlin.View.Chrome {
                                                                Gee.ArrayList<BreadcrumbElement> newelements) {
             /* Ensure the breadcrumb texts are escaped strings whether or not the parameter newpath was supplied escaped */
             string newpath = "";
-
-            if (protocol == "archive://") {
+            bool is_archive = protocol == "archive://";
+            if (is_archive) {
                 newpath = PF.FileUtils.unescape_archive_uri (path);
             } else {
                 newpath = PF.FileUtils.escape_uri (Uri.unescape_string (path) ?? path);
             }
 
             newelements.add (new BreadcrumbElement (protocol, this, button_context));
+
+            if (is_archive) {
+                var el = new BreadcrumbElement ("file://", this, button_context);
+                el.display = false;
+                newelements.add (el);
+                newpath = newpath.slice ("file://".length, -1);
+            }
+
             foreach (string dir in newpath.split (Path.DIR_SEPARATOR_S)) {
                 if (dir != "") {
                     newelements.add (new BreadcrumbElement (dir, this, button_context));
@@ -524,12 +533,14 @@ namespace Marlin.View.Chrome {
                             found = false;
                             break;
                         }
+
                         h = i;
                     }
 
                     if (found) {
-                        for (int j = 0; j < h; j++)
+                        for (int j = 0; j < h; j++) {
                             newelements[j].display = false;
+                        }
 
                         newelements[h].display = true;
                         newelements[h].set_icon (icon.icon);
@@ -537,8 +548,9 @@ namespace Marlin.View.Chrome {
                         newelements[h].text_is_displayed = (icon.text_displayed != null) || !icon.break_loop;
                         newelements[h].text_for_display = icon.text_displayed;
 
-                        if (icon.break_loop)
+                        if (icon.break_loop) {
                             break;
+                        }
                     }
                 }
             }

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -372,7 +372,7 @@ namespace Marlin.View.Chrome {
 
         /** Returns a list of breadcrumbs that are displayed in natural order - that is, the breadcrumb at the start
           * of the pathbar is at the start of the list
-         **/  
+         **/
         public double get_displayed_breadcrumbs_natural_width (out GLib.List<BreadcrumbElement> displayed_breadcrumbs) {
             double total_width = 0.0;
             displayed_breadcrumbs = null;
@@ -401,7 +401,7 @@ namespace Marlin.View.Chrome {
             }
 
             /* Allow enough space after the breadcrumbs for secondary icon and entry */
-            w += 2 * YPAD + MINIMUM_LOCATION_BAR_ENTRY_WIDTH + ICON_WIDTH; 
+            w += 2 * YPAD + MINIMUM_LOCATION_BAR_ENTRY_WIDTH + ICON_WIDTH;
 
             return (int) (w);
         }
@@ -484,12 +484,21 @@ namespace Marlin.View.Chrome {
                                                                string path,
                                                                Gee.ArrayList<BreadcrumbElement> newelements) {
             /* Ensure the breadcrumb texts are escaped strings whether or not the parameter newpath was supplied escaped */
-            string newpath = PF.FileUtils.escape_uri (Uri.unescape_string (path) ?? path);
+            string newpath = "";
+
+            if (protocol == "archive://") {
+                newpath = PF.FileUtils.unescape_archive_uri (path);
+            } else {
+                newpath = PF.FileUtils.escape_uri (Uri.unescape_string (path) ?? path);
+            }
+
             newelements.add (new BreadcrumbElement (protocol, this, button_context));
             foreach (string dir in newpath.split (Path.DIR_SEPARATOR_S)) {
-                if (dir != "")
+                if (dir != "") {
                     newelements.add (new BreadcrumbElement (dir, this, button_context));
+                }
             }
+
             set_element_icons (protocol, newelements);
             replace_elements (newelements);
         }
@@ -645,7 +654,7 @@ namespace Marlin.View.Chrome {
                 double total_arrow_width = displayed_breadcrumbs.length () * (height_marged / 2 + padding.left);
                 width_marged -= total_arrow_width;
                 if (max_width > width_marged) { /* let's check if the breadcrumbs are bigger than the widget */
-                    var unfixed = displayed_breadcrumbs.length () - 2; 
+                    var unfixed = displayed_breadcrumbs.length () - 2;
                     if (unfixed > 0) {
                         width_marged -= unfixed * MINIMUM_BREADCRUMB_WIDTH;
                     }

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -478,6 +478,11 @@ namespace Marlin.View.Chrome {
                 }
             }
 
+            /* Strip the archive prefix - it will be replaced only when required */
+            if (newpath.has_prefix ("archive:")) {
+                newpath = PF.FileUtils.strip_archive_prefix (newpath);
+            }
+
             return PF.FileUtils.sanitize_path (newpath);
         }
 
@@ -499,7 +504,7 @@ namespace Marlin.View.Chrome {
                 var el = new BreadcrumbElement ("file://", this, button_context);
                 el.display = false;
                 newelements.add (el);
-                newpath = newpath.slice ("file://".length, -1);
+                newpath = newpath.slice ("file://".length, newpath.length);
             }
 
             foreach (string dir in newpath.split (Path.DIR_SEPARATOR_S)) {

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -491,11 +491,12 @@ namespace Marlin.View.Chrome {
                                                                Gee.ArrayList<BreadcrumbElement> newelements) {
             /* Ensure the breadcrumb texts are escaped strings whether or not the parameter newpath was supplied escaped */
             string newpath = "";
-            bool is_archive = protocol == "archive://";
+
+            bool is_archive = protocol.has_prefix ("archive://");
             if (is_archive) {
                 newpath = PF.FileUtils.unescape_archive_uri (path);
             } else {
-                newpath = PF.FileUtils.escape_uri (Uri.unescape_string (path) ?? path);
+                newpath = Uri.unescape_string (path) ?? path;
             }
 
             newelements.add (new BreadcrumbElement (protocol, this, button_context));

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -75,6 +75,9 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         widget = widget_;
         padding = button_context.get_padding (button_context.get_state ());
         text_for_display = Uri.unescape_string (text);
+        if (text_for_display == null) {
+            text_for_display = text;
+        }
     }
 
     public void set_icon (Gdk.Pixbuf icon_) {

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -49,7 +49,6 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         }
     }
 
-    public bool hidden = false;
     public bool display = true;
     public bool can_shrink = true;
     public bool pressed = false;

--- a/libwidgets/Chrome/BreadcrumbIconList.vala
+++ b/libwidgets/Chrome/BreadcrumbIconList.vala
@@ -50,6 +50,7 @@ namespace Marlin.View.Chrome {
             add_icon ({ "trash://", Marlin.ICON_TRASH_SYMBOLIC, true, null, null, null, true, Marlin.PROTOCOL_NAME_TRASH});
             add_icon ({ "recent://", Marlin.ICON_RECENT_SYMBOLIC, true, null, null, null, true, Marlin.PROTOCOL_NAME_RECENT});
             add_icon ({ "mtp://[", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, true, null, null, null, true, Marlin.PROTOCOL_NAME_MTP});
+            add_icon ({ "archive://", Marlin.ICON_ARCHIVE_SYMBOLIC, true, null, null, null, true, Marlin.PROTOCOL_NAME_ARCHIVE});
 
 
             /* music */
@@ -120,6 +121,12 @@ namespace Marlin.View.Chrome {
             /* filesystem */
             BreadcrumbIconInfo icon = {Path.DIR_SEPARATOR_S, Marlin.ICON_FILESYSTEM_SYMBOLIC, false, null, null, null, false, null};
             icon.exploded = {Path.DIR_SEPARATOR_S};
+            add_icon (icon);
+
+            /* filesystem */
+            dir = "file://";
+            icon = {dir, Marlin.ICON_FILESYSTEM_SYMBOLIC, false, null, null, null, false, null};
+            icon.exploded = {dir};
             add_icon (icon);
 
         }

--- a/libwidgets/Resources.vala
+++ b/libwidgets/Resources.vala
@@ -27,6 +27,7 @@ namespace Marlin {
     public const string ICON_APP_LOGO = "system-file-manager";
     public const string ICON_FILESYSTEM = "drive-harddisk-system";
     public const string ICON_FILESYSTEM_SYMBOLIC = "drive-harddisk-symbolic";
+    public const string ICON_ARCHIVE_SYMBOLIC = "archive-manager-symbolic";
     public const string ICON_FOLDER = "folder";
     public const string ICON_FOLDER_DOCUMENTS_SYMBOLIC = "folder-documents-symbolic";
     public const string ICON_FOLDER_DOWNLOADS_SYMBOLIC = "folder-download-symbolic";
@@ -66,6 +67,7 @@ namespace Marlin {
     public const string PROTOCOL_NAME_RECENT = _("Recent");
     public const string PROTOCOL_NAME_MTP = _("MTP");
     public const string PROTOCOL_NAME_FILE = _("File System");
+    public const string PROTOCOL_NAME_ARCHIVE = _("Archive");
 
     public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 36;
     public const uint LOCATION_BAR_ANIMATION_TIME_MSEC = 300;
@@ -73,7 +75,7 @@ namespace Marlin {
     public const uint BUTTON_LONG_PRESS = 300;
 
     public const string[] SKIP_IMAGES = {"image/svg+xml", "image/tiff", "image/jp2"};
-    
+
     public string protocol_to_name (string protocol) {
         /* Deal with protocol with or without : or / characters at the end */
         string s = protocol.delimit (":/", ' ').chomp ();
@@ -101,6 +103,8 @@ namespace Marlin {
                 return Marlin.PROTOCOL_NAME_MTP;
             case "file":
                 return Marlin.PROTOCOL_NAME_FILE;
+            case "archive":
+                return Marlin.PROTOCOL_NAME_ARCHIVE;
             default:
                 return protocol;
         }

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -361,6 +361,10 @@ namespace Marlin.View {
 
        private void update_tab_name () {
             string? slot_path = Uri.unescape_string (this.uri);
+            if (this.uri.has_prefix ("archive")) {
+                slot_path = Uri.unescape_string (slot_path.slice ("archive://".length, -1));
+            }
+
             string? tab_name = null;
 
             if (slot_path != null) {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -361,29 +361,31 @@ namespace Marlin.View {
 
        private void update_tab_name () {
             string? slot_path = null;
-            if (this.uri.has_prefix ("archive")) {
-                slot_path = PF.FileUtils.strip_archive_prefix (this.uri);
-            } else {
-                slot_path = Uri.unescape_string (this.uri);
-            }
-
+            bool is_in_archive = this.uri.has_prefix ("archive");
             string? tab_name = null;
 
-            if (slot_path != null) {
-                if (this.location.get_path () == null) {
-                    tab_name = Marlin.protocol_to_name (this.uri);
-                } else {
-                    try {
-                        var fn = Filename.from_uri (slot_path);
-                        if (fn == Environment.get_home_dir ()) {
-                            tab_name = _("Home");
-                        } else if (fn == "/") {
-                            tab_name = _("File System");
-                        }
-                    } catch (ConvertError e) {}
+            if (is_in_archive) {
+                slot_path = PF.FileUtils.strip_archive_prefix (this.uri);
+                tab_name = Path.get_basename (slot_path);
+                is_in_archive = true;
+            } else {
+                slot_path = Uri.unescape_string (this.uri);
+                if (slot_path != null) {
+                    if (this.location.get_path () == null) {
+                        tab_name = Marlin.protocol_to_name (this.uri);
+                    } else {
+                        try {
+                            var fn = Filename.from_uri (slot_path);
+                            if (fn == Environment.get_home_dir ()) {
+                                tab_name = _("Home");
+                            } else if (fn == "/") {
+                                tab_name = _("File System");
+                            }
+                        } catch (ConvertError e) {}
 
-                    if (tab_name == null) {
-                        tab_name = Path.get_basename (slot_path);
+                        if (tab_name == null) {
+                            tab_name = Path.get_basename (slot_path);
+                        }
                     }
                 }
             }
@@ -391,7 +393,7 @@ namespace Marlin.View {
             if (tab_name == null) {
                 tab_name = Marlin.INVALID_TAB_NAME;
             } else if (Posix.getuid () == 0) {
-                    tab_name = tab_name + " " + _("(as Administrator)");
+                tab_name = tab_name + " " + _("(as Administrator)");
             }
 
             this.tab_name = tab_name;

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -201,7 +201,7 @@ namespace Marlin.View {
         public bool go_up () {
             selected_locations.append (this.location);
             GLib.File parent = location;
-            if (view.directory.has_parent ()) { /* May not work for some protocols */
+            if (!uri.has_prefix ("archive") && view.directory.has_parent ()) { /* May not work for some protocols */
                 parent = view.directory.get_parent ();
             } else {
                 var parent_path = PF.FileUtils.get_parent_path_from_path (location.get_uri ());
@@ -360,9 +360,11 @@ namespace Marlin.View {
         }
 
        private void update_tab_name () {
-            string? slot_path = Uri.unescape_string (this.uri);
+            string? slot_path = null;
             if (this.uri.has_prefix ("archive")) {
-                slot_path = Uri.unescape_string (slot_path.slice ("archive://".length, -1));
+                slot_path = PF.FileUtils.strip_archive_prefix (this.uri);
+            } else {
+                slot_path = Uri.unescape_string (this.uri);
             }
 
             string? tab_name = null;

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -517,13 +517,13 @@ namespace Marlin.View {
                 return name;
             }
 
-            string path = Uri.unescape_string (vc.uri);
+            string path = PF.FileUtils.unescape_uri (vc.uri);
             string new_name = name;
 
             foreach (Granite.Widgets.Tab tab in tabs.tabs) {
                 var content = (ViewContainer)(tab.page);
                 if (content != vc) {
-                    string content_path = Uri.unescape_string (content.uri);
+                    string content_path = PF.FileUtils.unescape_uri (content.uri);
                     if (content.tab_name == name && content_path != path) {
                         if (content.tab_name == tab.label) {
                             Idle.add_full (GLib.Priority.LOW, () => {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1143,15 +1143,23 @@ namespace Marlin.View {
 
         /** Use this function to standardise how locations are generated from uris **/
         private File? get_file_from_uri (string uri) {
-            /* Sanitize path removes file:// scheme if present, but GOF.Directory.Async will replace it */
-            string? current_uri = null;
-            if (current_tab != null && current_tab.location != null) {
-                current_uri = current_tab.location.get_uri ();
+            string  path = "";
+
+            if (uri.has_prefix ("archive")) {
+                /* gvfs-archive backend will not open an unescaped url */
+                path = uri;
+            } else {
+                /* Sanitize path removes file:// scheme if present, but GOF.Directory.Async will replace it */
+                string? current_uri = null;
+                if (current_tab != null && current_tab.location != null) {
+                    current_uri = current_tab.location.get_uri ();
+                }
+
+                path = PF.FileUtils.sanitize_path (uri, current_uri);
             }
 
-            string path = PF.FileUtils.sanitize_path (uri, current_uri);
             if (path.length > 0) {
-                return File.new_for_uri (PF.FileUtils.escape_uri (path));
+                return File.new_for_uri (path);
             } else {
                 return null;
             }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1146,17 +1146,19 @@ namespace Marlin.View {
             string  path = "";
 
             if (uri.has_prefix ("archive")) {
-                /* gvfs-archive backend will not open an unescaped url */
-                path = uri;
-            } else {
-                /* Sanitize path removes file:// scheme if present, but GOF.Directory.Async will replace it */
-                string? current_uri = null;
-                if (current_tab != null && current_tab.location != null) {
-                    current_uri = current_tab.location.get_uri ();
-                }
-
-                path = PF.FileUtils.sanitize_path (uri, current_uri);
+                /* Convert to normal uri to avoid specially handling */
+                /* GOF.Directory.Async will reconstruct correctly formatted and escaped uri if required */
+                path = PF.FileUtils.strip_archive_prefix (uri);
+                return File.new_for_commandline_arg (path);
             }
+
+            /* Sanitize path removes file:// scheme if present, but GOF.Directory.Async will replace it */
+            string? current_uri = null;
+            if (current_tab != null && current_tab.location != null) {
+                current_uri = current_tab.location.get_uri ();
+            }
+
+            path = PF.FileUtils.sanitize_path (uri, current_uri);
 
             if (path.length > 0) {
                 return File.new_for_uri (path);


### PR DESCRIPTION
See #83.

This branch adds code to handle the special format required by gvfs-archive for uris pointing at or inside compressed files.  Once this is done Files can browse such folders fairly transparently (although only read-only).  This facility is (currently) limited to compressed files with a local filesystem uri.  Compressed files inside another compressed file cannot be browsed, but open with FileRoller as before.

Some unit tests are added for key added functions to check that "difficult" uris are handled correctly.
