### PR TITLE
Handle escaped uris for creating AppInfo in FileManager1.vala

### DIFF
--- a/pantheon-files-daemon/FileManager1.vala
+++ b/pantheon-files-daemon/FileManager1.vala
@@ -43,7 +43,7 @@ public class FileManager1 : Object {
         StringBuilder sb = new StringBuilder ("io.elementary.files -t");
         foreach (string s in uris) {
                 sb.append (" ");
-                sb.append (prepare_uri_for_appinfo_create (s));
+                sb.append (FileManager1.prepare_uri_for_appinfo_create (s));
         }
 
         try {
@@ -59,7 +59,7 @@ public class FileManager1 : Object {
         }
     }
 
-    private string prepare_uri_for_appinfo_create (string uri, bool allow_utf8 = true) {
+    private static string prepare_uri_for_appinfo_create (string uri, bool allow_utf8 = true) {
         string rc = reserved_chars.replace("#", "").replace ("*","");
         string? escaped_uri = Uri.escape_string ((Uri.unescape_string (uri) ?? uri), rc , allow_utf8);
         return (escaped_uri ?? "").replace ("%", "%%");

--- a/pantheon-files-daemon/FileManager1.vala
+++ b/pantheon-files-daemon/FileManager1.vala
@@ -18,7 +18,6 @@
 
 [DBus (name = "org.freedesktop.FileManager1")]
 public class FileManager1 : Object {
-    const string reserved_chars = (GLib.Uri.RESERVED_CHARS_GENERIC_DELIMITERS + GLib.Uri.RESERVED_CHARS_SUBCOMPONENT_DELIMITERS);
 
     [DBus (name = "ShowFolders")]
     public void show_folders (string[] uris, string startup_id) throws DBusError, IOError {
@@ -59,9 +58,13 @@ public class FileManager1 : Object {
         }
     }
 
+    static string RESERVED_CHARS = (GLib.Uri.RESERVED_CHARS_GENERIC_DELIMITERS +
+                                    GLib.Uri.RESERVED_CHARS_SUBCOMPONENT_DELIMITERS)
+                                   .replace ("#", "")
+                                   .replace ("*", "");
+
     private static string prepare_uri_for_appinfo_create (string uri, bool allow_utf8 = true) {
-        string rc = reserved_chars.replace("#", "").replace ("*","");
-        string? escaped_uri = Uri.escape_string ((Uri.unescape_string (uri) ?? uri), rc , allow_utf8);
+        string? escaped_uri = Uri.escape_string ((Uri.unescape_string (uri) ?? uri), RESERVED_CHARS, allow_utf8);
         return (escaped_uri ?? "").replace ("%", "%%");
     }
 }


### PR DESCRIPTION
Fixes #42 

To test:

After installing and killing any existing Files daemon, open a terminal and enter:

```
dbus-send --session --print-reply --reply-timeout=120000 --type=method_call \
--dest='org.freedesktop.FileManager1'   '/org/freedesktop/FileManager1' \
org.freedesktop.FileManager1.ShowFolders   array:string:"[path to be tested]" string:"TESTID"
```
Replace `[path to be tested]` with the path to an existing file or folder with spaces in the name.  The spaces may or may not be escaped (%20).

The branch should also cope with other unusual characters in the name although it cannot be guaranteed that all weird paths will be handled properly.

