### PR TITLE
Better trash detection

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -555,8 +555,9 @@ namespace PF.FileUtils {
 
     public bool location_is_in_trash (GLib.File location) {
         var uri = location.get_uri ();
+        var scheme = Uri.parse_scheme (uri);
 
-        return (uri.has_prefix ("trash") ||
+        return (scheme != null && scheme.has_prefix ("trash") ||
                 uri.contains (GLib.Path.DIR_SEPARATOR_S + ".Trash-") ||
                 (uri.contains (GLib.Path.DIR_SEPARATOR_S + ".local") &&
                  uri.contains (GLib.Path.DIR_SEPARATOR_S + "Trash" + GLib.Path.DIR_SEPARATOR_S)));

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -552,6 +552,15 @@ namespace PF.FileUtils {
                 return false;
         }
     }
+
+    public bool location_is_in_trash (GLib.File location) {
+        var uri = location.get_uri ();
+
+        return (uri.has_prefix ("trash") ||
+                uri.contains (GLib.Path.DIR_SEPARATOR_S + ".Trash-") ||
+                (uri.contains (GLib.Path.DIR_SEPARATOR_S + ".local") &&
+                 uri.contains (GLib.Path.DIR_SEPARATOR_S + "Trash" + GLib.Path.DIR_SEPARATOR_S)));
+    }
 }
 
 namespace Marlin {

--- a/libcore/eel-gio-extensions.c
+++ b/libcore/eel-gio-extensions.c
@@ -86,13 +86,6 @@ eel_g_file_get_trash_original_file (const gchar *string)
     return location;
 }
 
-gboolean
-eel_g_file_is_trashed (GFile *file)
-{
-  g_return_val_if_fail (G_IS_FILE (file), FALSE);
-  return g_file_has_uri_scheme (file, "trash");
-}
-
 GKeyFile *
 eel_g_file_query_key_file (GFile *file, GCancellable *cancellable, GError **error)
 {

--- a/libcore/eel-gio-extensions.h
+++ b/libcore/eel-gio-extensions.h
@@ -25,7 +25,6 @@
 GList       *eel_g_file_list_new_from_string (const gchar *string);
 gchar       *eel_g_file_get_location (GFile *file);
 GFile       *eel_g_file_get_trash_original_file (const gchar *string);
-gboolean    eel_g_file_is_trashed (GFile *file);
 GKeyFile    *eel_g_file_query_key_file (GFile *file, GCancellable *cancellable, GError **error);
 GFile       *eel_g_file_ref (GFile *file);
 void        eel_g_file_unref (GFile *file);

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -128,7 +128,7 @@ public class Async : Object {
         can_load = false;
 
         scheme = location.get_uri_scheme ();
-        is_trash = (scheme == "trash");
+        is_trash = PF.FileUtils.location_is_in_trash (location);
         is_recent = (scheme == "recent");
         is_no_info = ("cdda mtp ssh sftp afp dav davs".contains (scheme)); //Try lifting requirement for info on remote connections
         is_local = is_trash || is_recent || (scheme == "file");

--- a/libcore/gof-file.c
+++ b/libcore/gof-file.c
@@ -1275,7 +1275,7 @@ gboolean
 gof_file_is_trashed (GOFFile *file)
 {
     g_return_val_if_fail (GOF_IS_FILE (file), FALSE);
-    return eel_g_file_is_trashed (gof_file_get_target_location (file));
+    return pf_file_utils_location_is_in_trash (gof_file_get_target_location (file));
 }
 
 const gchar *
@@ -1635,7 +1635,7 @@ gof_file_accepts_drop (GOFFile          *file,
             g_free (scheme);
 
             /* copy/move/link within the trash not possible */
-            if (G_UNLIKELY (eel_g_file_is_trashed (lp->data) && gof_file_is_trashed (file)))
+            if (G_UNLIKELY (pf_file_utils_location_is_in_trash (lp->data) && gof_file_is_trashed (file)))
                 return 0;
         }
 
@@ -1652,7 +1652,7 @@ gof_file_accepts_drop (GOFFile          *file,
             for (lp = file_list, n = 0; lp != NULL && n < 100; lp = lp->next, ++n)
             {
                 /* dropping from the trash always suggests move */
-                if (G_UNLIKELY (eel_g_file_is_trashed (lp->data)))
+                if (G_UNLIKELY (pf_file_utils_location_is_in_trash (lp->data)))
                     break;
 
                 /* determine the cached version of the source file */


### PR DESCRIPTION
Fixes #229 

* New Vala PF.FileUtils.function location_is_in_trash ()
* Use new function throughout.

Still detects file is in trash even if the scheme is not trash:// but the actual location of the system or user trash folder.
