### PR TITLE
Only lose final "\r\n" when pasting text.

### DIFF
--- a/libcore/DndHandler.vala
+++ b/libcore/DndHandler.vala
@@ -289,7 +289,6 @@ namespace Marlin {
 
             GLib.StringBuilder sb = new GLib.StringBuilder (prefix);
             set_stringbuilder_from_file_list (sb, file_list, prefix, false);  /* Use escaped paths */
-            sb.append ("\r\n"); /* Drop onto Filezilla does not work without the "\r" */
             selection_data.@set (selection_data.get_target (),
                                  8,
                                  sb.data);
@@ -302,7 +301,8 @@ namespace Marlin {
 
             GLib.StringBuilder sb = new GLib.StringBuilder (prefix);
             set_stringbuilder_from_file_list (sb, file_list, prefix, true); /* Use sanitized paths */
-            selection_data.set_text (sb.str, (int)(sb.len)); /* Do not want new line at end */
+            sb.truncate (sb.len - 2);  /* Do not want "\r\n" at end when pasting into text*/
+            selection_data.set_text (sb.str, (int)(sb.len));
         }
 
         private static void set_stringbuilder_from_file_list (GLib.StringBuilder sb, GLib.List<GOF.File> file_list,
@@ -317,6 +317,7 @@ namespace Marlin {
                     }
 
                     sb.append (target);
+                    sb.append ("\r\n"); /* Drop onto Filezilla does not work without the "\r" */
                 });
             } else {
                 warning ("Invalid file list for drag and drop ignored");

--- a/src/ClipboardManager.vala
+++ b/src/ClipboardManager.vala
@@ -244,7 +244,6 @@ namespace Marlin {
 
             switch (target_info) {
                 case ClipboardTarget.GNOME_COPIED_FILES: /* Pasting into a file handler */
-warning ("gnome copied");
                     string prefix = manager.files_cutted ? "cut" : (manager.files_linked ? "link" : "copy");
                     DndHandler.set_selection_data_from_file_list (sd,
                                                                   manager.files,
@@ -252,7 +251,6 @@ warning ("gnome copied");
                     break;
 
                 case ClipboardTarget.UTF8_STRING: /* Pasting into a text handler */
-warning ("utf8 string");
                     DndHandler.set_selection_text_from_file_list (sd, manager.files, "");
                     break;
                 default:

--- a/src/ClipboardManager.vala
+++ b/src/ClipboardManager.vala
@@ -244,6 +244,7 @@ namespace Marlin {
 
             switch (target_info) {
                 case ClipboardTarget.GNOME_COPIED_FILES: /* Pasting into a file handler */
+warning ("gnome copied");
                     string prefix = manager.files_cutted ? "cut" : (manager.files_linked ? "link" : "copy");
                     DndHandler.set_selection_data_from_file_list (sd,
                                                                   manager.files,
@@ -251,6 +252,7 @@ namespace Marlin {
                     break;
 
                 case ClipboardTarget.UTF8_STRING: /* Pasting into a text handler */
+warning ("utf8 string");
                     DndHandler.set_selection_text_from_file_list (sd, manager.files, "");
                     break;
                 default:


### PR DESCRIPTION
Fixes #583 

Fixes regression caused by  a1475450098eb65d4cd073acf6222453fb88b146
It is an open question whether, when pasting multiple file paths into a text application, the individual paths should be separated by newlines or, perhaps, spaces.  But for now I have retained the newlines except at the end.  So pasting a single path into terminal for example will not end the command (but pasting more than one will).  Any further change can be made in a future PR, it required.