### PR TITLE
Fix some icons not scaling in HiDPI

### DIFF
--- a/libcore/IconInfo.vala
+++ b/libcore/IconInfo.vala
@@ -87,7 +87,7 @@ public class Marlin.IconInfo : GLib.Object {
 
             var names = ((GLib.ThemedIcon) icon).get_names ();
             var theme = get_icon_theme ();
-            var gtkicon_info = theme.choose_icon_for_scale (names, size, scale, 0);
+            var gtkicon_info = theme.choose_icon_for_scale (names, size, scale, Gtk.IconLookupFlags.FORCE_SIZE);
             if (gtkicon_info == null) {
                 return new Marlin.IconInfo.for_pixbuf (null);
             }

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -93,8 +93,8 @@ namespace Marlin {
 
             var pix_rect = Gdk.Rectangle ();
 
-            pix_rect.width = pixbuf.get_width ()/icon_scale;
-            pix_rect.height = pixbuf.get_height ()/icon_scale;
+            pix_rect.width = pixbuf.get_width () / icon_scale;
+            pix_rect.height = pixbuf.get_height () / icon_scale;
             pix_rect.x = cell_area.x + (cell_area.width - pix_rect.width) / 2;
             pix_rect.y = cell_area.y + (cell_area.height - pix_rect.height) / 2;
 
@@ -168,7 +168,7 @@ namespace Marlin {
                 return;
             }
 
-            cr.scale (1.0/icon_scale, 1.0/icon_scale);
+            cr.scale (1.0 / icon_scale, 1.0 / icon_scale);
             style_context.render_icon (cr, pb, draw_rect.x * icon_scale, draw_rect.y * icon_scale);
             style_context.restore ();
 


### PR DESCRIPTION
Fixes #460 

Force requested size when creating GtkIconInfo.

For reasons external to Files, gtkicon_info = theme.choose_icon_for_scale () sometimes returns an incorrectly sized pixbuf in HiDPI.  Passing the Gtk.IconLookupFlag.FORCE_SIZE fixes this.