### PR TITLE
Avoid double event connection.

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -230,7 +230,7 @@ namespace FM {
 
         public bool renaming {get; protected set; default = false;}
 
-        private bool _is_frozen = true;
+        private bool _is_frozen = false;
         public bool is_frozen {
             set {
                 if (value && !_is_frozen) {


### PR DESCRIPTION
* Initialise AbstractDirectoryView.is_frozen false to avoid the keypress event being connected twice at start up.

If it is connected twice, it only gets disconnected once so there continues to be a connection which may cause unexpected results. This is the simplest solution; the need for is_frozen and its scope needs to be reviewed in future.