### PR TITLE
Fix drop auto open

### DIFF
--- a/libcore/DndHandler.vala
+++ b/libcore/DndHandler.vala
@@ -230,18 +230,26 @@ namespace Marlin {
                                               Gdk.DragAction possible_actions,
                                               Gdk.DragAction suggested_action,
                                               uint32 timestamp) {
+
             bool success = false;
             Gdk.DragAction action = suggested_action;
 
-            if ((possible_actions & Gdk.DragAction.ASK) != 0)
-                action = drag_drop_action_ask (dest_widget, win, possible_actions);
+            if (drop_file_list != null) {
+                if ((possible_actions & Gdk.DragAction.ASK) != 0) {
+                    action = drag_drop_action_ask (dest_widget, win, possible_actions);
+                }
 
-            if (action != Gdk.DragAction.DEFAULT) {
-                success = dnd_perform (dest_widget,
-                                       drop_target,
-                                       drop_file_list,
-                                       action);
+                if (action != Gdk.DragAction.DEFAULT) {
+                    success = dnd_perform (dest_widget,
+                                           drop_target,
+                                           drop_file_list,
+                                           action);
+                }
+
+            } else {
+                critical ("Attempt to drop null file list");
             }
+
             return success;
         }
 
@@ -255,6 +263,7 @@ namespace Marlin {
 
                 text = DndHandler.data_to_string (selection_data.get_data_with_length ());
             }
+
             debug ("DNDHANDLER selection data is uri list returning %s", (text != null).to_string ());
             return (text != null);
         }
@@ -262,8 +271,9 @@ namespace Marlin {
         public static string data_to_string (uchar [] cdata) {
             var sb = new StringBuilder ("");
 
-            foreach (uchar u in cdata)
+            foreach (uchar u in cdata) {
                 sb.append_c ((char)u);
+            }
 
             return sb.str;
         }
@@ -273,6 +283,7 @@ namespace Marlin {
                                                               string prefix = "") {
 
             GLib.StringBuilder sb = new GLib.StringBuilder (prefix);
+
             if (file_list != null && file_list.data != null && file_list.data is GOF.File) {
                 bool in_recent = file_list.data.is_recent_uri_scheme ();
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1499,8 +1499,10 @@ namespace FM {
 
             drag_file_list = get_selected_files_for_transfer ();
 
-            if (drag_file_list == null)
+            if (drag_file_list == null) {
+                warning ("drag with no selected files");
                 return;
+            }
 
             GOF.File file = drag_file_list.first ().data;
 
@@ -1521,6 +1523,9 @@ namespace FM {
             cancel_timeout (ref drag_scroll_timer_id);
             drag_file_list = null;
             drop_target_file = null;
+            drop_file_list = null;
+            drop_data_ready = false;
+
             current_suggested_action = Gdk.DragAction.DEFAULT;
             current_actions = Gdk.DragAction.DEFAULT;
             drag_has_begun = false;
@@ -1603,7 +1608,7 @@ namespace FM {
                 }
             }
 
-            if (drop_occurred) {
+            if (drop_occurred && drop_data_ready) {
                 drop_occurred = false;
                 if (current_actions != Gdk.DragAction.DEFAULT) {
                     switch (info) {
@@ -1658,11 +1663,6 @@ namespace FM {
                 queue_draw ();
             }
 
-            /* reset the "drop data ready" status and free the URI list */
-            if (drop_data_ready) {
-                drop_file_list = null;
-                drop_data_ready = false;
-            }
             /* disable the highlighting of the items in the view */
             highlight_path (null);
         }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1500,7 +1500,6 @@ namespace FM {
             drag_file_list = get_selected_files_for_transfer ();
 
             if (drag_file_list == null) {
-                warning ("drag with no selected files");
                 return;
             }
 


### PR DESCRIPTION
See #114 

A null check is used in DndHandler to prevent similar bugs (dropping an empty file list) causing a crash.
As an extra check, a drop is not acted on unless the "drop_data_ready" is true.

The root cause in this case is fixed by moving a couple of lines from the "drag leave" handler to the "drag end" handler.

See linked issue for test procedure.

