### PR TITLE
Add another shortcut for switch tab action; modify tab key handling

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -106,6 +106,10 @@ namespace Marlin.View {
             if (is_first_window) {
                 set_accelerators ();
             }
+
+            /* Ensure tab key works as desired (toggle between sidebar and view).  Other widgets/functions
+             * have other keyboard shortcuts (location bar, view mode etc) */
+            unset_focus_chain ();
         }
 
         construct {
@@ -218,13 +222,15 @@ namespace Marlin.View {
             undo_manager.request_menu_update.connect (undo_redo_menu_update_callback);
             button_press_event.connect (on_button_press_event);
 
-            /* Toggle focus between sidebar and view using Tab key, unless location
+            /* Toggle focus between sidebar and view using unmodified Tab key, unless location
              * bar in focus. */
             key_press_event.connect ((event) => {
+                var mods = (event.state & Gtk.accelerator_get_default_mod_mask ());
+
                 switch (event.keyval) {
                     case Gdk.Key.Tab:
                     case Gdk.Key.KP_Tab:
-                        if (top_menu.locked_focus) {
+                        if (mods != 0 || top_menu.locked_focus) {
                             return false;
                         }
                         /* This works better than trying to use a focus chain */
@@ -234,6 +240,7 @@ namespace Marlin.View {
                         } else {
                             sidebar.grab_focus ();
                         }
+
                     return true;
 
                     default:
@@ -1093,8 +1100,8 @@ namespace Marlin.View {
             application.set_accels_for_action ("win.find", {"<Ctrl>F"});
             application.set_accels_for_action ("win.tab::NEW", {"<Ctrl>T"});
             application.set_accels_for_action ("win.tab::CLOSE", {"<Ctrl>W"});
-            application.set_accels_for_action ("win.tab::NEXT", {"<Ctrl>Page_Down"});
-            application.set_accels_for_action ("win.tab::PREVIOUS", {"<Ctrl>Page_Up"});
+            application.set_accels_for_action ("win.tab::NEXT", {"<Ctrl>Page_Down", "<Ctrl>Tab"});
+            application.set_accels_for_action ("win.tab::PREVIOUS", {"<Ctrl>Page_Up", "<Shift><Ctrl>Tab"});
             application.set_accels_for_action ("win.view_mode::ICON", {"<Ctrl>1"});
             application.set_accels_for_action ("win.view_mode::LIST", {"<Ctrl>2"});
             application.set_accels_for_action ("win.view_mode::MILLER", {"<Ctrl>3"});


### PR DESCRIPTION
Fixes #191 
* Add Ctrl+Tab and Shift+Ctrl+Tab as hotkeys for switching tabs as this is more standard.
* Ensure only unmodified Tab toggles focus between sidebar and view.
* Ensure no default focus chain