### PR TITLE
Remove autosize to longest filename code.

### DIFF
--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -49,10 +49,6 @@ public class Async : Object {
     /* we're looking for particular path keywords like *\/icons* .icons ... */
     public bool uri_contains_keypath_icons = false;
 
-    /* for auto-sizing Miller columns */
-    public string longest_file_name = "";
-    public bool track_longest_name = false;
-
     public enum State {
         NOT_LOADED,
         LOADING,
@@ -615,7 +611,6 @@ public class Async : Object {
         }
 
         cancellable = new Cancellable ();
-        longest_file_name = "";
         permission_denied = false;
         can_load = true;
         files_count = 0;
@@ -697,13 +692,11 @@ public class Async : Object {
 
     private void after_load_file (GOF.File gof, bool show_hidden, GOFFileLoadedFunc? file_loaded_func) {
         if (!gof.is_hidden || show_hidden) {
-            if (track_longest_name)
-                update_longest_file_name (gof);
-
             if (file_loaded_func == null) {
                 file_loaded (gof);
-            } else
+            } else {
                 file_loaded_func (gof);
+            }
         }
     }
 
@@ -736,11 +729,6 @@ public class Async : Object {
             monitor_blocked = false;
             monitor.changed.connect (directory_changed);
         }
-    }
-
-    private void update_longest_file_name (GOF.File gof) {
-        if (longest_file_name.length < gof.basename.length)
-            longest_file_name = gof.basename;
     }
 
     public void load_hiddens () {
@@ -866,11 +854,6 @@ public class Async : Object {
                 sorted_dirs.insert_sorted (gof,
                     GOF.File.compare_by_display_name);
             }
-        }
-
-        if (track_longest_name && gof.basename.length > longest_file_name.length) {
-            longest_file_name = gof.basename;
-            done_loading ();
         }
     }
 
@@ -1036,12 +1019,6 @@ public class Async : Object {
                 if (dir != null) {
                     dir.file_deleted (dir.file);
                 }
-            }
-        }
-
-        foreach (var d in dirs) {
-            if (d.track_longest_name) {
-                d.list_cached_files ();
             }
         }
     }

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -27,7 +27,6 @@ namespace Marlin.View {
         private uint reload_timeout_id = 0;
         private uint path_change_timeout_id = 0;
         private bool original_reload_request = false;
-        private bool has_autosized = false;
 
         private const string EMPTY_MESSAGE = _("This Folder Is Empty");
         private const string EMPTY_TRASH_MESSAGE = _("Trash Is Empty");
@@ -154,8 +153,33 @@ namespace Marlin.View {
         private void on_directory_done_loading (GOF.Directory.Async dir) {
             directory_loaded (dir);
 
+            /*  Column View requires slots to determine their own width (other views' width determined by Window */
             if (mode == Marlin.ViewMode.MILLER_COLUMNS) {
-                autosize_slot ();
+
+                if (dir.is_empty ()) { /* No files in the file cache */
+                    Pango.Rectangle extents;
+                    var layout = dir_view.create_pango_layout (null);
+                    layout.set_markup (get_empty_message (), -1);
+                    layout.get_extents (null, out extents);
+                    width = (int) Pango.units_to_double (extents.width);
+                } else {
+                    width = preferred_column_width;
+                }
+
+                width += dir_view.icon_size + 64; /* allow some extra room for icon padding and right margin*/
+
+                /* Allow extra room for MESSAGE_CLASS styling of special messages */
+                if (dir.is_empty () || dir.permission_denied) {
+                    width += width;
+                }
+
+                size_change ();
+                hpane.set_position (width);
+                colpane.show_all ();
+
+                if (colpane.get_realized ()) {
+                    colpane.queue_draw ();
+                }
             }
 
             is_frozen = false;
@@ -205,12 +229,6 @@ namespace Marlin.View {
             assert (directory != null);
 
             connect_dir_signals ();
-
-            has_autosized = false;
-
-            if (mode == Marlin.ViewMode.MILLER_COLUMNS) {
-                directory.track_longest_name = true;
-            }
         }
 
         /* This delay in passing on the path change request is necessary to prevent occasional crashes
@@ -238,43 +256,6 @@ namespace Marlin.View {
             } else {
                 new_container_request (loc, flag);
             }
-        }
-
-        public void autosize_slot () {
-            if (dir_view == null || has_autosized) {
-                return;
-            }
-
-            Pango.Layout layout = dir_view.create_pango_layout (null);
-
-            if (directory.is_empty ()) { /* No files in the file cache */
-                layout.set_markup (get_empty_message (), -1);
-            } else {
-                layout.set_markup (GLib.Markup.escape_text (directory.longest_file_name), -1);
-            }
-            Pango.Rectangle extents;
-            layout.get_extents (null, out extents);
-
-            width = (int) Pango.units_to_double (extents.width)
-                  + dir_view.icon_size
-                  + 64; /* allow some extra room for icon padding and right margin*/
-
-            /* Allow extra room for MESSAGE_CLASS styling of special messages */
-            if (directory.is_empty () || directory.permission_denied) {
-                width += width;
-            }
-
-            width = width.clamp (preferred_column_width, preferred_column_width * 3);
-
-            size_change ();
-            hpane.set_position (width);
-            colpane.show_all ();
-
-            if (colpane.get_realized ()) {
-                colpane.queue_draw ();
-            }
-
-            has_autosized = true;
         }
 
         public override void user_path_change_request (GLib.File loc, bool make_root = true) {


### PR DESCRIPTION
Fixes #247 

The column width in Miller View now initialises to the preferred width setting plus room for the icon and margin.