### PR TITLE
Fix race between selection change and showing context menu.

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3305,7 +3305,8 @@ namespace FM {
 
                 case Gdk.BUTTON_SECONDARY:
                     if (click_zone == ClickZone.NAME ||
-                        click_zone == ClickZone.BLANK_PATH) {
+                        click_zone == ClickZone.BLANK_PATH ||
+                        click_zone == ClickZone.ICON) {
 
                         select_path (path);
                     } else if (click_zone == ClickZone.INVALID) {
@@ -3313,6 +3314,8 @@ namespace FM {
                     }
 
                     unblock_drag_and_drop ();
+                    /* Ensure selected files list and menu actions are updated before context menu shown */
+                    after_selected_files_changed ();
                     result = handle_secondary_button_click (event);
                     break;
 


### PR DESCRIPTION
This fixes a regression due to throttling selection-change signals (which improved handling of large selection changes), which resulted in the wrong context menu being shown under some circumstances (see issue #124 see also #41).  

In this branch the delay is by-passed when dealing with right-clicks.

TO TEST.

In Icon View:

1) select one item.
2) right click on the icon or name of a different item.
3) In trunk: Instead of the item context being shown the background context shows.
   In branch:  The correct context menu shows 
