### PR TITLE
Allow dragging item with helper if not multi-selecting.

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3298,6 +3298,7 @@ namespace FM {
                                     select_path (path, true); /* Cursor follow and selection preserved */
                                 }
 
+                                unblock_drag_and_drop ();
                                 result = true; /* Prevent rubberbanding and deselection of other paths */
                             }
                             break;


### PR DESCRIPTION
It is currently only possible to drag on the helper using the secondary button but not using the primary button.

This fixes the inconsistency by allowing dragging with both (except when multi-selecting).