### PR TITLE
Use Granite.HeaderLabel and style class constants

### DIFF
--- a/src/Dialogs/AbstractPropertiesDialog.vala
+++ b/src/Dialogs/AbstractPropertiesDialog.vala
@@ -46,7 +46,7 @@ protected abstract class Marlin.View.AbstractPropertiesDialog : Gtk.Dialog {
     construct {
         set_default_size (220, -1);
 
-        var info_header = new HeaderLabel (_("Info"));
+        var info_header = new Granite.HeaderLabel (_("Info"));
 
         info_grid = new Gtk.Grid ();
         info_grid.column_spacing = 6;
@@ -84,7 +84,7 @@ protected abstract class Marlin.View.AbstractPropertiesDialog : Gtk.Dialog {
     }
 
     protected void create_header_title () {
-        header_title.get_style_context ().add_class ("h2");
+        header_title.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
         header_title.hexpand = true;
         header_title.margin_top = 6;
         header_title.valign = Gtk.Align.CENTER;
@@ -133,7 +133,7 @@ protected abstract class Marlin.View.AbstractPropertiesDialog : Gtk.Dialog {
     }
 
     protected void create_storage_bar (GLib.FileInfo file_info, int line) {
-        var storage_header = new HeaderLabel (_("Device Usage"));
+        var storage_header = new Granite.HeaderLabel (_("Device Usage"));
         info_grid.attach (storage_header, 0, line, 1, 1);
 
         if (file_info != null &&

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1854,7 +1854,7 @@ namespace FM {
                 menu.attach_to_widget (this, null);
                 /* Override style MESSAGE_CLASS of view when it is empty */
                 if (slot.directory.is_empty ())
-                    menu.get_style_context ().add_class ("context-menu");
+                    menu.get_style_context ().add_class (Gtk.STYLE_CLASS_CONTEXT_MENU);
                 Eel.pop_up_context_menu (menu,
                                          Marlin.DEFAULT_POPUP_MENU_DISPLACEMENT,
                                          Marlin.DEFAULT_POPUP_MENU_DISPLACEMENT,

--- a/src/View/Sidebar.vala
+++ b/src/View/Sidebar.vala
@@ -251,8 +251,8 @@ namespace Marlin.Places {
 
         private void configure_tree_view () {
             var style_context = tree_view.get_style_context ();
-            style_context.add_class ("sidebar");
-            style_context.add_class ("source-list");
+            style_context.add_class (Gtk.STYLE_CLASS_SIDEBAR);
+            style_context.add_class (Granite.STYLE_CLASS_SOURCE_LIST);
 
             tree_view.set_search_column (Column.NAME);
             var selection = tree_view.get_selection ();

--- a/src/View/Widgets/Label.vala
+++ b/src/View/Widgets/Label.vala
@@ -17,16 +17,6 @@
 * Boston, MA 02110-1335 USA.
 */
 
-public class HeaderLabel : Gtk.Label {
-    public HeaderLabel (string label) {
-        Object (halign: Gtk.Align.START, label: label);
-    }
-
-    construct {
-        get_style_context ().add_class ("h4");
-    }
-}
-
 public class KeyLabel : Gtk.Label {
     public KeyLabel (string label) {
         Object (halign: Gtk.Align.END, label: label, margin_start: 12);


### PR DESCRIPTION
Replaces internal headerlabel class with Granite.HeaderLabel
Use style class constants from Granite and Gtk instead of strings