### PR TITLE
Select with secondary button on helper (#663)

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3332,7 +3332,8 @@ namespace FM {
                 case Gdk.BUTTON_SECONDARY: // button 3
                     if (click_zone == ClickZone.NAME ||
                         click_zone == ClickZone.BLANK_PATH ||
-                        click_zone == ClickZone.ICON) {
+                        click_zone == ClickZone.ICON ||
+                        click_zone == ClickZone.HELPER) {
 
                         select_path (path);
                     } else if (click_zone == ClickZone.INVALID) {


### PR DESCRIPTION
Fixes #663

Makes sure the file item is selected first when dragging with secondary button.

Probably should also armour DnD code against dragging with an empty selection list, but that is left for another PR.