### PR TITLE
Add check for stale thumbnail

### DIFF
--- a/libcore/gof-file.c
+++ b/libcore/gof-file.c
@@ -854,7 +854,7 @@ gof_file_query_thumbnail_update (GOFFile *file)
         g_free (md5_hash);
     }
 
-    gof_file_check_stale_thumbnail(file);
+    gof_file_check_stale_thumbnail (file);
 
     gof_file_update_icon_internal (file, file->pix_size);
 }


### PR DESCRIPTION
Fix  #398

Add function to check thumbnail change time and compare it with file change time. If file is newer than thumbnails, unlink thumbnail to force recreation of thumbnail file.

Several documents such as https://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html recommend to use modified time to check for stale thumbnail. However renaming doesn't update modified time at all, so this method is not viable in our case.

According to https://stackoverflow.com/questions/3385203/regarding-access-time-unix, file metadata will update change time value. Therefore file modification can be tracked using changed time too.

Possible effect on directory with many file, since this will add at least 1 file stats for each item displayed. But I think it will negligible.