### PR TITLE
Drop force-icon-size setting and functionality

### DIFF
--- a/data/schemas/io.elementary.files.gschema.xml
+++ b/data/schemas/io.elementary.files.gschema.xml
@@ -136,11 +136,6 @@
       <default>[(0,'','')]</default>
       <description>Array of tab info:  View mode, root uri, tip uri (for Miller view)</description>
     </key>
-    <key type="b" name="force-icon-size">
-      <default>false</default>
-      <summary>Whether to force icons to the specified size</summary>
-      <description>Whether to scale up small icons to the size specified by the zoom level, if necessary</description>
-    </key>
   </schema>
 
   <schema path="/io/elementary/files/icon-view/" id="io.elementary.files.icon-view">

--- a/libcore/FileConflictDialog.vala
+++ b/libcore/FileConflictDialog.vala
@@ -319,7 +319,7 @@ public class Marlin.FileConflictDialog : Gtk.Dialog {
         }
 
         secondary_label.label = "%s %s".printf (message, message_extra);
-        source_image.gicon = source.get_icon_pixbuf (64, true, GOF.FileIconFlags.USE_THUMBNAILS);
+        source_image.gicon = source.get_icon_pixbuf (64, GOF.FileIconFlags.USE_THUMBNAILS);
         source_size_label.label = source.format_size;
         source_time_label.label = source.formated_modified;
         if (should_show_type && src_ftype != null) {
@@ -329,7 +329,7 @@ public class Marlin.FileConflictDialog : Gtk.Dialog {
             source_type_label.no_show_all = true;
         }
 
-        destination_image.gicon = destination.get_icon_pixbuf (64, true, GOF.FileIconFlags.USE_THUMBNAILS);
+        destination_image.gicon = destination.get_icon_pixbuf (64, GOF.FileIconFlags.USE_THUMBNAILS);
         destination_size_label.label = destination.format_size;
         destination_time_label.label = destination.formated_modified;
         if (should_show_type && dest_ftype != null) {
@@ -347,11 +347,11 @@ public class Marlin.FileConflictDialog : Gtk.Dialog {
         }
 
         source.changed.connect (() => {
-            source_image.gicon = source.get_icon_pixbuf (64, true, GOF.FileIconFlags.USE_THUMBNAILS);
+            source_image.gicon = source.get_icon_pixbuf (64, GOF.FileIconFlags.USE_THUMBNAILS);
         });
 
         destination.changed.connect (() => {
-            destination_image.gicon = destination.get_icon_pixbuf (64, true, GOF.FileIconFlags.USE_THUMBNAILS);
+            destination_image.gicon = destination.get_icon_pixbuf (64, GOF.FileIconFlags.USE_THUMBNAILS);
         });
     }
 }

--- a/libcore/IconInfo.vala
+++ b/libcore/IconInfo.vala
@@ -147,34 +147,6 @@ public class Marlin.IconInfo : GLib.Object {
         return pixbuf;
     }
 
-    public Gdk.Pixbuf get_pixbuf_force_size (int size, bool force_size) {
-        if (force_size) {
-            return get_pixbuf_at_size (size);
-        } else {
-            return get_pixbuf_nodefault ();
-        }
-    }
-
-    public Gdk.Pixbuf? get_pixbuf_at_size (int forced_size) {
-        var pixbuf = get_pixbuf_nodefault ();
-        if (pixbuf == null) {
-            return null;
-        }
-
-        var w = pixbuf.get_width ();
-        var h = pixbuf.get_height ();
-        var s = int.max (w, h);
-        if (s == forced_size) {
-            return pixbuf;
-        }
-
-        if (w >= h) {
-            return pixbuf.scale_simple (forced_size, -1, Gdk.InterpType.BILINEAR);
-        } else {
-            return pixbuf.scale_simple (-1, forced_size, Gdk.InterpType.BILINEAR);
-        }
-    }
-
     /*
      * Use for testing only
      */

--- a/libcore/gof-file.c
+++ b/libcore/gof-file.c
@@ -623,13 +623,13 @@ gof_file_get_icon (GOFFile *file, int size, GOFFileIconFlags flags)
 }
 
 GdkPixbuf *
-gof_file_get_icon_pixbuf (GOFFile *file, gint size, gboolean force_size, GOFFileIconFlags flags)
+gof_file_get_icon_pixbuf (GOFFile *file, gint size, GOFFileIconFlags flags)
 {
     MarlinIconInfo *nicon;
     GdkPixbuf *pix;
     g_return_val_if_fail (size >= 1, NULL);
     nicon = gof_file_get_icon (file, size, flags);
-    pix = marlin_icon_info_get_pixbuf_force_size (nicon, size, force_size);
+    pix = marlin_icon_info_get_pixbuf_nodefault (nicon);
 
     if (nicon) {
         g_object_unref (nicon);
@@ -648,9 +648,7 @@ gof_file_update_icon_internal (GOFFile *file, gint size)
     /* destroy pixbuff if already present */
     _g_object_unref0 (file->pix);
     /* make sure we always got a non null pixbuf of the specified size */
-    file->pix = gof_file_get_icon_pixbuf (file, size,
-                                          gof_preferences_get_force_icon_size (gof_preferences_get_default ()),
-                                          GOF_FILE_ICON_FLAGS_USE_THUMBNAILS);
+    file->pix = gof_file_get_icon_pixbuf (file, size, GOF_FILE_ICON_FLAGS_USE_THUMBNAILS);
     file->pix_size = size;
 }
 

--- a/libcore/gof-file.h
+++ b/libcore/gof-file.h
@@ -190,7 +190,7 @@ GList           *gof_file_get_location_list (GList *files);
 void            gof_file_list_free (GList *list);
 GList           *gof_file_list_ref (GList *list);
 GList           *gof_file_list_copy (GList *list);
-GdkPixbuf       *gof_file_get_icon_pixbuf (GOFFile *file, gint size, gboolean force_size, GOFFileIconFlags flags);
+GdkPixbuf       *gof_file_get_icon_pixbuf (GOFFile *file, gint size, GOFFileIconFlags flags);
 _MarlinIconInfo  *gof_file_get_icon (GOFFile *file, int size, GOFFileIconFlags flags);
 gboolean        gof_file_is_writable (GOFFile *file);
 gboolean        gof_file_is_trashed (GOFFile *file);

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -205,7 +205,7 @@ namespace GOF {
         public string get_symlink_target ();
         public unowned string? get_ftype ();
         public string? get_formated_time (string attr);
-        public Gdk.Pixbuf get_icon_pixbuf (int size, bool forced_size, FileIconFlags flags);
+        public Gdk.Pixbuf get_icon_pixbuf (int size, FileIconFlags flags);
         public void get_folder_icon_from_uri_or_path ();
         public Marlin.IconInfo get_icon (int size, FileIconFlags flags);
         public string thumbnail_path;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -262,8 +262,6 @@ public class Marlin.Application : Granite.Application {
                                    GOF.Preferences.get_default (), "confirm-trash", GLib.SettingsBindFlags.DEFAULT);
         Preferences.settings.bind ("date-format",
                                    GOF.Preferences.get_default (), "date-format", GLib.SettingsBindFlags.DEFAULT);
-        Preferences.settings.bind ("force-icon-size",
-                                   GOF.Preferences.get_default (), "force-icon-size", GLib.SettingsBindFlags.DEFAULT);
         Preferences.gnome_interface_settings.bind ("clock-format",
                                    GOF.Preferences.get_default (), "clock-format", GLib.SettingsBindFlags.GET);
     }

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -186,7 +186,7 @@ public class PropertiesWindow : AbstractPropertiesDialog {
         update_selection_size (); /* Start counting first to get number of selected files and folders */
 
         /* create some widgets first (may be hidden by update_selection_size ()) */
-        var file_pix = goffile.get_icon_pixbuf (48, false, GOF.FileIconFlags.NONE);
+        var file_pix = goffile.get_icon_pixbuf (48, GOF.FileIconFlags.NONE);
         var file_icon = new Gtk.Image.from_pixbuf (file_pix);
         overlay_emblems (file_icon, goffile.emblems_list);
 


### PR DESCRIPTION
Fixes #423 

This functionality no longer works (crashes) and is not needed so has been removed.