### PR TITLE
Fix drag'n'drop regression.

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1491,7 +1491,13 @@ namespace FM {
                                        uint info,
                                        uint timestamp) {
 
-            drag_file_list = get_selected_files_for_transfer ();
+            /* get file list only once in case view changes location automatically
+             * while dragging (which loses file selection.
+             */
+
+            if (drag_file_list == null) {
+                drag_file_list = get_selected_files_for_transfer ();
+            }
 
             if (drag_file_list == null) {
                 return;


### PR DESCRIPTION
Commit 84bcaf6022315aba8f093d08cb06ccbf6a3f37b4 causes a regression in dragging and dropping when the view changes automatically during a drag (e.g. by hovering over a folder to open it before dropping).  This branch prevents the drag_file_list changing when this happens.  In master, the selection data is lost mid drag under these circumstances which causes a lot of problems.

TO TEST:
* Open a folder with files and subfolders.
* Drag a file and hover over subfolder
* Wait for the subfolder to open automatically
* Drop the file.

In master:  The file is not transferred, but returning to the parent folder and attempting to repeat the operation causes Files to hang mid drag (which captures the mouse input so use keyboard to focus the terminal and close FIles from there)

In branch: Operation occurs properly.
