### PR TITLE
Translate const strings at runtime

### DIFF
--- a/libwidgets/Chrome/BreadcrumbIconList.vala
+++ b/libwidgets/Chrome/BreadcrumbIconList.vala
@@ -113,17 +113,16 @@ namespace Marlin.View.Chrome {
             icon_info_list = new Gee.ArrayList<BreadcrumbIconInfo> ();
 
             /* FIXME the string split of the path url is kinda too basic, we should use the Gile to split our uris and determine the protocol (if any) with g_uri_parse_scheme or g_file_get_uri_scheme */
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("afp://", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, Marlin.PROTOCOL_NAME_AFP));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("dav://", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, Marlin.PROTOCOL_NAME_DAV));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("davs://", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, Marlin.PROTOCOL_NAME_DAVS));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("ftp://", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, Marlin.PROTOCOL_NAME_FTP));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("network://", Marlin.ICON_NETWORK_SYMBOLIC, Marlin.PROTOCOL_NAME_NETWORK));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("sftp://", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, Marlin.PROTOCOL_NAME_SFTP));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("smb://", Marlin.ICON_NETWORK_SERVER_SYMBOLIC, Marlin.PROTOCOL_NAME_SMB));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("trash://", Marlin.ICON_TRASH_SYMBOLIC, Marlin.PROTOCOL_NAME_TRASH));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("recent://", Marlin.ICON_RECENT_SYMBOLIC, Marlin.PROTOCOL_NAME_RECENT));
-            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory ("mtp://[", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC, Marlin.PROTOCOL_NAME_MTP));
-
+            add_protocol_directory ("afp", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
+            add_protocol_directory ("dav", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
+            add_protocol_directory ("davs", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
+            add_protocol_directory ("ftp", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
+            add_protocol_directory ("sftp", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
+            add_protocol_directory ("mtp", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
+            add_protocol_directory ("network", Marlin.ICON_NETWORK_SYMBOLIC);
+            add_protocol_directory ("smb", Marlin.ICON_NETWORK_SERVER_SYMBOLIC);
+            add_protocol_directory ("trash", Marlin.ICON_TRASH_SYMBOLIC);
+            add_protocol_directory ("recent", Marlin.ICON_RECENT_SYMBOLIC);
 
             /* music */
             string? dir;
@@ -187,6 +186,11 @@ namespace Marlin.View.Chrome {
             /* filesystem */
             var icon = new BreadcrumbIconInfo.special_directory (Path.DIR_SEPARATOR_S, Marlin.ICON_FILESYSTEM_SYMBOLIC);
             icon_info_list.add (icon);
+        }
+
+        private void add_protocol_directory (string protocol, string icon) {
+            var separator = "://" + (protocol == "mtp" ? "[" : "");
+            icon_info_list.add (new BreadcrumbIconInfo.protocol_directory (protocol + separator, icon, protocol_to_name (protocol)));
         }
 
         private void make_icons () {

--- a/libwidgets/Chrome/BreadcrumbIconList.vala
+++ b/libwidgets/Chrome/BreadcrumbIconList.vala
@@ -112,7 +112,6 @@ namespace Marlin.View.Chrome {
         construct {
             icon_info_list = new Gee.ArrayList<BreadcrumbIconInfo> ();
 
-            /* FIXME the string split of the path url is kinda too basic, we should use the Gile to split our uris and determine the protocol (if any) with g_uri_parse_scheme or g_file_get_uri_scheme */
             add_protocol_directory ("afp", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
             add_protocol_directory ("dav", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
             add_protocol_directory ("davs", Marlin.ICON_FOLDER_REMOTE_SYMBOLIC);
@@ -124,73 +123,28 @@ namespace Marlin.View.Chrome {
             add_protocol_directory ("trash", Marlin.ICON_TRASH_SYMBOLIC);
             add_protocol_directory ("recent", Marlin.ICON_RECENT_SYMBOLIC);
 
-            /* music */
-            string? dir;
-            dir = Environment.get_user_special_dir (UserDirectory.MUSIC);
-            if (dir != null && dir.contains (Path.DIR_SEPARATOR_S)) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, Marlin.ICON_FOLDER_MUSIC_SYMBOLIC);
-                icon_info_list.add (icon);
-            }
-
-            /* image */
-            dir = Environment.get_user_special_dir (UserDirectory.PICTURES);
-            if (dir != null && dir.contains (Path.DIR_SEPARATOR_S)) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, Marlin.ICON_FOLDER_PICTURES_SYMBOLIC);
-                icon_info_list.add (icon);
-            }
-
-            /* movie */
-            dir = Environment.get_user_special_dir (UserDirectory.VIDEOS);
-            if (dir != null && dir.contains (Path.DIR_SEPARATOR_S)) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, Marlin.ICON_FOLDER_VIDEOS_SYMBOLIC);
-                icon_info_list.add (icon);
-            }
-
-            /* downloads */
-            dir = Environment.get_user_special_dir (UserDirectory.DOWNLOAD);
-            if (dir != null && dir.contains (Path.DIR_SEPARATOR_S)) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, Marlin.ICON_FOLDER_DOWNLOADS_SYMBOLIC);
-                icon_info_list.add (icon);
-            }
-
-            /* documents */
-            dir = Environment.get_user_special_dir (UserDirectory.DOCUMENTS);
-            if (dir != null && dir.contains (Path.DIR_SEPARATOR_S)) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, Marlin.ICON_FOLDER_DOCUMENTS_SYMBOLIC);
-                icon_info_list.add (icon);
-            }
-
-            /* templates */
-            dir = Environment.get_user_special_dir (UserDirectory.TEMPLATES);
-            if (dir != null && dir.contains (Path.DIR_SEPARATOR_S)) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, Marlin.ICON_FOLDER_TEMPLATES_SYMBOLIC);
-                icon_info_list.add (icon);
-            }
-
-            /* home */
-            dir = PF.UserUtils.get_real_user_home ();
-            if (dir.contains (Path.DIR_SEPARATOR_S)) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, Marlin.ICON_GO_HOME_SYMBOLIC);
-                icon.break_loop = true;
-                icon_info_list.add (icon);
-            }
-
-            /* media mounted volumes */
-            dir = "/media";
-            if (dir.contains (Path.DIR_SEPARATOR_S)) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, Marlin.ICON_FILESYSTEM_SYMBOLIC);
-                icon.break_loop = true;
-                icon_info_list.add (icon);
-            }
-
-            /* filesystem */
-            var icon = new BreadcrumbIconInfo.special_directory (Path.DIR_SEPARATOR_S, Marlin.ICON_FILESYSTEM_SYMBOLIC);
-            icon_info_list.add (icon);
+            add_special_directory (Environment.get_user_special_dir (UserDirectory.MUSIC), Marlin.ICON_FOLDER_MUSIC_SYMBOLIC);
+            add_special_directory (Environment.get_user_special_dir (UserDirectory.PICTURES), Marlin.ICON_FOLDER_PICTURES_SYMBOLIC);
+            add_special_directory (Environment.get_user_special_dir (UserDirectory.VIDEOS), Marlin.ICON_FOLDER_VIDEOS_SYMBOLIC);
+            add_special_directory (Environment.get_user_special_dir (UserDirectory.DOWNLOAD), Marlin.ICON_FOLDER_DOWNLOADS_SYMBOLIC);
+            add_special_directory (Environment.get_user_special_dir (UserDirectory.DOCUMENTS), Marlin.ICON_FOLDER_DOCUMENTS_SYMBOLIC);
+            add_special_directory (Environment.get_user_special_dir (UserDirectory.TEMPLATES), Marlin.ICON_FOLDER_TEMPLATES_SYMBOLIC);
+            add_special_directory (PF.UserUtils.get_real_user_home (), Marlin.ICON_GO_HOME_SYMBOLIC, true);
+            add_special_directory ("/media", Marlin.ICON_FILESYSTEM_SYMBOLIC, true);
+            add_special_directory (Path.DIR_SEPARATOR_S, Marlin.ICON_FILESYSTEM_SYMBOLIC);
         }
 
         private void add_protocol_directory (string protocol, string icon) {
             var separator = "://" + (protocol == "mtp" ? "[" : "");
             icon_info_list.add (new BreadcrumbIconInfo.protocol_directory (protocol + separator, icon, protocol_to_name (protocol)));
+        }
+
+        private void add_special_directory (string? dir, string icon_name, bool break_loop = false) {
+            if (dir != null) {
+                var icon = new BreadcrumbIconInfo.special_directory (dir, icon_name);
+                icon.break_loop = break_loop;
+                icon_info_list.add (icon);
+            }
         }
 
         private void make_icons () {

--- a/libwidgets/Resources.vala
+++ b/libwidgets/Resources.vala
@@ -55,17 +55,17 @@ namespace Marlin {
 
     public const string OPEN_IN_TERMINAL_DESKTOP_ID = "open-pantheon-terminal-here.desktop";
 
-    public const string PROTOCOL_NAME_AFP = _("AFP");
-    public const string PROTOCOL_NAME_DAV = _("DAV");
-    public const string PROTOCOL_NAME_DAVS = _("DAVS");
-    public const string PROTOCOL_NAME_FTP = _("FTP");
-    public const string PROTOCOL_NAME_NETWORK = _("Network");
-    public const string PROTOCOL_NAME_SFTP = _("SFTP");
-    public const string PROTOCOL_NAME_SMB = _("SMB");
-    public const string PROTOCOL_NAME_TRASH = _("Trash");
-    public const string PROTOCOL_NAME_RECENT = _("Recent");
-    public const string PROTOCOL_NAME_MTP = _("MTP");
-    public const string PROTOCOL_NAME_FILE = _("File System");
+    public const string PROTOCOL_NAME_AFP = N_("AFP");
+    public const string PROTOCOL_NAME_DAV = N_("DAV");
+    public const string PROTOCOL_NAME_DAVS = N_("DAVS");
+    public const string PROTOCOL_NAME_FTP = N_("FTP");
+    public const string PROTOCOL_NAME_NETWORK = N_("Network");
+    public const string PROTOCOL_NAME_SFTP = N_("SFTP");
+    public const string PROTOCOL_NAME_SMB = N_("SMB");
+    public const string PROTOCOL_NAME_TRASH = N_("Trash");
+    public const string PROTOCOL_NAME_RECENT = N_("Recent");
+    public const string PROTOCOL_NAME_MTP = N_("MTP");
+    public const string PROTOCOL_NAME_FILE = N_("File System");
 
     public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 36;
     public const uint LOCATION_BAR_ANIMATION_TIME_MSEC = 300;
@@ -82,61 +82,29 @@ namespace Marlin {
 
         switch (s) {
             case "recent":
-                return Marlin.PROTOCOL_NAME_RECENT;
+                return _(Marlin.PROTOCOL_NAME_RECENT);
             case "trash":
-                return Marlin.PROTOCOL_NAME_TRASH;
+                return _(Marlin.PROTOCOL_NAME_TRASH);
             case "network":
-                return Marlin.PROTOCOL_NAME_NETWORK;
+                return _(Marlin.PROTOCOL_NAME_NETWORK);
             case "smb":
-                return Marlin.PROTOCOL_NAME_SMB;
+                return _(Marlin.PROTOCOL_NAME_SMB);
             case "ftp":
-                return Marlin.PROTOCOL_NAME_FTP;
+                return _(Marlin.PROTOCOL_NAME_FTP);
             case "sftp":
-                return Marlin.PROTOCOL_NAME_SFTP;
+                return _(Marlin.PROTOCOL_NAME_SFTP);
             case "afp":
-                return Marlin.PROTOCOL_NAME_AFP;
+                return _(Marlin.PROTOCOL_NAME_AFP);
             case "dav":
-                return Marlin.PROTOCOL_NAME_DAV;
+                return _(Marlin.PROTOCOL_NAME_DAV);
             case "davs":
-                return Marlin.PROTOCOL_NAME_DAVS;
+                return _(Marlin.PROTOCOL_NAME_DAVS);
             case "mtp":
-                return Marlin.PROTOCOL_NAME_MTP;
+                return _(Marlin.PROTOCOL_NAME_MTP);
             case "file":
-                return Marlin.PROTOCOL_NAME_FILE;
+                return _(Marlin.PROTOCOL_NAME_FILE);
             default:
                 return protocol;
         }
-    }
-
-    public string name_to_protocol_uri (string pname) {
-        /* Deal with protocol with or without : or / characters at the end */
-
-        switch (pname.strip ()) {
-            case Marlin.PROTOCOL_NAME_RECENT:
-                return Marlin.RECENT_URI;
-            case Marlin.PROTOCOL_NAME_TRASH:
-                return Marlin.TRASH_URI;
-            case Marlin.PROTOCOL_NAME_NETWORK:
-                return Marlin.NETWORK_URI;
-            case Marlin.PROTOCOL_NAME_SMB:
-                return Marlin.SMB_URI;
-            case Marlin.PROTOCOL_NAME_FTP:
-                return Marlin.FTP_URI;
-            case Marlin.PROTOCOL_NAME_SFTP:
-                return Marlin.SFTP_URI;
-            case Marlin.PROTOCOL_NAME_AFP:
-                return Marlin.AFP_URI;
-            case Marlin.PROTOCOL_NAME_DAV:
-                return Marlin.DAV_URI;
-            case Marlin.PROTOCOL_NAME_DAVS:
-                return Marlin.DAVS_URI;
-            default:
-                return "";
-        }
-    }
-
-    public string sanitize_protocol (string p) {
-        string pname = Marlin.protocol_to_name (p);
-        return Marlin.name_to_protocol_uri (pname);
     }
 }


### PR DESCRIPTION
Protocol names stored as constant strings are translated at runtime.  
Some unused related functions and incompatible functions are removed.
BreadcrumbIconInfoList updated accordingly and some extra DRYing applied.