### PR TITLE
Simplify ViewContainer path/mode/container changes

### DIFF
--- a/libcore/AbstractSlot.vala
+++ b/libcore/AbstractSlot.vala
@@ -58,7 +58,7 @@ namespace GOF {
 
         public signal void active (bool scroll = true, bool animate = true);
         public signal void inactive ();
-        public signal void path_changed (bool change_mode_to_icons = true);
+        public signal void path_changed ();
         public signal void new_container_request (GLib.File loc, Marlin.OpenFlag flag);
         public signal void directory_loaded (GOF.Directory.Async dir);
         public signal void item_hovered (GOF.File? file);
@@ -80,7 +80,7 @@ namespace GOF {
         public abstract unowned AbstractSlot? get_current_slot ();
         public abstract void reload (bool non_local_only = false);
         public abstract void grab_focus ();
-        public abstract void user_path_change_request (GLib.File loc, bool allow_mode_change, bool make_root);
+        public abstract void user_path_change_request (GLib.File loc, bool make_root);
 
         public abstract void select_first_for_empty_selection ();
         public abstract void select_glib_files (GLib.List<GLib.File> locations, GLib.File? focus_location);

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -552,6 +552,10 @@ namespace PF.FileUtils {
                 return false;
         }
     }
+
+    public bool is_icon_path (string path) {
+        return "/icons" in path || "/.icons" in path;
+    }
 }
 
 namespace Marlin {

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -40,7 +40,7 @@ public class Async : Object {
     public int icon_size = 32;
 
     /* we're looking for particular path keywords like *\/icons* .icons ... */
-    public bool uri_contain_keypath_icons;
+    public bool uri_contain_keypath_icons = false;
 
     /* for auto-sizing Miller columns */
     public string longest_file_name = "";
@@ -444,8 +444,7 @@ public class Async : Object {
         set_confirm_trash ();
 
         if (can_load) {
-            uri_contain_keypath_icons = "/icons" in file.uri || "/.icons" in file.uri;
-
+            uri_contain_keypath_icons = PF.FileUtils.is_icon_path (file.uri);
             if (file_loaded_func == null && is_local) {
                 try {
                     monitor = location.monitor_directory (0);
@@ -459,7 +458,6 @@ public class Async : Object {
                     }
                 }
             }
-
 
             if (is_trash) {
                 connect_volume_monitor_signals ();

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -40,7 +40,7 @@ public class Async : Object {
     public int icon_size = 32;
 
     /* we're looking for particular path keywords like *\/icons* .icons ... */
-    public bool uri_contain_keypath_icons = false;
+    public bool uri_contains_keypath_icons = false;
 
     /* for auto-sizing Miller columns */
     public string longest_file_name = "";
@@ -444,7 +444,7 @@ public class Async : Object {
         set_confirm_trash ();
 
         if (can_load) {
-            uri_contain_keypath_icons = PF.FileUtils.is_icon_path (file.uri);
+            uri_contains_keypath_icons = PF.FileUtils.is_icon_path (file.uri);
             if (file_loaded_func == null && is_local) {
                 try {
                     monitor = location.monitor_directory (0);

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -87,7 +87,7 @@ namespace Marlin.View {
         public void add_location (GLib.File loc, Marlin.View.Slot? host = null, bool scroll = true, bool animate = true) {
             Marlin.View.Slot new_slot = new Marlin.View.Slot (loc, ctab, Marlin.ViewMode.MILLER_COLUMNS);
             /* Notify view container of path change - will set tab to working and change pathbar */
-            path_changed (false); /* DO not allow mode change when adding a location */
+            path_changed ();
             new_slot.slot_number = (host != null) ? host.slot_number + 1 : 0;
             total_width += new_slot.width;
 
@@ -160,9 +160,9 @@ namespace Marlin.View {
 /** Signal handling **/
 /*********************/
 
-        public override void user_path_change_request (GLib.File loc, bool allow_mode_change = false, bool make_root = false) {
+        public override void user_path_change_request (GLib.File loc, bool make_root = false) {
             /* Requests from history buttons, pathbar come here with make_root = false.
-             * These do not create a new root and automatic mode change for icon directories is not allowed.
+             * These do not create a new root.
              * Requests from the sidebar have make_root = true
              */
             change_path (loc, make_root);
@@ -190,7 +190,7 @@ namespace Marlin.View {
             if (!found) {
                 truncate_list_after_slot (first_slot);
                 if (loc.get_uri () != first_slot.uri) {
-                    first_slot.user_path_change_request (loc, false, true);
+                    first_slot.user_path_change_request (loc, true);
                     root_location = loc;
                     /* Sidebar requests make_root true - first directory will be selected;
                      * Go_up requests make_root false - previous directory will be selected
@@ -280,8 +280,8 @@ namespace Marlin.View {
             return true;
         }
 
-        private void on_slot_path_changed (GOF.AbstractSlot aslot, bool allow_mode_change) {
-            path_changed (false);
+        private void on_slot_path_changed () {
+            path_changed ();
         }
 
         private void on_slot_directory_loaded (GOF.Directory.Async dir) {

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -166,7 +166,7 @@ namespace Marlin.View {
                 dir_view.prepare_reload (dir); /* clear model but do not change directory */
                 /* view and slot are unfrozen when done loading signal received */
                 is_frozen = true;
-                path_changed (false);
+                path_changed ();
                 /* if original_request false, leave original_load_request as it is (it may already be true
                  * if reloading in response to reload button press). */
                 if (original_request) {
@@ -233,7 +233,7 @@ namespace Marlin.View {
                 if (mode == Marlin.ViewMode.MILLER_COLUMNS) {
                     miller_slot_request (loc, make_root); /* signal to parent MillerView */
                 } else {
-                    user_path_change_request (loc, false, make_root); /* Handle ourselves */
+                    user_path_change_request (loc, make_root); /* Handle ourselves */
                 }
             } else {
                 new_container_request (loc, flag);
@@ -277,16 +277,14 @@ namespace Marlin.View {
             has_autosized = true;
         }
 
-        public override void user_path_change_request (GLib.File loc, bool allow_mode_change = true, bool make_root = true) {
+        public override void user_path_change_request (GLib.File loc, bool make_root = true) {
         /** Only this function must be used to change or reload the path **/
             assert (loc != null);
             var old_dir = directory;
             set_up_directory (loc);
 
-            path_changed (allow_mode_change && directory.uri_contains_keypath_icons);
-            /* ViewContainer listens to this signal takes care of updating appearance
-             * If allow_mode_change is false View Container will not automagically
-             * switch to icon view for icon folders (needed for Miller View) */
+            path_changed ();
+            /* ViewContainer listens to this signal takes care of updating appearance */
             dir_view.change_directory (old_dir, directory);
             initialize_directory ();
         }

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -283,7 +283,7 @@ namespace Marlin.View {
             var old_dir = directory;
             set_up_directory (loc);
 
-            path_changed (allow_mode_change && directory.uri_contain_keypath_icons);
+            path_changed (allow_mode_change && directory.uri_contains_keypath_icons);
             /* ViewContainer listens to this signal takes care of updating appearance
              * If allow_mode_change is false View Container will not automagically
              * switch to icon view for icon folders (needed for Miller View) */

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -302,15 +302,6 @@ namespace Marlin.View {
             refresh_slot_info (slot.location);
         }
 
-        private void user_path_change_request (GLib.File loc, bool allow_mode_change = true, bool make_root = true) {
-            /* Ony call directly if it is known that a change of folder is required
-             * otherwise call focus_location.
-             */
-            open_location (loc,
-                           make_root ? Marlin.OpenFlag.NEW_ROOT : Marlin.OpenFlag.DEFAULT,
-                           allow_mode_change);
-        }
-
         private void open_location (GLib.File loc,
                                     Marlin.OpenFlag flag = Marlin.OpenFlag.NEW_ROOT,
                                     bool allow_mode_change = true) {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -315,11 +315,12 @@ namespace Marlin.View {
                                     Marlin.OpenFlag flag = Marlin.OpenFlag.NEW_ROOT,
                                     bool allow_mode_change = true) {
 
+            /* Default to not change view mode automatically */
             bool change_to_icon_mode = false;
 
             if (allow_mode_change &&
                 view_mode != Marlin.ViewMode.ICON &&
-                PF.FileUtils.is_icon_path (loc.get_uri ())) {
+                PF.FileUtils.is_icon_path (loc.get_uri ())) { // In this case, automagical change to IconMode
 
                     change_to_icon_mode = true;
             }
@@ -341,6 +342,7 @@ namespace Marlin.View {
                                                        allow_mode_change,
                                                        flag == Marlin.OpenFlag.NEW_ROOT);
                     }
+
                     break;
             }
         }

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -166,6 +166,7 @@ namespace Marlin.View {
                 if (content_item != null) {
                     remove (content_item);
                 }
+
                 content_item = value;
 
                 if (content_item != null) {
@@ -306,36 +307,20 @@ namespace Marlin.View {
         }
 
         private void open_location (GLib.File loc,
-                                    Marlin.OpenFlag flag = Marlin.OpenFlag.NEW_ROOT,
-                                    bool allow_mode_change = true) {
-
-            /* Default to not change view mode automatically */
-            bool change_to_icon_mode = false;
-
-            if (allow_mode_change &&
-                view_mode != Marlin.ViewMode.ICON &&
-                PF.FileUtils.is_icon_path (loc.get_uri ())) { // In this case, automagical change to IconMode
-
-                    change_to_icon_mode = true;
-            }
+                                    Marlin.OpenFlag flag = Marlin.OpenFlag.NEW_ROOT) {
 
             switch ((Marlin.OpenFlag)flag) {
                 case Marlin.OpenFlag.NEW_TAB:
-                    this.window.add_tab (loc, change_to_icon_mode ? Marlin.ViewMode.ICON : view_mode);
+                    this.window.add_tab (loc, view_mode);
                     break;
 
                 case Marlin.OpenFlag.NEW_WINDOW:
-                    this.window.add_window (loc, change_to_icon_mode ? Marlin.ViewMode.ICON : view_mode);
+                    this.window.add_window (loc, view_mode);
                     break;
 
                 default:
-                    if (change_to_icon_mode) {
-                        change_view_mode (Marlin.ViewMode.ICON, loc);
-                    } else {
                         view.user_path_change_request (loc,
-                                                       allow_mode_change,
                                                        flag == Marlin.OpenFlag.NEW_ROOT);
-                    }
 
                     break;
             }
@@ -345,7 +330,7 @@ namespace Marlin.View {
             open_location (loc, flag);
         }
 
-        public void on_slot_path_changed (GOF.AbstractSlot slot, bool change_mode_to_icons) {
+        public void on_slot_path_changed (GOF.AbstractSlot slot) {
             directory_is_loading (slot.location);
         }
 


### PR DESCRIPTION
Fixes #236 
* Improve some variable & function names
* Handle path, container and automagical mode change in one function.
* Use PF.FileUtils function to detect icon directory
* Modify existing handlers to call new function

Note: Additional lines are due to formatting and comments. 