### PR TITLE
Remove thumbs for deleted files

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -751,6 +751,13 @@ namespace PF.FileUtils {
                 filesystem_a == filesystem_b);
 
     }
+
+    public void remove_thumbnail_paths_for_uri (string uri) {
+        string hash = GLib.Checksum.compute_for_string (ChecksumType.MD5, uri);
+        string base_name = "%s.png".printf (hash);
+        GLib.FileUtils.unlink (Path.build_filename (Environment.get_user_cache_dir (), "thumbnails", "normal", base_name));
+        GLib.FileUtils.unlink (Path.build_filename (Environment.get_user_cache_dir (), "thumbnails", "large", base_name));
+    }
 }
 
 namespace Marlin {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1288,6 +1288,10 @@ namespace FM {
             model.remove_file (file, dir);
 
             remove_marlin_icon_info_cache (file);
+            if (file.get_thumbnail_path () != null) {
+                PF.FileUtils.remove_thumbnail_paths_for_uri (file.uri);
+            }
+
             if (file.is_folder ()) {
                 /* Check whether the deleted file is the directory */
                 var file_dir = GOF.Directory.Async.cache_lookup (file.location);


### PR DESCRIPTION
Fixes #398 #402 

This is a slightly simpler fix than #400, which seems to be abandoned.