### PR TITLE
Suppress empty context menu on Connect Server Item

### DIFF
--- a/src/View/Sidebar.vala
+++ b/src/View/Sidebar.vala
@@ -1504,8 +1504,7 @@ namespace Marlin.Places {
             bool show_property = show_mount || show_unmount || show_eject || uri == "file:///";
 
             if (is_plugin) {
-                var menu = new PopupMenuBuilder ();
-                menu.build ().popup_at_pointer (event);
+                /* TODO Implement sidebar plugin interface for context menu */
             } else {
                 var menu = new PopupMenuBuilder ()
                 .add_open (open_shortcut_cb)


### PR DESCRIPTION
Fixes #654 
A quick fix for linked issue, (only sidebar plugin at present is Connect Server, which has no context menu - it just opens a dialog), pending refactoring of sidebar plugin interface to implement cloud provider plugins. 