### PR TITLE
Add a search icon

### DIFF
--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -33,7 +33,7 @@ namespace Marlin.View.Chrome {
          * user enter /home/user/a, we will search for "a". */
         string to_search = "";
 
-        public bool search_mode = false; // Used to suppress activate events while searching
+        public bool search_mode { get; set; default = false; } // Used to suppress activate events while searching
 
         /** Drag and drop support **/
         protected const Gdk.DragAction file_drag_actions = (Gdk.DragAction.COPY | Gdk.DragAction.MOVE | Gdk.DragAction.LINK);

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -22,7 +22,8 @@
 namespace Marlin.View.Chrome
 {
     public class LocationBar : BasicLocationBar {
-        private BreadcrumbsEntry bread;
+        public BreadcrumbsEntry bread { get; private set; }
+
         private SearchResults search_results;
         private GLib.File? search_location = null;
 

--- a/src/View/Widgets/TopMenu.vala
+++ b/src/View/Widgets/TopMenu.vala
@@ -28,6 +28,7 @@ namespace Marlin.View.Chrome
         public LocationBar? location_bar;
         public Chrome.ButtonWithMenu button_forward;
         public Chrome.ButtonWithMenu button_back;
+        private Gtk.ToggleButton find_button;
 
         public bool locked_focus {get; private set; default = false;}
 
@@ -70,8 +71,7 @@ namespace Marlin.View.Chrome
             button_forward.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
             button_forward.show_all ();
             pack_start (button_forward);
-
-
+            
             button_forward.slow_press.connect (() => {
                 forward (1);
             });
@@ -89,6 +89,22 @@ namespace Marlin.View.Chrome
             connect_location_bar_signals ();
             location_bar.show_all ();
             pack_start (location_bar);
+
+            find_button = new Gtk.ToggleButton ();
+            find_button.image = new Gtk.Image.from_icon_name ("edit-find", Gtk.IconSize.LARGE_TOOLBAR);
+            find_button.tooltip_text = _("Find…");
+            find_button.show_all ();
+            find_button.toggled.connect (() => {
+                if (find_button.active) {
+                    enter_search_mode ();
+                } else {
+                    cancel ();
+                }
+            });
+
+            pack_end (find_button);
+
+            location_bar.bread.bind_property ("search-mode", find_button, "active", BindingFlags.SYNC_CREATE);
 
             show ();
         }


### PR DESCRIPTION
Fixes #170?

Adds a simple search icon to be consistent with the rest of the apps that have search icon in the headerbar (e.g Code).

![files-search](https://user-images.githubusercontent.com/8205284/39020578-bb582c96-442d-11e8-8553-2883d4a7a135.png)
