### PR TITLE
Refactor opening windows and tabs

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -199,11 +199,11 @@ public class Marlin.Application : Granite.Application {
 
         /* Open application */
         if (open_in_tab || files == null) {
-             create_window (files);
+             create_windows (files);
         } else {
             /* Open windows with tab at each requested location. */
             foreach (var file in files) {
-                create_window ({file});
+                create_window (file);
             }
         }
 
@@ -268,10 +268,17 @@ public class Marlin.Application : Granite.Application {
                                    GOF.Preferences.get_default (), "clock-format", GLib.SettingsBindFlags.GET);
     }
 
+    public Marlin.View.Window? create_window (File? location = null,
+                                              Marlin.ViewMode viewmode = Marlin.ViewMode.PREFERRED,
+                                              int x = -1, int y = -1) {
+
+        return create_windows ({location}, viewmode, x, y);
+    }
+
     /* All window creation should be done via this function */
-    public Marlin.View.Window? create_window (File[] locations = {},
-                                             Marlin.ViewMode viewmode = Marlin.ViewMode.PREFERRED,
-                                             int x = -1, int y = -1) {
+    public Marlin.View.Window? create_windows (File[] locations = {},
+                                               Marlin.ViewMode viewmode = Marlin.ViewMode.PREFERRED,
+                                               int x = -1, int y = -1) {
         if (this.get_windows ().length () >= MAX_WINDOWS) {
             return null;
         }
@@ -306,7 +313,7 @@ public class Marlin.Application : Granite.Application {
 
         /* New window will not size or show itself if new_win_rect is not null */
         win = new Marlin.View.Window (this, screen, new_win_rect == null);
-        this.add_window (win as Gtk.Window);
+        add_window (win as Gtk.Window);
         plugins.interface_loaded (win as Gtk.Widget);
 
         win.open_tabs (locations, viewmode);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -196,16 +196,18 @@ public class Marlin.Application : Granite.Application {
                 files += (file);
             }
         }
+
         /* Open application */
-        if (create_new_window) {
-            var win = create_window (null);
-            win.add_tab (); /* Default tab */
-        } else if (open_in_tab) {
-            open_tabs (files);
+        if (open_in_tab || files == null) {
+             create_window (files);
         } else {
-            open_windows (files);
+            /* Open windows with tab at each requested location. */
+            foreach (var file in files) {
+                create_window ({file});
+            }
         }
-        return Posix.EXIT_SUCCESS;
+
+        return get_windows ().length () > 0 ? Posix.EXIT_SUCCESS : Posix.EXIT_FAILURE;
     }
 
     public override void quit_mainloop () {
@@ -266,19 +268,8 @@ public class Marlin.Application : Granite.Application {
                                    GOF.Preferences.get_default (), "clock-format", GLib.SettingsBindFlags.GET);
     }
 
-    private void open_windows (File[]? files) {
-        if (files == null)
-            open_tabs (null); /* open_tabs () will restore saved tabs or default tab depending on preference */
-        else {
-            /* Open windows with tab at each requested location. */
-            foreach (var file in files) {
-                create_window (file);
-            }
-        }
-    }
-
     /* All window creation should be done via this function */
-    public Marlin.View.Window? create_window (File? location,
+    public Marlin.View.Window? create_window (File[] locations = {},
                                              Marlin.ViewMode viewmode = Marlin.ViewMode.PREFERRED,
                                              int x = -1, int y = -1) {
         if (this.get_windows ().length () >= MAX_WINDOWS) {
@@ -318,9 +309,7 @@ public class Marlin.Application : Granite.Application {
         this.add_window (win as Gtk.Window);
         plugins.interface_loaded (win as Gtk.Widget);
 
-        if (location != null) {
-            win.add_tab (location, viewmode);
-        }
+        win.open_tabs (locations, viewmode);
 
         if (new_win_rect != null) {
             move_resize_window (win, new_win_rect);
@@ -330,41 +319,6 @@ public class Marlin.Application : Granite.Application {
         win.present ();
 
         return win;
-    }
-
-    private void open_tabs (File[]? files, Gdk.Screen screen = Gdk.Screen.get_default ()) {
-        Marlin.View.Window window = null;
-
-        /* Get the first window, if any, else create a new window */
-        if (windows_exist ()) {
-            window = (this.get_windows ()).data as Marlin.View.Window;
-            window.present ();
-        } else {
-            window = create_window (null); /* Do not add a tab on creation */
-            if (window == null) { /* Maximum number of windows reached */
-                return;
-            }
-        }
-        if (files == null) {
-            /* Restore session if not root and settings allow */
-            if (Posix.getuid () == 0 ||
-                !Preferences.settings.get_boolean ("restore-tabs") ||
-                window.restore_tabs () < 1) {
-
-                /* Open a tab pointing at the default location if no tabs restored*/
-                var location = File.new_for_path (Eel.get_real_user_home ());
-                window.add_tab (location, Marlin.ViewMode.PREFERRED);
-            }
-        } else {
-            /* Open tabs at each requested location */
-            foreach (var file in files)
-                window.add_tab (file, Marlin.ViewMode.PREFERRED);
-        }
-    }
-
-    private bool windows_exist () {
-        unowned List<weak Gtk.Window> windows = this.get_windows ();
-        return (windows != null && windows.data != null);
     }
 
     private void move_resize_window (Gtk.Window win, Gdk.Rectangle? rect) {

--- a/src/QuicklistHandler.vala
+++ b/src/QuicklistHandler.vala
@@ -104,7 +104,7 @@ namespace Marlin {
                     menuitem.property_set ("label", bookmark.label);
                     menuitem.item_activated.connect (() => {
                         var location = bookmark.get_location ();
-                        Marlin.Application.get ().create_window ({location});
+                        Marlin.Application.get ().create_window (location);
                     });
 
                     ql.child_add_position (menuitem, index);

--- a/src/QuicklistHandler.vala
+++ b/src/QuicklistHandler.vala
@@ -104,7 +104,7 @@ namespace Marlin {
                     menuitem.property_set ("label", bookmark.label);
                     menuitem.item_activated.connect (() => {
                         var location = bookmark.get_location ();
-                        Marlin.Application.get ().create_window (location);
+                        Marlin.Application.get ().create_window ({location});
                     });
 
                     ql.child_add_position (menuitem, index);

--- a/src/View/Sidebar.vala
+++ b/src/View/Sidebar.vala
@@ -1318,9 +1318,9 @@ namespace Marlin.Places {
                         var location = mount.get_root ();
                         if (flags == Marlin.OpenFlag.NEW_WINDOW) {
                             var app = Marlin.Application.get ();
-                            app.create_window (location);
+                            app.create_window ({location});
                         } else if (flags == Marlin.OpenFlag.NEW_TAB) {
-                            window.add_tab (location, Marlin.ViewMode.CURRENT);
+                            window.open_tabs ({location}, Marlin.ViewMode.CURRENT);
                         } else {
                             window.uri_path_change_request (location.get_uri ());
                         }

--- a/src/View/Sidebar.vala
+++ b/src/View/Sidebar.vala
@@ -1318,9 +1318,9 @@ namespace Marlin.Places {
                         var location = mount.get_root ();
                         if (flags == Marlin.OpenFlag.NEW_WINDOW) {
                             var app = Marlin.Application.get ();
-                            app.create_window ({location});
+                            app.create_window (location);
                         } else if (flags == Marlin.OpenFlag.NEW_TAB) {
-                            window.open_tabs ({location}, Marlin.ViewMode.CURRENT);
+                            window.open_single_tab (location, Marlin.ViewMode.CURRENT);
                         } else {
                             window.uri_path_change_request (location.get_uri ());
                         }

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -311,7 +311,7 @@ namespace Marlin.View {
 
             switch ((Marlin.OpenFlag)flag) {
                 case Marlin.OpenFlag.NEW_TAB:
-                    window.open_tabs ({loc}, view_mode);
+                    window.open_single_tab (loc, view_mode);
                     break;
 
                 case Marlin.OpenFlag.NEW_WINDOW:

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -309,11 +309,11 @@ namespace Marlin.View {
 
             switch ((Marlin.OpenFlag)flag) {
                 case Marlin.OpenFlag.NEW_TAB:
-                    this.window.add_tab (loc, view_mode);
+                    window.open_tabs ({loc}, view_mode);
                     break;
 
                 case Marlin.OpenFlag.NEW_WINDOW:
-                    this.window.add_window (loc, view_mode);
+                    window.add_window (loc, view_mode);
                     break;
 
                 default:

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -309,7 +309,7 @@ namespace Marlin.View {
 
             tabs.tab_moved.connect ((tab, x, y) => {
                 var vc = tab.page as ViewContainer;
-                ((Marlin.Application) application).create_window ({vc.location}, real_mode (vc.view_mode), x, y);
+                ((Marlin.Application) application).create_window (vc.location, real_mode (vc.view_mode), x, y);
                 /* A crash occurs if the original tab is removed while processing the signal */
                 GLib.Idle.add (() => {
                     remove_tab (vc);
@@ -407,6 +407,11 @@ namespace Marlin.View {
             loading_uri (current_tab.uri);
             current_tab.set_active_state (true, false); /* changing tab should not cause animated scrolling */
             top_menu.working = current_tab.is_frozen;
+        }
+
+        /** Convenience function for opening a single tab **/
+        public void open_single_tab (File? file = null, Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED) {
+            open_tabs ({file}, mode);
         }
 
         public void open_tabs (File[]? files = null, Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED) {
@@ -539,7 +544,7 @@ namespace Marlin.View {
                                  Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED,
                                  int x = -1, int y = -1) {
 
-            ((Marlin.Application) application).create_window ({location}, real_mode (mode), x, y);
+            ((Marlin.Application) application).create_window (location, real_mode (mode), x, y);
         }
 
         private void undo_actions_set_insensitive () {


### PR DESCRIPTION
* Move open_tabs to from Application to Window
* Make add_tab and add_tab_by_uri in Window private (only one public function now used to open tabs).
* Allow create_window to open more than one tab in the window
* Lose separate open_windows () from Application.
* Lose no longer used windows_exist ()
* Some small simplifications
* Consequential changes to QuickListHandler, Sidebar and ViewContainer

As well as simplifying making a modest reduction in code, this PR slightly changes behaviour of "New Window" to be consistent with other apps.  Now saved tabs are always restored unless one or more specific urls are provided, if it is the first window (otherwise never restored). The command line option -n now accepts a list of urls and opens them in separate windows.