### PR TITLE
More checks for null in MimeActions; correct some function signatures

### DIFF
--- a/src/Utils/MimeActions.vala
+++ b/src/Utils/MimeActions.vala
@@ -37,10 +37,10 @@ public class Marlin.MimeActions {
         return app;
     }
 
-    public static AppInfo? get_default_application_for_files (GLib.List<unowned GOF.File> files) {
+    public static AppInfo? get_default_application_for_files (GLib.List<GOF.File> files) {
         assert (files != null);
         /* Need to make a new list to avoid corrupting the selection */
-        GLib.List<unowned GOF.File> sorted_files = null;
+        GLib.List<GOF.File> sorted_files = null;
         files.@foreach ((file) => {
             sorted_files.prepend (file);
         });
@@ -87,7 +87,10 @@ public class Marlin.MimeActions {
             return result;
         }
 
+        /* For some reason this may return null even when a default app exists (e.g. for
+         * compressed files */
         result = AppInfo.get_all_for_type (type);
+
         string uri_scheme = file.location.get_uri_scheme ();
 
         if (uri_scheme != null) {
@@ -96,6 +99,10 @@ public class Marlin.MimeActions {
             if (uri_handler != null) {
                 result.prepend (uri_handler);
             }
+        }
+
+        if (result == null) {
+            return null;
         }
 
         if (!file_has_local_path (file)) {
@@ -123,11 +130,15 @@ public class Marlin.MimeActions {
             result = filter_non_uri_apps (result);
         }
 
+        if (result == null) {
+            return null;
+        }
+
         result.sort (application_compare_by_name);
         return result;
     }
 
-    public static List<AppInfo>? get_applications_for_files (GLib.List<unowned GOF.File> files) {
+    public static List<AppInfo>? get_applications_for_files (GLib.List<GOF.File> files) {
         assert (files != null);
         /* Need to make a new list to avoid corrupting the selection */
         GLib.List<unowned GOF.File> sorted_files = null;
@@ -143,6 +154,10 @@ public class Marlin.MimeActions {
         foreach (unowned GOF.File file in sorted_files) {
             if (previous_file == null) {
                 result = get_applications_for_file (file);
+                if (result == null) {
+                    debug ("No application found for %s", file.get_ftype ());
+                    return null;
+                }
                 previous_file = file;
                 continue;
             }
@@ -167,6 +182,10 @@ public class Marlin.MimeActions {
             }
 
             previous_file = file;
+        }
+
+        if (result == null) {
+            return null;
         }
 
         result.sort (application_compare_by_name);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -478,7 +478,7 @@ namespace FM {
             return open_with_apps;
         }
 
-        public unowned GLib.AppInfo get_default_app () {
+        public GLib.AppInfo get_default_app () {
             return default_app;
         }
 
@@ -2047,13 +2047,12 @@ namespace FM {
         }
 
         private GLib.MenuModel? build_menu_open (ref Gtk.Builder builder) {
-
             var menu = new GLib.Menu ();
             GLib.MenuModel? app_submenu;
 
             string label = _("Invalid");
-            unowned GLib.List<unowned GOF.File> selection = get_files_for_action ();
-            unowned GOF.File selected_file = selection.data;
+            unowned GLib.List<GOF.File> selection = get_files_for_action ();
+            GOF.File selected_file = selection.data;
 
             if (can_open_file (selected_file)) {
                 if (!selected_file.is_folder () && selected_file.is_executable ()) {
@@ -2097,6 +2096,7 @@ namespace FM {
 
             if (can_open_file (selection.data)) {
                 open_with_apps = Marlin.MimeActions.get_applications_for_files (selection);
+
                 if (selection.data.is_executable () == false) {
                     filter_default_app_from_open_with_apps ();
                 }
@@ -3343,7 +3343,7 @@ namespace FM {
                     update_selected_files_and_menu ();
                     unblock_drag_and_drop ();
                     start_drag_timer (event);
-                    
+
                     result = handle_secondary_button_click (event);
                     break;
 


### PR DESCRIPTION
Fixes #632 

Checks whether AppInfo.get_all_for_type () returns null (which it does for compressed files for some reason).

Also corrects the signature of some related functions which did not match the parameters used by the calling functions.