### PR TITLE
Fix valac warnings

### DIFF
--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -535,7 +535,7 @@ public class Async : Object {
             debug ("Unmounting because of timeout");
             cancellable.cancel ();
             cancellable = new Cancellable ();
-            file.location.unmount_mountable (GLib.MountUnmountFlags.FORCE, cancellable);
+            file.location.unmount_mountable_with_operation (GLib.MountUnmountFlags.FORCE, null, cancellable);
             file.mount = null;
             file.is_mounted = false;
         }

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -535,7 +535,7 @@ public class Async : Object {
             debug ("Unmounting because of timeout");
             cancellable.cancel ();
             cancellable = new Cancellable ();
-            file.location.unmount_mountable_with_operation (GLib.MountUnmountFlags.FORCE, null, cancellable);
+            file.location.unmount_mountable_with_operation.begin (GLib.MountUnmountFlags.FORCE, null, cancellable);
             file.mount = null;
             file.is_mounted = false;
         }

--- a/libwidgets/Chrome/ButtonWithMenu.vala
+++ b/libwidgets/Chrome/ButtonWithMenu.vala
@@ -81,45 +81,24 @@ namespace Marlin.View.Chrome {
 
         public ulong toggled_sig_id;
 
-        /**
-         * Delegate function used to populate menu
-         */
-        public delegate Gtk.Menu MenuFetcher ();
-
         public signal void slow_press ();
 
-        public MenuFetcher fetcher {
-            set {
-                _fetcher = value;
-                has_fetcher = true;
-            }
-            get {
-                return _fetcher;
-            }
-        }
-
+        private Gtk.Menu _menu;
         public Gtk.Menu menu {
             get {
                 return _menu;
             }
+
             set {
-                if (has_fetcher) {
-                    warning ("Don't set the menu property on a ToolMenuButton when there is already a menu fetcher");
-                }
-                else {
-                    _menu = value;
-                    update_menu_properties ();
-                }
+                _menu = value;
+                update_menu_properties ();
             }
         }
 
         private int LONG_PRESS_TIME = Gtk.Settings.get_default ().gtk_double_click_time * 2;
         private uint timeout = 0;
         private uint last_click_time = 0;
-        private bool has_fetcher = false;
 
-        private unowned MenuFetcher _fetcher;
-        private Gtk.Menu _menu;
 
         public ButtonWithMenu.from_icon_name (string icon_name, Gtk.IconSize size) {
             this ();
@@ -212,9 +191,6 @@ namespace Marlin.View.Chrome {
         }
 
         protected new void popup_menu (Gdk.EventButton? ev = null) {
-            if (has_fetcher)
-                fetch_menu ();
-
             try {
                 menu.popup (null,
                             null,
@@ -228,11 +204,6 @@ namespace Marlin.View.Chrome {
 
         protected void popdown_menu () {
             menu.popdown ();
-        }
-
-        private void fetch_menu () {
-            _menu = fetcher ();
-            update_menu_properties ();
         }
 
         private void get_menu_position (Gtk.Menu menu, out int x, out int y, out bool push_in) {

--- a/src/Thumbnailer.vala
+++ b/src/Thumbnailer.vala
@@ -231,7 +231,7 @@ namespace Marlin {
             uint handle = request_handle_mapping.lookup (req);
             thumbnailer_lock.unlock ();
 
-            proxy.dequeue (handle); /* hash tables will be updated when "finished" signal received. */
+            proxy.dequeue.begin (handle); /* hash tables will be updated when "finished" signal received. */
         }
 
         private bool is_supported (GOF.File file) {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -112,10 +112,6 @@ namespace Marlin.View {
             overlay_statusbar = new OverlayBar (this);
             browser = new Browser ();
 
-            /* Override background color to support transparency on overlay widgets */
-            Gdk.RGBA transparent = {0, 0, 0, 0};
-            override_background_color (0, transparent);
-
             set_events (Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
             connect_signals ();
         }


### PR DESCRIPTION
Fixes the warnings arising from .vala code on compilation with valac.

* Replace deprecated unmount_mountable () with equivalent
* Insert two missing .begin in async calls
* Fix improper use of delegate as property by removing this unused property and delegate.
* Remove unneeded deprecated override_background_color ().