### PR TITLE
ViewContainer destruct

### DIFF
--- a/src/View/Browser.vala
+++ b/src/View/Browser.vala
@@ -35,6 +35,9 @@ namespace Marlin.View {
             forward_stack = new Stack<string> ();
         }
 
+        ~Browser () {
+            debug ("Browser destruct");
+        }
         /**
          * Use this method to track an uri location in
          * the back/forward stacks
@@ -45,7 +48,7 @@ namespace Marlin.View {
                 if (uri != null) {
                     /* Only record if the uri has changed other than by use of forward or back buttons */
                     /* If the forward or back buttons were pressed then the current uri would already have
-                     * been made equal to the new uri */ 
+                     * been made equal to the new uri */
                     if (current_uri != uri) {
                         forward_stack.clear ();
                         back_stack.push (current_uri);

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -117,7 +117,7 @@ namespace Marlin.View {
         }
 
         ~ViewContainer () {
-            warning ("ViewContainer destruct");
+            debug ("ViewContainer destruct");
         }
 
         private void connect_signals () {
@@ -155,6 +155,11 @@ namespace Marlin.View {
 
         public void close () {
             close_view_slot ();
+
+            /* Need to force destruction because of circular reference.
+             * (https://github.com/elementary/granite/issues/110).
+             * Note: causes fatal warning in terminal. */
+            destroy ();
         }
 
         private void close_view_slot () {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -117,7 +117,7 @@ namespace Marlin.View {
         }
 
         ~ViewContainer () {
-            debug ("ViewContainer destruct");
+            warning ("ViewContainer destruct");
         }
 
         private void connect_signals () {
@@ -154,8 +154,14 @@ namespace Marlin.View {
         }
 
         public void close () {
-            disconnect_signals ();
+            close_view_slot ();
+        }
+
+        private void close_view_slot () {
+            /* Make sure async loading and thumbnailing are cancelled and signal handlers disconnected */
             view.close ();
+            content_item = null; /* Make sure old slot and directory view are destroyed */
+            view = null; /* Pre-requisite for add view */
         }
 
         public Gtk.Widget? content {
@@ -268,11 +274,7 @@ namespace Marlin.View {
 
         private void before_mode_change () {
             store_selection ();
-            /* Make sure async loading and thumbnailing are cancelled and signal handlers disconnected */
-            view.close ();
-            disconnect_slot_signals (view);
-            content = null; /* Make sure old slot and directory view are destroyed */
-            view = null; /* Pre-requisite for add view */
+            close_view_slot ();
             loading (false);
         }
 

--- a/src/View/Widgets/OverlayBar.vala
+++ b/src/View/Widgets/OverlayBar.vala
@@ -36,11 +36,15 @@ namespace Marlin.View {
         private uint hover_timeout_id = 0;
         private Marlin.DeepCount? deep_counter = null;
         private uint deep_count_timeout_id = 0;
-
+        private WeakNotify h;
         public bool showbar = false;
 
         public OverlayBar (Gtk.Overlay overlay) {
             base (overlay); /* this adds the overlaybar to the overlay (ViewContainer) */
+
+            /* Temporary workaround for bug in Granite.OverlayBar resulting in circular reference */
+            overlay.weak_ref (() => {});
+            overlay.unref ();
 
             buffer = new uint8[IMAGE_LOADER_BUFFER_SIZE];
             label = "";
@@ -49,6 +53,7 @@ namespace Marlin.View {
 
         ~OverlayBar () {
             cancel ();
+            debug ("OverlayBar destruct");
         }
 
         public void selection_changed (GLib.List<unowned GOF.File> files) {

--- a/src/View/Widgets/OverlayBar.vala
+++ b/src/View/Widgets/OverlayBar.vala
@@ -42,10 +42,6 @@ namespace Marlin.View {
         public OverlayBar (Gtk.Overlay overlay) {
             base (overlay); /* this adds the overlaybar to the overlay (ViewContainer) */
 
-            /* Temporary workaround for bug in Granite.OverlayBar resulting in circular reference */
-            overlay.weak_ref (() => {});
-            overlay.unref ();
-
             buffer = new uint8[IMAGE_LOADER_BUFFER_SIZE];
             label = "";
             hide.connect (cancel);

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -65,7 +65,7 @@ namespace Marlin.View {
         public Granite.Widgets.DynamicNotebook tabs;
         private Gtk.Paned lside_pane;
         public Marlin.Places.Sidebar sidebar;
-        public ViewContainer? current_tab = null;
+        private ViewContainer? current_tab = null;
 
         private bool tabs_restored = false;
         private bool restoring_tabs = false;
@@ -277,8 +277,6 @@ namespace Marlin.View {
                     current_tab = null;
                 }
 
-                view_container.close ();
-
                 if (tabs.n_tabs == 1) {
                     add_tab ();
                 }
@@ -327,7 +325,9 @@ namespace Marlin.View {
             sidebar.path_change_request.connect (uri_path_change_request);
         }
 
-        private void on_tab_removed () {
+        private void on_tab_removed (Granite.Widgets.Tab tab) {
+            (tab.page as ViewContainer).close ();
+
             if (tabs.n_tabs == 0) {
                 add_tab ();
             }
@@ -417,12 +417,16 @@ namespace Marlin.View {
                              Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED) {
             mode = real_mode (mode);
             var content = new View.ViewContainer (this);
+
+
             var tab = new Granite.Widgets.Tab ("", null, content);
             tab.ellipsize_mode = Pango.EllipsizeMode.MIDDLE;
 
             content.tab_name_changed.connect ((tab_name) => {
+                /* Adding a reference to content in the closure
+                   prevents destruction of viewcontainer when tab closed */
                 Idle.add (() => {
-                    tab.label = check_for_tab_with_same_name (content);
+                    tab.label = check_current_for_tab_with_same_name ();
                     return false;
                 });
             });
@@ -436,13 +440,18 @@ namespace Marlin.View {
                 update_top_menu ();
             });
 
-            content.add_view (mode, location);
 
+            content.add_view (mode, location);
             change_tab ((int)tabs.insert_tab (tab, -1));
             tabs.current = tab;
         }
 
-        private string check_for_tab_with_same_name (ViewContainer vc) {
+        private string check_current_for_tab_with_same_name () {
+            var vc = current_tab;
+            if (vc == null) {
+                return "";
+            }
+
             string name = vc.tab_name;
 
             if (name == Marlin.INVALID_TAB_NAME) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -65,7 +65,7 @@ namespace Marlin.View {
         public Granite.Widgets.DynamicNotebook tabs;
         private Gtk.Paned lside_pane;
         public Marlin.Places.Sidebar sidebar;
-        private ViewContainer? current_tab = null;
+        public ViewContainer? current_tab = null; /* Used by connect server dialog only - to be refactored */
 
         private bool tabs_restored = false;
         private bool restoring_tabs = false;

--- a/src/marlin-connect-server-dialog.c
+++ b/src/marlin-connect-server-dialog.c
@@ -462,7 +462,7 @@ marlin_connect_server_dialog_display_location_async (MarlinConnectServerDialog *
 
     //g_message ("ConnectServer display location %s", g_file_get_uri (location));
     //marlin_application_create_window_from_gfile (marlin_application_new (), location, gtk_widget_get_screen (widget));
-    //g_signal_emit_by_name (MARLIN_VIEW_WINDOW (self->details->parent_window)->current_tab, "path-changed", location);
+    g_signal_emit_by_name (MARLIN_VIEW_WINDOW (self->details->parent_window)->current_tab, "path-changed", location);
 
     g_simple_async_result_complete (display_location_res);
     g_object_unref (display_location_res);

--- a/src/marlin-connect-server-dialog.c
+++ b/src/marlin-connect-server-dialog.c
@@ -462,7 +462,7 @@ marlin_connect_server_dialog_display_location_async (MarlinConnectServerDialog *
 
     //g_message ("ConnectServer display location %s", g_file_get_uri (location));
     //marlin_application_create_window_from_gfile (marlin_application_new (), location, gtk_widget_get_screen (widget));
-    g_signal_emit_by_name (MARLIN_VIEW_WINDOW (self->details->parent_window)->current_tab, "path-changed", location);
+    //g_signal_emit_by_name (MARLIN_VIEW_WINDOW (self->details->parent_window)->current_tab, "path-changed", location);
 
     g_simple_async_result_complete (display_location_res);
     g_object_unref (display_location_res);


### PR DESCRIPTION
This makes two changes that ensure that the ViewContainer object associated with each notebook tab is destroyed (along with its child slot(s), browser and overlaybar) when that tab is closed.

* Do not reference the ViewContainer in a nested closure.  Refactor the function to use the current tab page.
* Close the view later in the tab close process, and call destroy explicitly to break circular reference to overlaybar.

Some repeated code was made into a function.

To test:

Run with --debug flag and monitor for "ViewContainer destruct" message. 