### PR TITLE
Remove special open in terminal entry

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1185,20 +1185,9 @@ namespace FM {
                     activate_selected_items (Marlin.OpenFlag.NEW_WINDOW, get_files_for_action ());
                     break;
 
-                case "TERMINAL":
-                    open_selected_in_terminal (get_files_for_action ());
-                    break;
-
                 default:
                     break;
             }
-        }
-
-        private void open_selected_in_terminal (GLib.List<GOF.File> selection = get_selected_files ()) {
-            var terminal = new GLib.DesktopAppInfo (Marlin.OPEN_IN_TERMINAL_DESKTOP_ID);
-
-            if (terminal != null)
-                open_files_with (terminal, selection);
         }
 
         private void on_common_action_properties (GLib.SimpleAction action, GLib.Variant? param) {
@@ -2017,10 +2006,11 @@ namespace FM {
             app_submenu = build_submenu_open_with_applications (ref builder, selection);
 
             if (app_submenu != null && app_submenu.get_n_items () > 0) {
-                if (selected_file.is_folder () || selected_file.is_root_network_folder ())
+                if (selected_file.is_folder () || selected_file.is_root_network_folder ()) {
                     label =  _("Open in");
-                else
+                } else {
                     label = _("Open with");
+                }
 
                 menu.append_submenu (label, app_submenu);
             }
@@ -2033,8 +2023,6 @@ namespace FM {
 
             var open_with_submenu = new GLib.Menu ();
             open_with_apps = null;
-
-            int index = -1;
 
             if (common_actions.get_action_enabled ("open_in")) {
                 open_with_submenu.append_section (null, builder.get_object ("open-in") as GLib.MenuModel);
@@ -2054,7 +2042,11 @@ namespace FM {
                 if (open_with_apps != null) {
                     var apps_section = new GLib.Menu ();
                     string last_label = "";
+                    int index = -1;
+                    int count = 0;
+
                     foreach (var app in open_with_apps) {
+                        index++;
                         if (app != null && app is AppInfo) {
                             var label = app.get_display_name ();
                             /* The following mainly applies to Nautilus, whose display name is also "Files" */
@@ -2075,15 +2067,16 @@ namespace FM {
                              * with the same name (e.g. Nautilus)
                              */
                             if (label != last_label) {
-                                index++;
                                 apps_section.append (label, "selection.open_with_app::" + index.to_string ());
                                 last_label = label.dup ();
+                                count++;
                             }
                         }
                     };
 
-                    if (index >= 0)
+                    if (count >= 0) {
                         open_with_submenu.append_section (null, apps_section);
+                    }
                 }
 
                 if (selection != null && selection.first ().next == null) { // Only one selected
@@ -2092,6 +2085,7 @@ namespace FM {
                     open_with_submenu.append_section (null, other_app_menu);
                 }
             }
+
             return open_with_submenu as GLib.MenuModel;
         }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2041,36 +2041,23 @@ namespace FM {
 
                 if (open_with_apps != null) {
                     var apps_section = new GLib.Menu ();
-                    string last_label = "";
                     int index = -1;
                     int count = 0;
+                    string last_label = "";
+                    string last_exec = "";
 
                     foreach (var app in open_with_apps) {
                         index++;
                         if (app != null && app is AppInfo) {
                             var label = app.get_display_name ();
-                            /* The following mainly applies to Nautilus, whose display name is also "Files" */
-                            if (label == "Files") {
-                                label = app.get_executable ();
-                                label = label[0].toupper ().to_string () + label.substring (1);
-                            }
-
-                            /* If a terminal appears in this list, and is not the elementary app show executable name */
-                            if (label == "Terminal") {
-                                var exec = app.get_executable ();
-                                if (!exec.contains ("elementary")) {
-                                    label = exec[0].toupper ().to_string () + exec.substring (1);
-                                }
-                            }
-
-                            /* Do not show same name twice - some apps have more than one .desktop file
-                             * with the same name (e.g. Nautilus)
-                             */
-                            if (label != last_label) {
+                            var exec = app.get_executable ().split (" ")[0];
+                            if (label != last_label || exec != last_exec) {
                                 apps_section.append (label, "selection.open_with_app::" + index.to_string ());
-                                last_label = label.dup ();
                                 count++;
                             }
+
+                            last_label = label.dup ();
+                            last_exec = exec.dup ();
                         }
                     };
 

--- a/src/View/directory_view_popup.ui
+++ b/src/View/directory_view_popup.ui
@@ -86,14 +86,6 @@
         </item>
     </menu>
 
-    <menu id='open-in-terminal'>
-        <item>
-            <attribute name='label' translatable='yes'>Terminal</attribute>
-            <attribute name='action'>common.open_in</attribute>
-            <attribute name="target">TERMINAL</attribute>
-        </item>
-    </menu>
-
     <menu id='properties'>
         <item>
             <attribute name='label' translatable='yes'>Properties</attribute>


### PR DESCRIPTION
Fixes #334 

The special entry is no longer required - elementary terminal now appears in the general list of appropriate apps for folders.

If another terminal app capable of opening folders is present and has the short name "Terminal" then this is replaced with the executable name in the menu to distinguish it from elementary terminal app.

This branch also removes the app label disambiguation code, following discussion on Slack.  So if several filemanagers are installed, for example, then there is likely to be several entries labelled "Files".  Same for terminal apps.