### PR TITLE
Fix freeze when clicking on folder that is already open in Miller View

### DIFF
--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -106,7 +106,6 @@ namespace Marlin.View {
             }
 
             new_slot.active (scroll, animate); /* This will set the new slot to be current_slot. Must do this before loading */
-
         }
 
         private void nest_slot_in_host_slot (Marlin.View.Slot slot, Marlin.View.Slot? host) {

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -275,19 +275,13 @@ namespace Marlin.View {
         }
 
         private void on_miller_slot_request (Marlin.View.Slot slot, GLib.File loc, bool make_root) {
-            path_changed ();
-
-            Idle.add (() => {
-                if (make_root) {
-                    /* Start a new tree with root at loc */
-                    change_path (loc, true);
-                } else {
-                    /* Just add another column to the end. */
-                    add_location (loc, slot);
-                }
-
-                return false;
-            });
+            if (make_root) {
+                /* Start a new tree with root at loc */
+                change_path (loc, true);
+            } else {
+                /* Just add another column to the end. */
+                add_location (loc, slot);
+            }
         }
 
         private bool on_slot_horizontal_scroll_event (double delta_x) {


### PR DESCRIPTION
Fixes #467

Reuse opened slot in Miller.  Fixes signal race whereby the ViewContainer receives the "done-loading" signal before the "path changed" signal when clicking on a folder that is already opened resulting in the view staying in the "working" and "frozen" state.