### PR TITLE
Ensure cursor follows helper selection without losing existing selection

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3247,7 +3247,7 @@ namespace FM {
                                     unselect_path (path);
                                 } else {
                                     should_deselect = false;
-                                    select_path (path);  /* Cursor follows */
+                                    select_path (path, true);  /* Cursor follow and selection preserved */
                                 }
                             }
 


### PR DESCRIPTION
This makes IconView and TreeView behave the same way when the cursor is moved with the keyboard after making a selection using the helpers and mouse.

In master, the treeview behaves differently to icon view - the former does not move the cursor to the last selected item whereas iconview does (this is due to differences in Gtk implementation).

In this PR, the cursor moves to last selected without losing the existing selection in all views (in treeview the selection is remembered and reestablished after moving the cursor).

This fixes part of #330