### PR TITLE
Do not stop search when unfocusing the window

### DIFF
--- a/libcore/ProgressInfo.vala
+++ b/libcore/ProgressInfo.vala
@@ -46,7 +46,7 @@ public class PF.Progress.Info : GLib.Object {
     private bool progress_at_idle;
 
     public Info () {
-    
+
     }
 
     construct {
@@ -120,7 +120,7 @@ public class PF.Progress.Info : GLib.Object {
         if (activity_mode) {
             return -1;
         } else {
-            return progress;
+            return total;
         }
     }
 
@@ -186,7 +186,7 @@ public class PF.Progress.Info : GLib.Object {
             current_percent = double.max (current_percent, 0);
         }
 
-        /* 
+        /*
          * Emit on switch from activity mode
          * Emit on change of 0.5 percent
          */

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -304,6 +304,11 @@ namespace Marlin.View.Chrome {
                 });
                 return true;
             } else {
+                var window = get_toplevel () as Gtk.Window;
+                if (window != null && !window.has_toplevel_focus) {
+                    return true;
+                }
+
                 /* This the delayed propagated event */
                 focus_out_timeout_id = 0;
                 base.focus_out_event (event);

--- a/libwidgets/View/SearchResults.vala
+++ b/libwidgets/View/SearchResults.vala
@@ -136,8 +136,8 @@ namespace Marlin.View.Chrome
         public SearchResults (Gtk.Widget parent_widget)
         {
             Object (resizable: false,
-                    type_hint: Gdk.WindowTypeHint.COMBO,
-                    type: Gtk.WindowType.POPUP);
+                    type_hint: Gdk.WindowTypeHint.DND,
+                    decorated: false);
 
             parent = parent_widget;
         }

--- a/libwidgets/View/SearchResults.vala
+++ b/libwidgets/View/SearchResults.vala
@@ -135,6 +135,9 @@ namespace Marlin.View.Chrome
 
         public SearchResults (Gtk.Widget parent_widget)
         {
+            /* WindowTypeHint.DND seems the only hint that
+             * works for this specific case
+             */
             Object (resizable: false,
                     type_hint: Gdk.WindowTypeHint.DND,
                     decorated: false);

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -529,6 +529,15 @@ namespace Marlin.View.Chrome {
             return true;
         }
 
+        protected override bool on_focus_in (Gdk.EventFocus event) {
+            if (search_mode) {
+                return true;
+                
+            }
+
+            return base.on_focus_in (event);
+        }
+
         private BreadcrumbElement? mark_pressed_element (Gdk.EventButton event) {
             reset_elements_states ();
             BreadcrumbElement? el = get_element_from_coordinates ((int) event.x, (int) event.y);

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -532,7 +532,6 @@ namespace Marlin.View.Chrome {
         protected override bool on_focus_in (Gdk.EventFocus event) {
             if (search_mode) {
                 return true;
-                
             }
 
             return base.on_focus_in (event);


### PR DESCRIPTION
This allows the user to freely unfocus the window and let Files search for a query instead of just stopping the search operation.