### PR TITLE
Swipe back forward

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -22,7 +22,7 @@
 */
 
 namespace Marlin.View {
-
+    public const double SWIPE_THRESHOLD = 50;
     public class Window : Gtk.ApplicationWindow {
         const GLib.ActionEntry [] win_entries = {
             {"new_window", action_new_window},
@@ -145,16 +145,16 @@ namespace Marlin.View {
             swipe_gesture.propagation_phase = Gtk.PropagationPhase.CAPTURE;
 
             swipe_gesture.swipe.connect ((p0, p1) => {
-                if (p1.abs () < p0.abs () / 3)  {
-                    if (p0 > 10) {
+                if (p1.abs () < p0.abs () / 3)  { /* Approximately horizontal */
+                    if (p0 > SWIPE_THRESHOLD) { /* Left to right */
                         win_actions.activate_action ("go_to", new GLib.Variant.string ("FORWARD"));
-                    } else if (p0 < -10) {
+                    } else if (p0 < -SWIPE_THRESHOLD) {  /* Right to left */
                         win_actions.activate_action ("go_to", new GLib.Variant.string ("BACK"));
                     }
-                } else if (p0.abs () < p1.abs () / 3)  {
-                    if (p1 > 10) {
-                        /* Downward swipe not assigned an action at present */
-                    } else if (p1 < -10) {
+                } else if (p0.abs () < p1.abs () / 3)  { /* Approximately vertical */
+                    if (p1 > SWIPE_THRESHOLD) {  /* top to bottom */
+                        /* No action assigned at present */
+                    } else if (p1 < -SWIPE_THRESHOLD) { /* bottom to top */
                         win_actions.activate_action ("go_to", new GLib.Variant.string ("UP"));
                     }
                 }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -75,6 +75,8 @@ namespace Marlin.View {
         public signal void folder_deleted (GLib.File location);
         public signal void free_space_change ();
 
+        private Gtk.GestureSwipe swipe_gesture;
+
         public Window (Marlin.Application application, Gdk.Screen myscreen = Gdk.Screen.get_default ()) {
             Object (
                 application: application,
@@ -136,6 +138,27 @@ namespace Marlin.View {
                     move (default_x, default_y);
                 }
             }
+
+            add_events (Gdk.EventMask.TOUCH_MASK | Gdk.EventMask.TOUCHPAD_GESTURE_MASK);
+            swipe_gesture = new Gtk.GestureSwipe (this);
+            swipe_gesture.button = Gdk.BUTTON_MIDDLE;
+            swipe_gesture.propagation_phase = Gtk.PropagationPhase.CAPTURE;
+
+            swipe_gesture.swipe.connect ((p0, p1) => {
+                if (p1.abs () < p0.abs () / 3)  {
+                    if (p0 > 10) {
+                        win_actions.activate_action ("go_to", new GLib.Variant.string ("FORWARD"));
+                    } else if (p0 < -10) {
+                        win_actions.activate_action ("go_to", new GLib.Variant.string ("BACK"));
+                    }
+                } else if (p0.abs () < p1.abs () / 3)  {
+                    if (p1 > 10) {
+                        /* Downward swipe not assigned an action at present */
+                    } else if (p1 < -10) {
+                        win_actions.activate_action ("go_to", new GLib.Variant.string ("UP"));
+                    }
+                }
+            });
 
             present ();
         }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -76,6 +76,7 @@ namespace Marlin.View {
         public signal void free_space_change ();
 
         private Gtk.GestureSwipe swipe_gesture;
+        private Gtk.GestureMultiPress mp_gesture;
 
         public Window (Marlin.Application application, Gdk.Screen myscreen = Gdk.Screen.get_default ()) {
             Object (
@@ -140,8 +141,7 @@ namespace Marlin.View {
             }
 
             add_events (Gdk.EventMask.TOUCH_MASK | Gdk.EventMask.TOUCHPAD_GESTURE_MASK);
-            swipe_gesture = new Gtk.GestureSwipe (this);
-            swipe_gesture.button = Gdk.BUTTON_MIDDLE;
+            swipe_gesture = (Gtk.GestureSwipe)(new Object (typeof (Gtk.GestureSwipe), "n_points", 2, null));
             swipe_gesture.propagation_phase = Gtk.PropagationPhase.CAPTURE;
 
             swipe_gesture.swipe.connect ((p0, p1) => {


### PR DESCRIPTION
Partial fix for #588 (part 2)

An experimental branch implementing simple swipe detection in the Marlin.View.Window and linking to some actions.

This could only be tested with mouse swipes on the author's machine.  Needs testing on a touch enabled machine.