### PR TITLE
Update license notice where failed licensecheck.

### DIFF
--- a/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
+++ b/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
@@ -1,23 +1,22 @@
-/*
-* Copyright (c) 2017 elementary LLC
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-* Boston, MA 02111-1307, USA.
-*
-* Authored by: Jeremy Wootten <jeremy@elementaryos.org>
-*/
+/***
+    Copyright (c) 2017 elementary LLC
+
+    This file is part of Pantheon Files.
+
+    Pantheon Files is free software: you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License version 3, as published
+    by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranties of
+    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+    PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with Pantheon Files. If not, see <http://www.gnu.org/licenses/>.
+
+    Authored by: Jeremy Wootten <jeremy@elementaryos.org>
+***/
 
 namespace GOF.Directory {
 void add_gof_directory_async_tests () {

--- a/libcore/tests/GOFFileTests/GOFFileTests.vala
+++ b/libcore/tests/GOFFileTests/GOFFileTests.vala
@@ -1,23 +1,22 @@
-/*
-* Copyright (c) 2017 elementary LLC
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-* Boston, MA 02111-1307, USA.
-*
-* Authored by: Jeremy Wootten <jeremy@elementaryos.org>
-*/
+/***
+    Copyright (c) 2017 elementary LLC
+
+    This file is part of Pantheon Files.
+
+    Pantheon Files is free software: you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License version 3, as published
+    by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranties of
+    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+    PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with Pantheon Files. If not, see <http://www.gnu.org/licenses/>.
+
+    Authored by: Jeremy Wootten <jeremy@elementaryos.org>
+***/
 
 void add_gof_file_tests () {
     /* loading */
@@ -29,7 +28,7 @@ void add_gof_file_tests () {
 }
 
 void existing_local_folder_test () {
-    string parent_path = "/usr"; 
+    string parent_path = "/usr";
     string basename = "share";
     string path = Path.build_filename (parent_path, basename);
     string uri = "file://" + path;
@@ -76,7 +75,7 @@ void gof_file_cache_test () {
     assert (file == file2);
     assert (file.ref_count == 3);
     assert (file2.ref_count == 3);
-    
+
     file.remove_from_caches ();
     assert (file.ref_count == 2);
     assert (file2.ref_count == 2);

--- a/libcore/tests/MarlinIconInfoTests/MarlinIconInfoTests.vala
+++ b/libcore/tests/MarlinIconInfoTests/MarlinIconInfoTests.vala
@@ -1,23 +1,22 @@
-/*
-* Copyright (c) 2017 elementary LLC
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-* Boston, MA 02111-1307, USA.
-*
-* Authored by: Jeremy Wootten <jeremy@elementaryos.org>
-*/
+/***
+    Copyright (c) 2017 elementary LLC
+
+    This file is part of Pantheon Files.
+
+    Pantheon Files is free software: you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License version 3, as published
+    by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranties of
+    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+    PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with Pantheon Files. If not, see <http://www.gnu.org/licenses/>.
+
+    Authored by: Jeremy Wootten <jeremy@elementaryos.org>
+***/
 
 void add_icon_info_tests () {
     Test.add_func ("/MarlinIconInfo/goffile_icon_update", goffile_icon_update_test);


### PR DESCRIPTION
* Use version found at https://www.gnu.org/licenses/gpl-howto.html for multi-file programs.

Only files already failing licensecheck were changed.  Other fails using a postal address and the single file program form, but passing licensecheck, were left alone in this PR.