### PR TITLE
hidpi icons in location bar

### DIFF
--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -501,7 +501,7 @@ namespace Marlin.View.Chrome {
 
             foreach (BreadcrumbIconInfo icon in breadcrumb_icons.get_list ()) {
                 if (icon.protocol && protocol.has_prefix (icon.path)) {
-                    newelements[0].set_icon (icon.icon);
+                    newelements[0].set_icon (icon.icon, breadcrumb_icons.scale);
                     newelements[0].set_icon_name (icon.icon_name);
                     newelements[0].text_for_display = icon.text_displayed;
                     newelements[0].text_is_displayed = (icon.text_displayed != null);
@@ -523,7 +523,7 @@ namespace Marlin.View.Chrome {
                             newelements[j].display = false;
 
                         newelements[h].display = true;
-                        newelements[h].set_icon (icon.icon);
+                        newelements[h].set_icon (icon.icon, breadcrumb_icons.scale);
                         newelements[h].set_icon_name (icon.icon_name);
                         newelements[h].text_is_displayed = (icon.text_displayed != null) || !icon.break_loop;
                         newelements[h].text_for_display = icon.text_displayed;
@@ -625,12 +625,6 @@ namespace Marlin.View.Chrome {
             double height = get_allocated_height ();
             double width = get_allocated_width ();
 
-            int scale = 1;
-            Gdk.Window win = get_parent_window ();
-            if (win != null) {
-                scale = win.get_scale_factor ();
-            }
-
             Gtk.Border border = button_context_active.get_margin (Gtk.StateFlags.ACTIVE);
 
             if (!is_focus) {
@@ -661,7 +655,7 @@ namespace Marlin.View.Chrome {
                 cr.save ();
                 /* Really draw the elements */
                 foreach (BreadcrumbElement element in displayed_breadcrumbs) {
-                    x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, scale, this);
+                    x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, breadcrumb_icons.scale, this);
                     /* save element x axis position */
                     if (is_RTL) {
                         element.x = x_render + element.real_width;
@@ -673,7 +667,7 @@ namespace Marlin.View.Chrome {
                 if (old_elements != null) {
                     foreach (BreadcrumbElement element in old_elements) {
                         if (element.display) {
-                            x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, scale, this);
+                            x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, breadcrumb_icons.scale, this);
                             /* save element x axis position */
                             if (is_RTL) {
                                 element.x = x_render + element.real_width;

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -34,8 +34,8 @@ namespace Marlin.View.Chrome {
         protected Gee.ArrayList<BreadcrumbElement> elements;
         private BreadcrumbIconList breadcrumb_icons;
         private int minimum_width;
-        /*Animation support */
 
+        /*Animation support */
         protected bool animation_visible = true;
         uint animation_timeout_id = 0;
         protected Gee.Collection<BreadcrumbElement>? old_elements;
@@ -625,6 +625,17 @@ namespace Marlin.View.Chrome {
             double height = get_allocated_height ();
             double width = get_allocated_width ();
 
+            int scale = get_style_context ().get_scale ();
+            if (breadcrumb_icons.scale != scale) {
+                breadcrumb_icons.scale = scale;
+
+                string protocol = "";
+                if (elements.size > 0) {
+                    protocol  = elements[0].text;
+                }
+                set_element_icons (protocol, elements);
+            }
+
             Gtk.Border border = button_context_active.get_margin (Gtk.StateFlags.ACTIVE);
 
             if (!is_focus) {
@@ -655,7 +666,7 @@ namespace Marlin.View.Chrome {
                 cr.save ();
                 /* Really draw the elements */
                 foreach (BreadcrumbElement element in displayed_breadcrumbs) {
-                    x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, breadcrumb_icons.scale, this);
+                    x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, scale, this);
                     /* save element x axis position */
                     if (is_RTL) {
                         element.x = x_render + element.real_width;
@@ -667,7 +678,7 @@ namespace Marlin.View.Chrome {
                 if (old_elements != null) {
                     foreach (BreadcrumbElement element in old_elements) {
                         if (element.display) {
-                            x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, breadcrumb_icons.scale, this);
+                            x_render = element.draw (cr, x_render, margin, height_marged, button_context, is_RTL, scale, this);
                             /* save element x axis position */
                             if (is_RTL) {
                                 element.x = x_render + element.real_width;

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -208,8 +208,8 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                     double draw_scale = 1.0 / scale; 
                     cr.scale (draw_scale, draw_scale);
                     button_context.render_icon (cr, icon_to_draw,
-                                                Math.round((x - ICON_MARGIN - icon_width) * scale),
-                                                Math.round((y_half_height - icon_half_height) * scale));
+                                                Math.round ((x - ICON_MARGIN - icon_width) * scale),
+                                                Math.round ((y_half_height - icon_half_height) * scale));
                     cr.restore ();
                 }
                 if (text_is_displayed && room_for_text) {
@@ -232,8 +232,8 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                     double draw_scale = 1.0 / scale; 
                     cr.scale (draw_scale, draw_scale);
                     button_context.render_icon (cr, icon_to_draw,
-                                                Math.round((x + ICON_MARGIN) * scale),
-                                                Math.round((y_half_height - icon_half_height) * scale));
+                                                Math.round ((x + ICON_MARGIN) * scale),
+                                                Math.round ((y_half_height - icon_half_height) * scale));
                     cr.restore ();
                 }
                 if (text_is_displayed && room_for_text) {

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -78,10 +78,10 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         text_for_display = Uri.unescape_string (text);
     }
 
-    public void set_icon (Gdk.Pixbuf icon_) {
+    public void set_icon (Gdk.Pixbuf icon_, int icon_scale) {
         icon = icon_;
-        icon_width = icon.get_width ();
-        icon_half_height = icon.get_height () / 2;
+        icon_width = icon.get_width () / icon_scale;
+        icon_half_height = icon.get_height () / (2 * icon_scale);
     }
     public void set_icon_name (string icon_name_) {
         icon_name = icon_name_;
@@ -204,9 +204,13 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                 }
             } else {
                 if (room_for_icon) {
+                    cr.save ();
+                    double draw_scale = 1.0 / scale; 
+                    cr.scale (draw_scale, draw_scale);
                     button_context.render_icon (cr, icon_to_draw,
-                                                px_round(x - ICON_MARGIN - icon_width, scale),
-                                                px_round(y_half_height - icon_half_height, scale));
+                                                Math.round((x - ICON_MARGIN - icon_width) * scale),
+                                                Math.round((y_half_height - icon_half_height) * scale));
+                    cr.restore ();
                 }
                 if (text_is_displayed && room_for_text) {
                     /* text_width already includes icon_width */
@@ -224,9 +228,13 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                 }
             } else {
                 if (room_for_icon) {
+                    cr.save ();
+                    double draw_scale = 1.0 / scale; 
+                    cr.scale (draw_scale, draw_scale);
                     button_context.render_icon (cr, icon_to_draw,
-                                                px_round(x + ICON_MARGIN, scale),
-                                                px_round(y_half_height - icon_half_height, scale));
+                                                Math.round((x + ICON_MARGIN) * scale),
+                                                Math.round((y_half_height - icon_half_height) * scale));
+                    cr.restore ();
                 }
                 if (text_is_displayed && room_for_text) {
                     button_context.render_layout (cr, x + iw,
@@ -291,10 +299,6 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         layout.get_size (out width, out height);
         this.text_width = Pango.units_to_double (width);
         this.text_half_height = Pango.units_to_double (height) / 2;
-    }
-
-    private double px_round (double val, int scale) {
-        return Math.round(val * scale) / scale;
     }
 
     /** To help testing **/

--- a/libwidgets/Chrome/BreadcrumbIconList.vala
+++ b/libwidgets/Chrome/BreadcrumbIconList.vala
@@ -33,11 +33,13 @@ namespace Marlin.View.Chrome {
 
         private GLib.List<BreadcrumbIconInfo?> icon_info_list = null;
         private Granite.Services.IconFactory icon_factory;
-        Gtk.StyleContext context;
+        private Gtk.StyleContext context;
+        public int scale { public get; private set; }
 
         public BreadcrumbIconList (Gtk.StyleContext _context) {
             context = _context;
             icon_factory = Granite.Services.IconFactory.get_default ();
+            scale = context.get_scale ();
 
             /* FIXME the string split of the path url is kinda too basic, we should use the Gile to split our uris and determine the protocol (if any) with g_uri_parse_scheme or g_file_get_uri_scheme */
             add_icon ({ "afp://", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, true, null, null, null, true, Marlin.PROTOCOL_NAME_AFP});
@@ -125,11 +127,11 @@ namespace Marlin.View.Chrome {
         }
 
         private void add_icon (BreadcrumbIconInfo icon_info) {
-            if (icon_info.gicon != null)
-                icon_info.icon = icon_factory.load_symbolic_icon_from_gicon (context, icon_info.gicon, 16);
-            else
-                icon_info.icon = icon_factory.load_symbolic_icon (context, icon_info.icon_name, 16);
-
+            if (icon_info.gicon != null) {
+                icon_info.icon = icon_factory.load_symbolic_icon_from_gicon (context, icon_info.gicon, 16 * scale);
+            } else {
+                icon_info.icon = icon_factory.load_symbolic_icon (context, icon_info.icon_name, 16 * scale);
+            }
             icon_info_list.append (icon_info);
         }
 

--- a/libwidgets/Chrome/BreadcrumbIconList.vala
+++ b/libwidgets/Chrome/BreadcrumbIconList.vala
@@ -34,12 +34,29 @@ namespace Marlin.View.Chrome {
         private GLib.List<BreadcrumbIconInfo?> icon_info_list = null;
         private Granite.Services.IconFactory icon_factory;
         private Gtk.StyleContext context;
-        public int scale { public get; private set; }
+
+        private int _scale;
+        public int scale {
+            get {
+                return _scale;
+            }
+            set {
+                _scale = value;
+                make_icons ();
+            }
+        }
 
         public BreadcrumbIconList (Gtk.StyleContext _context) {
             context = _context;
             icon_factory = Granite.Services.IconFactory.get_default ();
             scale = context.get_scale ();
+        }
+
+        private void make_icons() {
+            context.save ();
+            context.set_state (Gtk.StateFlags.NORMAL);
+
+            icon_info_list = new GLib.List<BreadcrumbIconInfo?> ();
 
             /* FIXME the string split of the path url is kinda too basic, we should use the Gile to split our uris and determine the protocol (if any) with g_uri_parse_scheme or g_file_get_uri_scheme */
             add_icon ({ "afp://", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, true, null, null, null, true, Marlin.PROTOCOL_NAME_AFP});
@@ -124,6 +141,7 @@ namespace Marlin.View.Chrome {
             icon.exploded = {Path.DIR_SEPARATOR_S};
             add_icon (icon);
 
+            context.restore ();
         }
 
         private void add_icon (BreadcrumbIconInfo icon_info) {
@@ -136,6 +154,9 @@ namespace Marlin.View.Chrome {
         }
 
         public void add_mounted_volumes () {
+            context.save ();
+            context.set_state (Gtk.StateFlags.NORMAL);
+
             /* Add every mounted volume in our BreadcrumbIcon in order to load them properly in the pathbar if needed */
             var volume_monitor = VolumeMonitor.get ();
             var mount_list = volume_monitor.get_mounts ();
@@ -152,6 +173,8 @@ namespace Marlin.View.Chrome {
                     add_icon (icon_info);
                 }
             }
+
+            context.restore ();
         }
 
         public void truncate_to_length (uint new_length) {


### PR DESCRIPTION
This fixes blurry icons in location bar, similar to my previous PR https://github.com/elementary/files/pull/192, but for hidpi.

At 2x scale, icons are loaded with twice the size to pixbuf. When those icons are drawn, cairo.context is scaled appropriately.