### PR TITLE
Clear large folder rapidly

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -637,7 +637,7 @@ namespace FM {
             freeze_tree ();
          }
 
-        protected void after_loading_directory (GOF.Directory dir) {
+        protected void after_loading_directory (GOF.Directory.Async dir) {
             dir.file_loaded.disconnect (on_directory_file_loaded);
             dir.done_loading.disconnect (on_directory_done_loading);
         }
@@ -647,7 +647,6 @@ namespace FM {
             /* will not have been disconnected */
 
             if (dir.is_loading ()) {
-                disconnect_directory_loading_handlers (dir);
                 after_loading_directory (dir);
             }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -676,22 +676,14 @@ namespace FM {
         }
 
         private void clear_model () {
-            /* At some point it is quicker to build a new model than clear the old one
-             * time taken proportional to n2 ?*/
-             block_model ();
+            /* It is much quicker to recreate the model for large folders and does no harm for small
+             * folders. */
+            int sort_column_id;
+            Gtk.SortType sort_type;
 
-            if (slot.directory.files_count < 1000) {
-                model.clear ();
-            } else {
-                int sort_column_id;
-                Gtk.SortType sort_type;
-
-                model.get_sort_column_id (out sort_column_id, out sort_type);
-                model = GLib.Object.@new (FM.ListModel.get_type (), null) as FM.ListModel;
-                model.set_sort_column_id (sort_column_id, sort_type);
-            }
-
-            unblock_model ();
+            model.get_sort_column_id (out sort_column_id, out sort_type);
+            model = GLib.Object.@new (FM.ListModel.get_type (), null) as FM.ListModel;
+            model.set_sort_column_id (sort_column_id, sort_type);
         }
 
         protected void connect_drag_drop_signals (Gtk.Widget widget) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -391,10 +391,6 @@ namespace FM {
             (GOF.Preferences.get_default ()).notify["show-remote-thumbnails"].connect (on_show_remote_thumbnails_changed);
 
             connect_model_signals ();
-
-            model.row_deleted.connect (on_row_deleted);
-            /* Sort order of model is set after loading */
-            model.sort_column_changed.connect (on_sort_column_changed);
         }
 
         private void set_up__menu_actions () {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -664,6 +664,17 @@ namespace FM {
             clear ();
             disconnect_directory_handlers (old_dir);
             connect_directory_handlers (new_dir);
+
+            /* If navigating to new folder reset the sort order as appropriate */
+            if (new_dir.file.uri != old_dir.file.uri) {
+                in_trash = new_dir.is_trash;
+                in_recent = new_dir.is_recent;
+                if (in_recent)
+                    model.set_sort_column_id (get_column_id_from_string ("modified"), Gtk.SortType.DESCENDING);
+                else if (new_dir.file.info != null) {
+                    model.set_sort_column_id (slot.directory.file.sort_column_id, slot.directory.file.sort_order);
+                }
+            }
         }
 
         public void clear () {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -312,7 +312,9 @@ namespace FM {
                     view.queue_draw ();
                 }
             });
+
             model = GLib.Object.@new (FM.ListModel.get_type (), null) as FM.ListModel;
+
             Preferences.settings.bind ("single-click", this, "single_click_mode", SettingsBindFlags.GET);
             Preferences.settings.bind ("show-remote-thumbnails", this, "show_remote_thumbnails", SettingsBindFlags.GET);
 
@@ -1366,11 +1368,6 @@ namespace FM {
 
             if (slot.directory.can_load) {
                 is_writable = slot.directory.file.is_writable ();
-                if (in_recent)
-                    model.set_sort_column_id (get_column_id_from_string ("modified"), Gtk.SortType.DESCENDING);
-                else if (slot.directory.file.info != null) {
-                    model.set_sort_column_id (slot.directory.file.sort_column_id, slot.directory.file.sort_order);
-                }
             } else {
                 is_writable = false;
             }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -669,9 +669,10 @@ namespace FM {
             if (new_dir.file.uri != old_dir.file.uri) {
                 in_trash = new_dir.is_trash;
                 in_recent = new_dir.is_recent;
-                if (in_recent)
+
+                if (in_recent) {
                     model.set_sort_column_id (get_column_id_from_string ("modified"), Gtk.SortType.DESCENDING);
-                else if (new_dir.file.info != null) {
+                } else if (new_dir.file.info != null) {
                     model.set_sort_column_id (slot.directory.file.sort_column_id, slot.directory.file.sort_order);
                 }
             }

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -316,12 +316,14 @@ namespace FM {
         protected override void freeze_tree () {
             tree.freeze_child_notify ();
             tree_frozen = true;
+            tree.set_model (null);
         }
 
         protected override void thaw_tree () {
             if (tree_frozen) {
                 tree.thaw_child_notify ();
                 tree_frozen = false;
+                tree.set_model (model);
             }
         }
 


### PR DESCRIPTION
Fixes #54 

Instead of deleting every row when clearing the model, the model is recreated.  This greatly speeds up reloading and navigating away from large folders (10's or 100's thousands of files) as well as switching "show hidden" off.

For simplicity the same is done for small folders as well as there seems no discernible downside.

TO TEST:
Monitor FIles cpu usage using system-monitor or htop.  Do not start a new step until cpu usage drops to zero.

1) Create a folder containing several 10's of thousand or 100,000 files (recommend using ListView for > 10,000 files).  Some of the files should be hidden,
2) Navigate into folder 
3) Reload the folder
4) Switch "show-hidden" from "on" to "off"
5) navigate away from folder while monitoring cpu usage.

Compared to trunk these operations are quicker and use less cpu.
