### PR TITLE
Fix filename appearing in pathbar in some circumstances

### DIFF
--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -446,6 +446,7 @@ namespace Marlin.View {
                 browser.record_uri (null);
             }
 
+            refresh_slot_info (slot.location);
             loading (false); /* Will cause topmenu to update */
             overlay_statusbar.update_hovered (null); /* Prevent empty statusbar showing */
         }


### PR DESCRIPTION
Fixes #239 

Also fixes same issue when opening a file (not a folder) from the command line without any option.
Updates slot info display after loading in case location changed during slot initialization.

TO TEST
At commandline type `io.elementary.files ~/Test_Folder/test_file.txt`  where Test_Folder and test_file.txt exist.

In master Files opens showing Test_Folder with test_file.txt selected, but the pathbar has an extra breadcrumb to `test_file.txt` and the tab name is `test_file.txt`.

In PR there is no extra breadcrumb and the tab name is `Test_Folder`