### PR TITLE
Changed colours for file tags

### DIFF
--- a/libcore/gof-preferences.vala
+++ b/libcore/gof-preferences.vala
@@ -21,7 +21,7 @@ namespace GOF {
 
     public class Preferences : Object {
 
-        public const string TAGS_COLORS[10] = { null, "#fce94f", "#fcaf3e", "#997666", "#8ae234", "#729fcf", "#ad7fa8", "#ef2929", "#d3d7cf", "#888a85" };
+        public const string TAGS_COLORS[9] = { null, "#fff394", "#ffc27d", "#ff8c82", "#d1ff82", "#8cd5ff", "#e29ffc", "#d4d4d4", "#95a3ab" };
 
         public bool show_hidden_files {get; set; default=false;}
         public bool show_remote_thumbnails {set; get; default=false;}

--- a/libcore/gof-preferences.vala
+++ b/libcore/gof-preferences.vala
@@ -21,7 +21,7 @@ namespace GOF {
 
     public class Preferences : Object {
 
-        public const string TAGS_COLORS[9] = { null, "#fff394", "#ffc27d", "#ff8c82", "#d1ff82", "#8cd5ff", "#e29ffc", "#d4d4d4", "#95a3ab" };
+        public const string TAGS_COLORS[10] = { null, "#fff394", "#ffc27d", "#bcaaa4", "#d1ff82", "#8cd5ff", "#e29ffc", "#ff8c82", "#d4d4d4", "#95a3ab" };
 
         public bool show_hidden_files {get; set; default=false;}
         public bool show_remote_thumbnails {set; get; default=false;}

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -365,7 +365,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             int xpad = 9;
 
             if (event.y >= y0 && event.y <= y0+btnh) {
-                for (i=1; i<=9; i++) {
+                for (i=1; i<=10; i++) {
                     if (event.x>= xpad+x0*i && event.x <= xpad+x0*i+btnw) {
                         color_changed (i-1);
                         break;
@@ -382,7 +382,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             int x0 = btnw+5;
             int xpad = 9;
 
-            for (i=1; i<=9; i++) {
+            for (i=1; i<=10; i++) {
                 if (i==1)
                     DrawCross (cr,xpad + x0*i, y0+1, btnw-2, btnh-2);
                 else {

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -365,7 +365,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             int xpad = 9;
 
             if (event.y >= y0 && event.y <= y0+btnh) {
-                for (i=1; i<=10; i++) {
+                for (i=1; i<=9; i++) {
                     if (event.x>= xpad+x0*i && event.x <= xpad+x0*i+btnw) {
                         color_changed (i-1);
                         break;
@@ -382,7 +382,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             int x0 = btnw+5;
             int xpad = 9;
 
-            for (i=1; i<=10; i++) {
+            for (i=1; i<=9; i++) {
                 if (i==1)
                     DrawCross (cr,xpad + x0*i, y0+1, btnw-2, btnh-2);
                 else {


### PR DESCRIPTION
Fixes #155 

Changed file tag colours to colours from elementary's palette.
![screenshot from 2017-10-10 16 44 37](https://user-images.githubusercontent.com/10608836/31413546-607c974c-addf-11e7-9e7d-f8389e836481.png)
![screenshot from 2017-10-10 16 39 31](https://user-images.githubusercontent.com/10608836/31413547-617ad064-addf-11e7-8ca0-ff3570a5ae9a.png)
