### PR TITLE
Blurry location bar icons

### DIFF
--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -661,13 +661,11 @@ namespace Marlin.View.Chrome {
                 cr.save ();
                 /* Really draw the elements */
                 foreach (BreadcrumbElement element in displayed_breadcrumbs) {
+                    x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, scale, this);
+                    /* save element x axis position */
                     if (is_RTL) {
-                        x_render = element.draw (cr, x_render, margin, height_marged, button_context, true, scale, this);
-                        /* save element x axis position */
                         element.x = x_render + element.real_width;
                     } else {
-                        x_render = element.draw (cr, x_render, margin, height_marged, button_context, false, scale, this);
-                        /* save element x axis position */
                         element.x = x_render - element.real_width;
                     }
                 }
@@ -675,13 +673,11 @@ namespace Marlin.View.Chrome {
                 if (old_elements != null) {
                     foreach (BreadcrumbElement element in old_elements) {
                         if (element.display) {
+                            x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, scale, this);
+                            /* save element x axis position */
                             if (is_RTL) {
-                                x_render = element.draw (cr, x_render, margin, height_marged, button_context, true, scale, this);
-                                /* save element x axis position */
                                 element.x = x_render + element.real_width;
                             } else {
-                                x_render = element.draw (cr, x_render, margin, height_marged, button_context, false, scale, this);
-                                /* save element x axis position */
                                 element.x = x_render - element.real_width;
                             }
                         }

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -625,6 +625,12 @@ namespace Marlin.View.Chrome {
             double height = get_allocated_height ();
             double width = get_allocated_width ();
 
+            int scale = 1;
+            Gdk.Window win = get_parent_window ();
+            if (win != null) {
+                scale = win.get_scale_factor ();
+            }
+
             Gtk.Border border = button_context_active.get_margin (Gtk.StateFlags.ACTIVE);
 
             if (!is_focus) {
@@ -656,11 +662,11 @@ namespace Marlin.View.Chrome {
                 /* Really draw the elements */
                 foreach (BreadcrumbElement element in displayed_breadcrumbs) {
                     if (is_RTL) {
-                        x_render = element.draw (cr, x_render, margin, height_marged, button_context, true, this);
+                        x_render = element.draw (cr, x_render, margin, height_marged, button_context, true, scale, this);
                         /* save element x axis position */
                         element.x = x_render + element.real_width;
                     } else {
-                        x_render = element.draw (cr, x_render, margin, height_marged, button_context, false, this);
+                        x_render = element.draw (cr, x_render, margin, height_marged, button_context, false, scale, this);
                         /* save element x axis position */
                         element.x = x_render - element.real_width;
                     }
@@ -670,11 +676,11 @@ namespace Marlin.View.Chrome {
                     foreach (BreadcrumbElement element in old_elements) {
                         if (element.display) {
                             if (is_RTL) {
-                                x_render = element.draw (cr, x_render, margin, height_marged, button_context, true, this);
+                                x_render = element.draw (cr, x_render, margin, height_marged, button_context, true, scale, this);
                                 /* save element x axis position */
                                 element.x = x_render + element.real_width;
                             } else {
-                                x_render = element.draw (cr, x_render, margin, height_marged, button_context, false, this);
+                                x_render = element.draw (cr, x_render, margin, height_marged, button_context, false, scale, this);
                                 /* save element x axis position */
                                 element.x = x_render - element.real_width;
                             }

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -87,7 +87,7 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         icon_name = icon_name_;
     }
 
-    public double draw (Cairo.Context cr, double x, double y, double height, Gtk.StyleContext button_context, bool is_RTL, Gtk.Widget widget) {
+    public double draw (Cairo.Context cr, double x, double y, double height, Gtk.StyleContext button_context, bool is_RTL, int scale, Gtk.Widget widget) {
         var state = button_context.get_state ();
         if (pressed) {
             state |= Gtk.StateFlags.ACTIVE;
@@ -204,13 +204,15 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                 }
             } else if (!text_is_displayed) {
                 if (room_for_icon) {
-                    button_context.render_icon (cr, icon_to_draw, x - ICON_MARGIN - icon_width,
-                                                y_half_height - icon_half_height);
+                    button_context.render_icon (cr, icon_to_draw,
+                                                px_round(x - ICON_MARGIN - icon_width, scale),
+                                                px_round(y_half_height - icon_half_height, scale));
                 }
             } else {
                 if (room_for_icon) {
-                    button_context.render_icon (cr, icon_to_draw, x - ICON_MARGIN - icon_width,
-                                                y_half_height - icon_half_height);
+                    button_context.render_icon (cr, icon_to_draw,
+                                                px_round(x - ICON_MARGIN - icon_width, scale),
+                                                px_round(y_half_height - icon_half_height, scale));
                 }
                 if (room_for_text) {
                     /* text_width already includes icon_width */
@@ -228,13 +230,15 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                 }
             } else if (!text_is_displayed) {
                 if (room_for_icon) {
-                    button_context.render_icon (cr, icon_to_draw, x + ICON_MARGIN,
-                                                 y_half_height - icon_half_height);
+                    button_context.render_icon (cr, icon_to_draw,
+                                                px_round(x + ICON_MARGIN, scale),
+                                                px_round(y_half_height - icon_half_height, scale));
                 }
             } else {
                 if (room_for_icon) {
-                    button_context.render_icon (cr, icon_to_draw, x + ICON_MARGIN,
-                                                 y_half_height - icon_half_height);
+                    button_context.render_icon (cr, icon_to_draw,
+                                                px_round(x + ICON_MARGIN, scale),
+                                                px_round(y_half_height - icon_half_height, scale));
                 }
                 if (room_for_text) {
                     button_context.render_layout (cr, x + iw,
@@ -299,6 +303,10 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         layout.get_size (out width, out height);
         this.text_width = Pango.units_to_double (width);
         this.text_half_height = Pango.units_to_double (height) / 2;
+    }
+
+    private double px_round (double val, int scale) {
+        return Math.round(val * scale) / scale;
     }
 
     /** To help testing **/

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -202,19 +202,13 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                     button_context.render_layout (cr, x - width,
                                                   y_half_height - text_half_height, layout);
                 }
-            } else if (!text_is_displayed) {
-                if (room_for_icon) {
-                    button_context.render_icon (cr, icon_to_draw,
-                                                px_round(x - ICON_MARGIN - icon_width, scale),
-                                                px_round(y_half_height - icon_half_height, scale));
-                }
             } else {
                 if (room_for_icon) {
                     button_context.render_icon (cr, icon_to_draw,
                                                 px_round(x - ICON_MARGIN - icon_width, scale),
                                                 px_round(y_half_height - icon_half_height, scale));
                 }
-                if (room_for_text) {
+                if (text_is_displayed && room_for_text) {
                     /* text_width already includes icon_width */
                     button_context.render_layout (cr, x - width,
                                                   y_half_height - text_half_height, layout);
@@ -228,19 +222,13 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                     button_context.render_layout (cr, x,
                                                   y_half_height - text_half_height, layout);
                 }
-            } else if (!text_is_displayed) {
-                if (room_for_icon) {
-                    button_context.render_icon (cr, icon_to_draw,
-                                                px_round(x + ICON_MARGIN, scale),
-                                                px_round(y_half_height - icon_half_height, scale));
-                }
             } else {
                 if (room_for_icon) {
                     button_context.render_icon (cr, icon_to_draw,
                                                 px_round(x + ICON_MARGIN, scale),
                                                 px_round(y_half_height - icon_half_height, scale));
                 }
-                if (room_for_text) {
+                if (text_is_displayed && room_for_text) {
                     button_context.render_layout (cr, x + iw,
                                                   y_half_height - text_half_height, layout);
                 }


### PR DESCRIPTION
Snap/align icon position with device pixels, so that they don't appear blurry.

before:
![screenshot from 2017-11-03 22 54 57](https://user-images.githubusercontent.com/805017/32397651-0dbf7780-c0eb-11e7-86a5-65868d9f35f8.png)
after:
![screenshot from 2017-11-03 22 54 37](https://user-images.githubusercontent.com/805017/32397655-112df4e6-c0eb-11e7-9553-c3bd584204db.png)

