### PR TITLE
Ensure is_on_icon receives appropriate coordinates

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3654,7 +3654,8 @@ namespace FM {
             }
         }
 
-        protected bool is_on_icon (int x, int y, Gdk.Rectangle area, Gdk.Pixbuf pix, bool rtl, ref bool on_helper) {
+        protected bool is_on_icon (int x, int y, ref bool on_helper) {
+            /* x and y must be in same coordinate system as used by the IconRenderer */
             Gdk.Rectangle pointer_rect = {x - 2, y - 2, 4, 4}; /* Allow slight inaccuracy */
             bool on_icon = pointer_rect.intersect (icon_renderer.hover_rect, null);
             on_helper = pointer_rect.intersect (icon_renderer.helper_rect, null);

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -240,7 +240,9 @@ namespace FM {
                     var rtl = (get_direction () == Gtk.TextDirection.RTL);
                     if (rtl ? (x > rect.x + rect.width - icon_size) : (x < rect.x + icon_size)) { /* cannot be on name */
                         bool on_helper = false;
-                        bool on_icon = is_on_icon (x, y, rect, file.pix, rtl, ref on_helper);
+                        /* In the case of GtkTreeView, we must adjust for scrolling */
+                        y += (int)(get_vadjustment ().get_value ());
+                        bool on_icon = is_on_icon (x, y, ref on_helper);
 
                         if (on_helper) {
                             zone = ClickZone.HELPER;

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -240,8 +240,6 @@ namespace FM {
                     var rtl = (get_direction () == Gtk.TextDirection.RTL);
                     if (rtl ? (x > rect.x + rect.width - icon_size) : (x < rect.x + icon_size)) { /* cannot be on name */
                         bool on_helper = false;
-                        /* In the case of GtkTreeView, we must adjust for scrolling */
-                        y += (int)(get_vadjustment ().get_value ());
                         bool on_icon = is_on_icon (x, y, ref on_helper);
 
                         if (on_helper) {

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -231,12 +231,11 @@ namespace FM {
                 tree.get_cell_rect (p, r, out rect);
                 area = r.get_aligned_area (tree, Gtk.CellRendererState.PRELIT, rect);
 
-                /* rectangles are in bin window coordinates - need to adjust event y coordinate
-                 * for vertical scrolling in order to accurately detect whicn area of item was
-                 * clicked on */
-                y -= (int)(get_vadjustment ().value);
-
                 if (r is Marlin.TextRenderer) {
+                    /* rectangles are in bin window coordinates - need to adjust event y coordinate
+                     * for vertical scrolling in order to accurately detect which area of TextRenderer was
+                     * clicked on */
+                    y -= (int)(get_vadjustment ().value);
                     Gtk.TreeIter iter;
                     model.get_iter (out iter, path);
                     string? text = null;
@@ -261,8 +260,9 @@ namespace FM {
                     bool on_helper = false;
                     GOF.File? file = model.file_for_path (p);
                     if (file != null) {
-                        /* RTL has no effect on is_on_icon in IconView so just pass false */
-                        bool on_icon = is_on_icon (x, y, rect, file.pix, false, ref on_helper);
+                        /* In the case of GtkIconView, the y coordinate does not need adjusting for scrolling
+                         * in order to match the icon renderer */
+                        bool on_icon = is_on_icon (x, y, ref on_helper);
 
                         if (on_helper) {
                             zone = ClickZone.HELPER;

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -260,8 +260,6 @@ namespace FM {
                     bool on_helper = false;
                     GOF.File? file = model.file_for_path (p);
                     if (file != null) {
-                        /* In the case of GtkIconView, the y coordinate does not need adjusting for scrolling
-                         * in order to match the icon renderer */
                         bool on_icon = is_on_icon (x, y, ref on_helper);
 
                         if (on_helper) {


### PR DESCRIPTION
Fixes  #612 

Properly allows for scrolling when determining click position using the IconRenderer via is_on_icon ().  IconView needs to be handled slightly differently.

The PR also loses some unused parameters in is_on_icon ().