### PR TITLE
Remove references to unused previewing facility

### DIFF
--- a/data/schemas/io.elementary.files.gschema.xml
+++ b/data/schemas/io.elementary.files.gschema.xml
@@ -105,11 +105,6 @@
       <summary>Confirm trash</summary>
       <description>Confirm trash</description>
     </key>
-    <key type="s" name="previewer-path">
-      <default>''</default>
-      <summary>Path of the previewer.</summary>
-      <description>Path of the previewer or executable name (if path already definied in PATH environnment variable). If no path is set, then the space bindkey would just activate the selected items instead of previewing them</description>
-    </key>
     <key type="b" name="restore-tabs">
       <default>true</default>
       <summary>Whether to restore tabs on start up</summary>

--- a/libcore/gof-file.c
+++ b/libcore/gof-file.c
@@ -2111,38 +2111,6 @@ gof_file_get_display_target_uri (GOFFile *file)
     return uri;
 }
 
-const gchar *
-gof_file_get_preview_path(GOFFile* file)
-{
-    gchar* thumbnail_path = gof_file_get_thumbnail_path(file);
-    gchar* new_thumbnail_path = NULL;
-    gchar** thumbnail_path_split = NULL;
-
-    if (thumbnail_path != NULL)
-    {
-        /* Construct new path to large thumbnail based on $XDG_CACHE_HOME */
-        thumbnail_path_split = g_strsplit(thumbnail_path, G_DIR_SEPARATOR_S, -1);
-        uint l;
-        l = g_strv_length(thumbnail_path_split);
-        if(l > 2)
-        {
-            new_thumbnail_path = g_strjoin(G_DIR_SEPARATOR_S, g_get_user_cache_dir (), "thumbnails/large", thumbnail_path_split[l-1], NULL);
-
-            if(!g_file_test(new_thumbnail_path, G_FILE_TEST_EXISTS))
-            {
-                new_thumbnail_path = g_strdup(thumbnail_path);
-            }
-        }
-        else
-        {
-            g_critical("Thumbnailer is not FD.o compliant?");
-            new_thumbnail_path = g_strdup(thumbnail_path);
-        }
-        g_strfreev(thumbnail_path_split);
-    }
-    return new_thumbnail_path;
-}
-
 gboolean
 gof_file_can_unmount (GOFFile *file)
 {

--- a/libcore/gof-file.h
+++ b/libcore/gof-file.h
@@ -227,7 +227,6 @@ GMount*         gof_file_get_mount_at (GFile* target);
  **/
 #define gof_file_get_thumb_state(file) (GOF_FILE ((file))->flags & GOF_FILE_THUMB_STATE_MASK)
 const gchar* gof_file_get_thumbnail_path (GOFFile *file);
-const gchar* gof_file_get_preview_path (GOFFile *file);
 gboolean        gof_file_can_set_owner (GOFFile *file);
 gboolean        gof_file_can_set_group (GOFFile *file);
 GList           *gof_file_get_settable_group_names (GOFFile *file);

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -325,7 +325,6 @@ namespace GOF {
         public void query_thumbnail_update ();
         public bool ensure_query_info ();
         public unowned string? get_thumbnail_path();
-        public string? get_preview_path();
         public bool can_set_owner ();
         public bool can_set_group ();
         public bool can_set_permissions ();

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -165,9 +165,6 @@ namespace FM {
         uint freeze_source_id = 0;
         Marlin.Thumbnailer thumbnailer = null;
 
-        /**TODO** Support for preview see bug #1380139 */
-        private string? previewer = null;
-
         /* Free space signal support */
         uint add_remove_file_timeout_id = 0;
         bool signal_free_space_change = false;
@@ -563,29 +560,6 @@ namespace FM {
                 }
             } else
                 warning ("Cannot open files in trash");
-        }
-
-        protected void preview_selected_items () {
-            if (previewer == null)  /* At present this is the case! */
-                activate_selected_items (Marlin.OpenFlag.DEFAULT);
-            else {
-                unowned GLib.List<GOF.File>? selection = get_selected_files ();
-
-                if (selection == null)
-                    return;
-
-                Gdk.Screen screen = Eel.gtk_widget_get_screen (this);
-                GLib.List<GLib.File> location_list = null;
-                GOF.File file = selection.data;
-                location_list.prepend (file.location);
-                Gdk.AppLaunchContext context = screen.get_display ().get_app_launch_context ();
-                try {
-                    GLib.AppInfo previewer_app = GLib.AppInfo.create_from_commandline (previewer, null, 0);
-                    previewer_app.launch (location_list, context as GLib.AppLaunchContext);
-                } catch (GLib.Error error) {
-                    Eel.show_error_dialog (_("Failed to preview"), error.message, null);
-                }
-            }
         }
 
         public void select_gof_file (GOF.File file) {
@@ -2745,17 +2719,11 @@ namespace FM {
                     break;
 
                 case Gdk.Key.space:
-                    if (view_has_focus ()) {
-                        if (only_shift_pressed  && !in_trash) {
-                            activate_selected_items (Marlin.OpenFlag.NEW_TAB);
-                        } else if (no_mods) {
-                            preview_selected_items ();
-                        } else {
-                            return false;
-                        }
-
+                    if (view_has_focus () && !in_trash) {
+                        activate_selected_items (Marlin.OpenFlag.NEW_TAB);
                         return true;
                     }
+
                     break;
 
                 case Gdk.Key.Return:


### PR DESCRIPTION
Towards aim of simplifying Files code.  If previewing is required in future it would be better provided by a contractor or plugin, but native apps should open fast enough to make it superfluous (beyond thumbnailing).

TO TEST:
* Should be no regressions when activating with space bar.