### PR TITLE
Wrap navigation in icon view

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3195,7 +3195,7 @@ namespace FM {
 
                             if (!no_mods || (on_blank && (!activate_on_blank || !path_selected))) {
                                 update_selected_files_and_menu ();
-                                result = handle_multi_select (path);
+                                result = only_shift_pressed && handle_multi_select (path);
                             } else {
                                 unblock_drag_and_drop ();
                                 result = handle_primary_button_click (event, path);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -213,11 +213,6 @@ namespace FM {
         protected GLib.List<unowned GOF.File> selected_files = null;
         private bool selected_files_invalid = true;
 
-        /* support for linear selection mode in icon view */
-        protected bool previous_selection_was_linear = false;
-        protected Gtk.TreePath? previous_linear_selection_path = null;
-        protected int previous_linear_selection_direction = 0;
-
         private GLib.List<GLib.File> templates = null;
 
         private GLib.AppInfo default_app;
@@ -2658,17 +2653,8 @@ namespace FM {
             bool other_mod_pressed = (((mods & ~Gdk.ModifierType.SHIFT_MASK) & ~Gdk.ModifierType.CONTROL_MASK) != 0);
             bool only_control_pressed = control_pressed && !other_mod_pressed; /* Shift can be pressed */
             bool only_alt_pressed = alt_pressed && ((mods & ~Gdk.ModifierType.MOD1_MASK) == 0);
-
             bool in_trash = slot.location.has_uri_scheme ("trash");
             bool in_recent = slot.location.has_uri_scheme ("recent");
-
-            /* Implement linear selection in Icon View with cursor keys */
-            bool linear_select_required = (no_mods || only_shift_pressed) && this is IconView;
-
-            if (!linear_select_required || !only_shift_pressed) {
-                previous_selection_was_linear = false;
-            }
-
             bool res = false;
 
             switch (keyval) {
@@ -2812,7 +2798,6 @@ namespace FM {
                 case Gdk.Key.Down:
                 case Gdk.Key.Left:
                 case Gdk.Key.Right:
-
                     unowned GLib.List<GOF.File> selection = get_selected_files ();
                     if (only_alt_pressed && keyval == Gdk.Key.Down) {
                         /* Only open a single selected folder */
@@ -3157,8 +3142,6 @@ namespace FM {
             bool only_shift_pressed = shift_pressed && !control_pressed && !other_mod_pressed;
             bool path_selected = (path != null ? path_is_selected (path) : false);
             bool on_blank = (click_zone == ClickZone.BLANK_NO_PATH || click_zone == ClickZone.BLANK_PATH);
-            bool linear_select_required = false;
-            bool is_selected = selected_files != null;
 
             /* Block drag and drop to allow rubberbanding and prevent unwanted effects of
              * dragging on blank areas
@@ -3167,16 +3150,8 @@ namespace FM {
 
             /* Handle un-modified clicks or control-clicks here else pass on.
              */
-            linear_select_required = false;
-            if (!no_mods && !only_control_pressed) {
-                if (only_shift_pressed && (this is IconView)) {
-                    linear_select_required = true;
-                } else {
-                    previous_selection_was_linear = false;
-                    return false;
-                }
-            } else {
-                previous_selection_was_linear = false;
+            if (!will_handle_button_press (no_mods, only_control_pressed, only_shift_pressed)) {
+                return false;
             }
 
             if (!path_selected && click_zone != ClickZone.HELPER) {
@@ -3220,35 +3195,21 @@ namespace FM {
 
                             if (!no_mods || (on_blank && (!activate_on_blank || !path_selected))) {
                                 update_selected_files_and_menu ();
-
-                                if (linear_select_required && selected_files.length () > 0) {
-                                    linear_select_path (path);
-                                    result = true;  /* Do not pass to default handler which would Rubberband */
-                                } else {
-                                    previous_selection_was_linear = false;
-                                }
+                                result = handle_multi_select (path);
                             } else {
                                 unblock_drag_and_drop ();
                                 result = handle_primary_button_click (event, path);
                             }
 
-                            previous_linear_selection_path = path.copy ();
-
                             break;
 
                         case ClickZone.HELPER:
-                            if (linear_select_required && is_selected) {
-                                linear_select_path (path);
+                            /* Only for selecting individual files so ignore any mods */
+                            if (path_selected) {
+                                unselect_path (path);
                             } else {
-                                previous_selection_was_linear = false;
-                                previous_linear_selection_path = null;
-
-                                if (path_selected) {
-                                    unselect_path (path);
-                                } else {
-                                    should_deselect = false;
-                                    select_path (path, true);  /* Cursor follow and selection preserved */
-                                }
+                                should_deselect = false;
+                                select_path (path, true);  /* Cursor follow and selection preserved */
                             }
 
                             result = true; /* Prevent rubberbanding and deselection of other paths */
@@ -3299,7 +3260,6 @@ namespace FM {
                     break;
             }
 
-            previous_linear_selection_path = path != null ? path.copy () : null;
             return result;
         }
 
@@ -3572,7 +3532,6 @@ namespace FM {
         }
 
         public virtual void highlight_path (Gtk.TreePath? path) {}
-        protected virtual void linear_select_path (Gtk.TreePath path) {}
         protected virtual Gtk.TreePath up (Gtk.TreePath path) {path.up (); return path;}
         protected virtual Gtk.TreePath down (Gtk.TreePath path) {path.down (); return path;}
 
@@ -3593,7 +3552,21 @@ namespace FM {
                                          bool scroll_to_top);
 
         /* By default use the native widget cursor handling by returning false */
-        protected virtual bool move_cursor (uint keyval, bool only_shift_pressed) {return false;}
+        protected virtual bool move_cursor (uint keyval, bool only_shift_pressed) {
+            return false;
+        }
+
+        protected virtual bool will_handle_button_press (bool no_mods, bool only_control_pressed,  bool only_shift_pressed) {
+            if (!no_mods && !only_control_pressed) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+        /* Multi-select could be by rubberbanding or modified clicking. Returning false
+         * invokes the default widget handler.  IconView requires special handler */
+        protected virtual bool handle_multi_select (Gtk.TreePath path) {return false;}
 
         protected abstract Gtk.Widget? create_view ();
         protected abstract Marlin.ZoomLevel get_set_up_zoom_level ();

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -210,7 +210,7 @@ namespace FM {
         /*  Selected files are originally obtained with
             gtk_tree_model_get(): this function increases the reference
             count of the file object.*/
-        private GLib.List<unowned GOF.File> selected_files = null;
+        protected GLib.List<unowned GOF.File> selected_files = null;
         private bool selected_files_invalid = true;
 
         /* support for linear selection mode in icon view */
@@ -2828,39 +2828,7 @@ namespace FM {
                         break;
                     }
 
-                    if (no_mods) {
-                        /* Deselect all except under cursor (works differently for Gtk.IconView and Gtk.TreeView) */
-                        unselect_others ();
-                        previous_linear_selection_path = null;
-                    } else if (linear_select_required) { /* Only true for Icon View */
-                        Gtk.TreePath? path = get_path_at_cursor ();
-
-                        if (path != null) {
-                            Gtk.TreePath old_path = path;
-
-                            if (event.keyval == Gdk.Key.Right) {
-                                path.next (); /* Does not check if path is valid */
-                            } else if (event.keyval == Gdk.Key.Left) {
-                                path.prev ();
-                            } else if (event.keyval == Gdk.Key.Up) {
-                                path = up (path);
-                            } else if (event.keyval == Gdk.Key.Down) {
-                                path = down (path);
-                            }
-
-                            Gtk.TreeIter? iter = null;
-                            /* Do not try to select invalid path */
-                            if (model.get_iter (out iter, path)) {
-                                if (only_shift_pressed && selected_files != null) {
-                                    linear_select_path (path);
-                                    res = true;
-                                }
-                            }
-                        }
-                    } else {
-                        previous_selection_was_linear = false;
-                        previous_linear_selection_path = null;
-                    }
+                    res = move_cursor (keyval, only_shift_pressed);
 
                     break;
 
@@ -3623,6 +3591,10 @@ namespace FM {
                                          bool start_editing,
                                          bool select,
                                          bool scroll_to_top);
+
+        /* By default use the native widget cursor handling by returning false */
+        protected virtual bool move_cursor (uint keyval, bool only_shift_pressed) {return false;}
+
         protected abstract Gtk.Widget? create_view ();
         protected abstract Marlin.ZoomLevel get_set_up_zoom_level ();
         protected abstract Marlin.ZoomLevel get_normal_zoom_level ();

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -294,6 +294,42 @@ namespace FM {
             tree.set_cursor (path, renderer, start_editing);
         }
 
+        /* Override native Gtk.IconView cursor handling */
+        protected override bool move_cursor (uint keyval, bool only_shift_pressed) {
+            Gtk.TreePath? path = get_path_at_cursor ();
+            if (path != null) {
+                Gtk.TreePath old_path = path;
+
+                if (keyval == Gdk.Key.Right) {
+                    path.next (); /* Does not check if path is valid */
+                } else if (keyval == Gdk.Key.Left) {
+                    path.prev ();
+                } else if (keyval == Gdk.Key.Up) {
+                    path = up (path);
+                } else if (keyval == Gdk.Key.Down) {
+                    path = down (path);
+                }
+
+                Gtk.TreeIter? iter = null;
+                /* Do not try to select invalid path */
+                if (model.get_iter (out iter, path)) {
+                    if (only_shift_pressed && selected_files != null) {
+                        linear_select_path (path);
+                    } else {
+                        unselect_all ();
+                        set_cursor (path, false, true, false);
+                        previous_linear_selection_path = path;
+                    }
+                }
+            } else {
+                path = new Gtk.TreePath.from_indices (0);
+                set_cursor (path, false, true, false);
+                previous_linear_selection_path = path;
+            }
+
+            return true;
+        }
+
         public override void set_cursor (Gtk.TreePath? path,
                                          bool start_editing,
                                          bool select,
@@ -354,6 +390,7 @@ namespace FM {
                 critical ("Ignoring attempt to select null path in linear_select_path");
                 return;
             }
+
             if (previous_linear_selection_path != null && path.compare (previous_linear_selection_path) == 0) {
                 /* Ignore if repeat click on same file as before. We keep the previous linear selection direction. */
                 return;
@@ -428,6 +465,7 @@ namespace FM {
                 critical ("Linear selection did not become end point - this should not happen!");
                 previous_linear_selection_direction = 0;
             }
+
             previous_linear_selection_path = path.copy ();
             /* Ensure cursor in correct place, regardless of any selections made in this function */
             tree.set_cursor (path, null, false);


### PR DESCRIPTION
Fixes #362  Fixes #391 

All icon view specific key and button controlled selection code is moved into IconView and the base abstract class thereby simplified.  The linked issues are fixed in the process.

To test: 
See https://github.com/jeremypw/elementary-files-testing/blob/master/selection.md (apart from overlay tests) for suggestions.
