### PR TITLE
Allow streaming from dav and davs.

### DIFF
--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -134,7 +134,7 @@ public class Async : Object {
         is_local = is_trash || is_recent || (scheme == "file");
         is_network = !is_local && ("ftp sftp afp dav davs".contains (scheme));
         can_open_files = !("mtp".contains (scheme));
-        can_stream_files = !("ftp sftp mtp dav davs".contains (scheme));
+        can_stream_files = !("ftp sftp mtp".contains (scheme));
 
         file_hash = new HashTable<GLib.File, GOF.File> (GLib.File.hash, GLib.File.equal);
 


### PR DESCRIPTION
see #125 

This removes the hard-coded restriction of streaming from dav and davs protocols as it seems unnecessary.   Trial with a simple local webdav server successfully streamed video.