### PR TITLE
Handle dummy row null file entries better

### DIFF
--- a/libcore/PluginManager.vala
+++ b/libcore/PluginManager.vala
@@ -224,9 +224,17 @@ public class Marlin.PluginManager : Object {
             plugin.update_sidebar (widget);
     }
 
-    public void update_file_info (GOF.File file) {
-        foreach (var plugin in plugin_hash.values)
+    public void update_file_info (GOF.File? file) {
+        /* Plugin interface demands non-null file.  A null file can
+         * arise from a dummy row in list view */
+
+        if (file == null) {
+            return;
+        }
+
+        foreach (var plugin in plugin_hash.values) {
             plugin.update_file_info (file);
+        }
     }
 
     public Gee.List<string> get_available_plugins () {

--- a/libcore/PluginManager.vala
+++ b/libcore/PluginManager.vala
@@ -224,14 +224,7 @@ public class Marlin.PluginManager : Object {
             plugin.update_sidebar (widget);
     }
 
-    public void update_file_info (GOF.File? file) {
-        /* Plugin interface demands non-null file.  A null file can
-         * arise from a dummy row in list view */
-
-        if (file == null) {
-            return;
-        }
-
+    public void update_file_info (GOF.File file) {
         foreach (var plugin in plugin_hash.values) {
             plugin.update_file_info (file);
         }

--- a/libcore/fm-list-model.c
+++ b/libcore/fm-list-model.c
@@ -540,13 +540,12 @@ fm_list_model_file_entry_compare_func (gconstpointer a,
                                             model->details->sort_id,
                                             TRUE,
                                             (model->details->order == GTK_SORT_DESCENDING));
-    } else {
+
+    } else if (file_entry1->file == NULL || file_entry1->file->location == NULL) {
         /* Dummy rows representing expanded empty directories have null files */
-        if (file_entry1->file == NULL || file_entry1->file->location == NULL) {
-            return -1;
-        } else {
-            return 1;
-        }
+        result = -1;
+    } else {
+        result = 1;
     }
 
     return result;

--- a/libcore/fm-list-model.c
+++ b/libcore/fm-list-model.c
@@ -533,15 +533,20 @@ fm_list_model_file_entry_compare_func (gconstpointer a,
     file_entry1 = (FileEntry *)a;
     file_entry2 = (FileEntry *)b;
 
-    if (file_entry1->file != NULL && file_entry2->file != NULL) {
+    if (file_entry1->file != NULL && file_entry2->file != NULL &&
+        file_entry1->file->location != NULL && file_entry2->file->location != NULL) {
+
         result = gof_file_compare_for_sort (file_entry1->file, file_entry2->file,
                                             model->details->sort_id,
                                             TRUE,
                                             (model->details->order == GTK_SORT_DESCENDING));
-    } else if (file_entry1->file == NULL) {
-        return -1;
     } else {
-        return 1;
+        /* Dummy rows representing expanded empty directories have null files */
+        if (file_entry1->file == NULL || file_entry1->file->location == NULL) {
+            return -1;
+        } else {
+            return 1;
+        }
     }
 
     return result;
@@ -697,7 +702,7 @@ fm_list_model_add_file (FMListModel *model, GOFFile *file,
     gboolean replaced_dummy;
     GHashTable *parent_hash;
 
-    g_return_val_if_fail (file != NULL, FALSE);
+    g_return_val_if_fail (file != NULL && file->location != NULL, FALSE);
     parent_ptr = g_hash_table_lookup (model->details->directory_reverse_map,
                                       directory);
     if (parent_ptr) {

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -37,7 +37,7 @@ namespace FM
         public bool get_first_iter_for_file (GOF.File file, out Gtk.TreeIter iter);
         public bool get_tree_iter_from_file (GOF.File file, GOF.Directory.Async directory, out Gtk.TreeIter iter);
         public bool get_directory_file (Gtk.TreePath path, out unowned GOF.Directory.Async directory, out unowned GOF.File file);
-        public GOF.File file_for_iter (Gtk.TreeIter iter);
+        public GOF.File? file_for_iter (Gtk.TreeIter iter);
         public void clear ();
         public signal void subdirectory_unloaded (GOF.Directory.Async directory);
     }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2441,7 +2441,7 @@ namespace FM {
                 Gtk.TreePath sp, ep;
                 Gtk.TreeIter iter;
                 bool valid_iter;
-                GOF.File file;
+                GOF.File? file;
                 GLib.List<GOF.File> visible_files = null;
                 uint actually_visible = 0;
 
@@ -2466,21 +2466,23 @@ namespace FM {
                     /* iterate over the range to collect all files */
                     valid_iter = model.get_iter (out iter, start_path);
                     while (valid_iter && thumbnail_source_id > 0) {
-                        file = model.file_for_iter (iter);
+                        file = model.file_for_iter (iter); // Maybe null if dummy row
                         path = model.get_path (iter);
 
-                        /* Ask thumbnailer only if ThumbState UNKNOWN */
-                        if (file != null && file.flags == GOF.File.ThumbState.UNKNOWN) {
-                            visible_files.prepend (file);
-                            if (path.compare (sp) >= 0 && path.compare (ep) <= 0) {
-                                actually_visible++;
+                        if (file != null) {
+                            /* Ask thumbnailer only if ThumbState UNKNOWN */
+                            if (file.flags == GOF.File.ThumbState.UNKNOWN) {
+                                visible_files.prepend (file);
+                                if (path.compare (sp) >= 0 && path.compare (ep) <= 0) {
+                                    actually_visible++;
+                                }
                             }
-                        }
 
-                        if (plugins != null) {
-                            plugins.update_file_info (file);
-                        }
+                            if (plugins != null) {
+                                plugins.update_file_info (file);
+                            }
 
+                        }
                         /* check if we've reached the end of the visible range */
                         if (path.compare (end_path) != 0)
                             valid_iter = get_next_visible_iter (ref iter);


### PR DESCRIPTION
TO TEST:

Check for regressions and terminal warnings when displaying expanded empty directories in ListView and carrying out operations such as resorting, copy/paste etc.