### PR TITLE
Dequeue pending thumbnail request when cancelled.

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -704,6 +704,7 @@ namespace FM {
 
         protected void cancel_thumbnailing () {
             if (thumbnail_request >= 0) {
+                thumbnailer.dequeue (thumbnail_request);
                 thumbnail_request = -1;
             }
 


### PR DESCRIPTION
The stored last thumbnail request should be used to cancel the request when no longer needed.