### PR TITLE
Iconview selection style

### DIFF
--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -167,6 +167,10 @@ namespace Marlin {
                         }
                     }
                 }
+
+                if (prelit || focused) {
+                    pb = PF.PixbufUtils.lighten (pb);
+                }
             }
 
             if (pb == null) {

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -153,7 +153,9 @@ namespace Marlin {
                 if (selected) {
                     state = Gtk.StateFlags.SELECTED;
                     state |= widget.get_state_flags ();
+                }
 
+                if (focused) {
                     var bg = style_context.get_property ("background-color", state);
 
                     if (bg.holds (typeof (Gdk.RGBA))) {
@@ -164,10 +166,6 @@ namespace Marlin {
                             pb = PF.PixbufUtils.colorize (pb, color);
                         }
                     }
-                }
-
-                if (prelit || focused) {
-                    pb = PF.PixbufUtils.lighten (pb);
                 }
             }
 


### PR DESCRIPTION
Takes advantage of a change in stylesheet master that makes selection more consistent between icon and list views.

Only colorize focused folders. Makes it clearer where focus lies in the selection

![screenshot from 2018-08-03 09 55 02 2x](https://user-images.githubusercontent.com/7277719/43655577-011ed850-9704-11e8-94fc-2b1d192711d9.png)