### PR TITLE
Fix crash when searching twice.

### DIFF
--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -298,7 +298,8 @@ namespace Marlin.View.Chrome {
         protected virtual bool on_focus_out (Gdk.EventFocus event) {
             if (focus_out_timeout_id == 0) {
                 /* Delay acting on focus out - may be temporary, due to keyboard layout change */
-                focus_out_timeout_id = GLib.Timeout.add (10, () => {
+                /* Also need to wait long enough for window.has_toplevel_focus () to return correct result */
+                focus_out_timeout_id = GLib.Timeout.add (50, () => {
                     focus_out_event (event);
                     return false;
                 });
@@ -373,7 +374,7 @@ namespace Marlin.View.Chrome {
 
         /** Returns a list of breadcrumbs that are displayed in natural order - that is, the breadcrumb at the start
           * of the pathbar is at the start of the list
-         **/  
+         **/
         public double get_displayed_breadcrumbs_natural_width (out GLib.List<BreadcrumbElement> displayed_breadcrumbs) {
             double total_width = 0.0;
             displayed_breadcrumbs = null;
@@ -403,7 +404,7 @@ namespace Marlin.View.Chrome {
             }
 
             /* Allow enough space after the breadcrumbs for secondary icon and entry */
-            w += 2 * YPAD + MINIMUM_LOCATION_BAR_ENTRY_WIDTH + ICON_WIDTH; 
+            w += 2 * YPAD + MINIMUM_LOCATION_BAR_ENTRY_WIDTH + ICON_WIDTH;
 
             return (int) (w);
         }
@@ -661,7 +662,7 @@ namespace Marlin.View.Chrome {
                 double total_arrow_width = displayed_breadcrumbs.length () * (height_marged / 2 + padding.left);
                 width_marged -= total_arrow_width;
                 if (max_width > width_marged) { /* let's check if the breadcrumbs are bigger than the widget */
-                    var unfixed = displayed_breadcrumbs.length () - 2; 
+                    var unfixed = displayed_breadcrumbs.length () - 2;
                     if (unfixed > 0) {
                         width_marged -= unfixed * MINIMUM_BREADCRUMB_WIDTH;
                     }


### PR DESCRIPTION
Fixes #466

This issue was due to an unnoticed side-effect of 6114ea723318d486f7be77d27c7b7e69ab5ea177

Make sure breadcrumbentry focus out handler loses race with window.has_top_level_focus () by increasing length of delay.

This is just a quick fix.  The pathbar widgets need refactoring to make less fragile.

Some trailing spaces have been automatically removed.