### PR TITLE
Reduce slot window dependency

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -372,7 +372,6 @@ namespace FM {
 
             size_allocate.connect_after (on_size_allocate);
 
-            button_press_event.connect (on_button_press_event);
             popup_menu.connect (on_popup_menu);
 
             unrealize.connect (() => {
@@ -1427,24 +1426,6 @@ namespace FM {
                 show_context_menu (event);
 
             return true;
-        }
-
-        private bool on_button_press_event (Gdk.EventButton event) {
-            /* Extra mouse button action: button8 = "Back" button9 = "Forward" */
-            GLib.Action? action = null;
-            GLib.SimpleActionGroup main_actions = window.get_action_group ();
-            if (event.type == Gdk.EventType.BUTTON_PRESS) {
-                if (event.button == 8)
-                    action = main_actions.lookup_action ("Back");
-                else if (event.button == 9)
-                    action = main_actions.lookup_action ("Forward");
-
-                if (action != null) {
-                    action.activate (null);
-                    return true;
-                }
-            }
-            return false;
         }
 
 /** Handle Motion events */
@@ -3232,12 +3213,12 @@ namespace FM {
                 }
             }
 
-            bool result = true;
+            bool result = false; // default false so events get passed to Window
             should_activate = false;
             should_scroll = true;
 
             switch (event.button) {
-                case Gdk.BUTTON_PRIMARY:
+                case Gdk.BUTTON_PRIMARY: // button 1
                     /* Control-click should deselect previously selected path on key release (unless
                      * pointer moves)
                      */
@@ -3308,13 +3289,13 @@ namespace FM {
                     }
                     break;
 
-                case Gdk.BUTTON_MIDDLE:
+                case Gdk.BUTTON_MIDDLE:  // button 2
                     if (path_is_selected (path))
                         activate_selected_items (Marlin.OpenFlag.NEW_TAB);
 
                     break;
 
-                case Gdk.BUTTON_SECONDARY:
+                case Gdk.BUTTON_SECONDARY: // button 3
                     if (click_zone == ClickZone.NAME ||
                         click_zone == ClickZone.BLANK_PATH ||
                         click_zone == ClickZone.ICON) {
@@ -3334,6 +3315,7 @@ namespace FM {
                     result = handle_default_button_click (event);
                     break;
             }
+
             previous_linear_selection_path = path != null ? path.copy () : null;
             return result;
         }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2933,16 +2933,6 @@ namespace FM {
                     break;
             }
 
-            /* Use find function instead of view interactive search */
-            if (no_mods || only_shift_pressed) {
-                /* Use printable characters to initiate search */
-                if (((unichar)(Gdk.keyval_to_unicode (keyval))).isprint ()) {
-                    window.win_actions.activate_action ("find", null);
-                    window.key_press_event (event);
-                    return true;
-                }
-            }
-
             return false;
         }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1054,7 +1054,8 @@ namespace FM {
                 return;
 
             foreach (GOF.File file in selected_files) {
-                window.add_tab (GLib.File.new_for_uri (file.get_display_target_uri ()), Marlin.ViewMode.CURRENT);
+                var loc = GLib.File.new_for_uri (file.get_display_target_uri ());
+                path_change_request (loc, Marlin.OpenFlag.NEW_TAB, true);
             }
         }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -303,7 +303,11 @@ namespace FM {
             activatable_cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), "pointer");
             selectable_cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), "default");
             blank_cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), "crosshair");
-            clipboard = ((Marlin.Application)(window.application)).get_clipboard_manager ();
+
+            var app = (Marlin.Application.get ());
+            clipboard = app.get_clipboard_manager ();
+            recent = app.get_recent_manager ();
+
             icon_renderer = new Marlin.IconRenderer ();
             thumbnailer = Marlin.Thumbnailer.get ();
             thumbnailer.finished.connect ((req) => {
@@ -315,8 +319,6 @@ namespace FM {
             model = GLib.Object.@new (FM.ListModel.get_type (), null) as FM.ListModel;
             Preferences.settings.bind ("single-click", this, "single_click_mode", SettingsBindFlags.GET);
             Preferences.settings.bind ("show-remote-thumbnails", this, "show_remote_thumbnails", SettingsBindFlags.GET);
-
-            recent = ((Marlin.Application)(window.application)).get_recent_manager ();
 
              /* Currently, "single-click rename" is disabled, matching existing UI
               * Currently, "activate on blank" is enabled, matching existing UI
@@ -806,11 +808,9 @@ namespace FM {
 
                 switch (flag) {
                     case Marlin.OpenFlag.NEW_TAB:
-                        window.add_tab (location, Marlin.ViewMode.CURRENT);
-                        break;
-
                     case Marlin.OpenFlag.NEW_WINDOW:
-                        window.add_window(location, Marlin.ViewMode.CURRENT);
+
+                        path_change_request (location, flag, true);
                         break;
 
                     default:

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3197,7 +3197,7 @@ namespace FM {
                     linear_select_required = true;
                 } else {
                     previous_selection_was_linear = false;
-                    return window.button_press_event (event);
+                    return false;
                 }
             } else {
                 previous_selection_was_linear = false;
@@ -3503,7 +3503,7 @@ namespace FM {
 
         protected virtual bool handle_default_button_click (Gdk.EventButton event) {
             /* pass unhandled events to the Marlin.View.Window */
-            return window.button_press_event (event);
+            return false;
         }
 
         protected virtual bool get_next_visible_iter (ref Gtk.TreeIter iter, bool recurse = true) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -220,7 +220,7 @@ namespace Marlin.View {
 
             /* Toggle focus between sidebar and view using Tab key, unless location
              * bar in focus. */
-            key_press_event.connect ((event) => {
+            key_press_event.connect_after ((event) => {
                 switch (event.keyval) {
                     case Gdk.Key.Tab:
                     case Gdk.Key.KP_Tab:
@@ -237,8 +237,20 @@ namespace Marlin.View {
                     return true;
 
                     default:
-                        return false;
+                        /* Use find function instead of view interactive search */
+                        if (event.state == 0 || event.state == Gdk.ModifierType.SHIFT_MASK) {
+                            /* Use printable characters to initiate search */
+                            if (((unichar)(Gdk.keyval_to_unicode (event.keyval))).isprint ()) {
+                                win_actions.activate_action ("find", null);
+                                key_press_event (event);
+                                return true;
+                            }
+                        }
+
+                        break;
                 }
+
+                return false;
             });
 
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -216,7 +216,7 @@ namespace Marlin.View {
             });
 
             undo_manager.request_menu_update.connect (undo_redo_menu_update_callback);
-            button_press_event.connect (on_button_press_event);
+            button_press_event.connect_after (on_button_press_event);
 
             /* Toggle focus between sidebar and view using Tab key, unless location
              * bar in focus. */
@@ -374,6 +374,7 @@ namespace Marlin.View {
                 default:
                     break;
             }
+
             return result;
         }
 


### PR DESCRIPTION
* Remove some direct references to Marlin.View.Window, either by moving the funcrion to Window or emitting a signal.

* Get a reference to the app directly