### PR TITLE
When pasting into text application, use sanitized path with newline

### DIFF
--- a/src/ClipboardManager.vala
+++ b/src/ClipboardManager.vala
@@ -243,14 +243,14 @@ namespace Marlin {
             }
 
             switch (target_info) {
-                case ClipboardTarget.GNOME_COPIED_FILES:
+                case ClipboardTarget.GNOME_COPIED_FILES: /* Pasting into a file handler */
                     string prefix = manager.files_cutted ? "cut" : (manager.files_linked ? "link" : "copy");
                     DndHandler.set_selection_data_from_file_list (sd,
                                                                   manager.files,
                                                                   prefix);
                     break;
 
-                case ClipboardTarget.UTF8_STRING: /* Not clear what this is for */
+                case ClipboardTarget.UTF8_STRING: /* Pasting into a text handler */
                     DndHandler.set_selection_text_from_file_list (sd, manager.files, "");
                     break;
                 default:


### PR DESCRIPTION
Fixes #534 

Restores previous behaviour when pasting copied file item into an application requesting text. Provide sanitized path (i.e. unescaped and no `file://` prefix).

Only append trailing newline characters when copying into an application requesting a uri.