### PR TITLE
Window.vala: restore default size

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -129,10 +129,10 @@ namespace Marlin.View {
             if (show_window) { /* otherwise Application will size and show window */
                 if (Preferences.settings.get_boolean ("maximized")) {
                     maximize ();
-                } else {
-                    resize (Preferences.settings.get_int ("window-width"),
-                            Preferences.settings.get_int ("window-height"));
                 }
+
+                default_width = Preferences.settings.get_int ("window-width");
+                default_height = Preferences.settings.get_int ("window-height");
                 show ();
             }
         }


### PR DESCRIPTION
Restore the window's default size even if we are restoring it maximized. This way, we restore as much state as possible in between sessions.

1. Resize the window
2. Maximize
3. Close and Reopen
4. Unmaximize

Master: The window is unmaximized to a different size than my last known unmaximized size

This branch: The window is unmaximized to my last known unmaximized size