### PR TITLE
Restore function of connect server dialog

### DIFF
--- a/src/marlin-connect-server-dialog.c
+++ b/src/marlin-connect-server-dialog.c
@@ -460,9 +460,7 @@ marlin_connect_server_dialog_display_location_async (MarlinConnectServerDialog *
                                    callback, user_data,
                                    marlin_connect_server_dialog_display_location_async);
 
-    //g_message ("ConnectServer display location %s", g_file_get_uri (location));
-    //marlin_application_create_window_from_gfile (marlin_application_new (), location, gtk_widget_get_screen (widget));
-    g_signal_emit_by_name (MARLIN_VIEW_WINDOW (self->details->parent_window)->current_tab, "path-changed", location);
+    marlin_view_window_uri_path_change_request (MARLIN_VIEW_WINDOW (self->details->parent_window), g_file_get_uri (location), MARLIN_OPEN_FLAG_DEFAULT);
 
     g_simple_async_result_complete (display_location_res);
     g_object_unref (display_location_res);


### PR DESCRIPTION
Fixes #354 

Restores function of the connect server dialog that opens the connection in the view (pending rewrite of dialog in vala).

Uses public function of Window instead of previously removed signal 'path-changed'