### PR TITLE
Add previously non-existing folders to directory cache after reloading successfully

### DIFF
--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -405,8 +405,8 @@ public class Async : Object {
                                                                            file.is_connected.to_string (),
                                                                            file.is_mounted.to_string (),
                                                                            file.exists.to_string ());
-
-            directory_cache.remove (creation_key);
+            Async.directory_cache.remove (creation_key);
+            is_ready = false;
             after_loading (file_loaded_func);
             return;
         }
@@ -419,15 +419,14 @@ public class Async : Object {
              * in some cases. dir_cache will always have been created via call to public static
              * functions from_file () or from_gfile (). Do not add toggle until cached. */
 
-            dir_cache_lock.@lock ();
-
+            Async.dir_cache_lock.@lock ();
             this.add_toggle_ref ((ToggleNotify) toggle_ref_notify);
 
-            if (!creation_key.equal (location)) {
-                directory_cache.insert (location.dup (), this);
+            if (!creation_key.equal (location) || Async.directory_cache.lookup (location) == null) {
+                Async.directory_cache.insert (location.dup (), this);
             }
 
-            dir_cache_lock.unlock ();
+            Async.dir_cache_lock.unlock ();
         }
 
         /* The following can run on reloading */

--- a/src/ClipboardManager.vala
+++ b/src/ClipboardManager.vala
@@ -134,7 +134,6 @@ namespace Marlin {
                                         Gtk.Widget? widget = null,
                                         GLib.Callback? new_files_callback = null) {
 
-
             /* check whether the retrieval worked */
             string? text;
             if (!DndHandler.selection_data_is_uri_list (sd, Marlin.TargetType.TEXT_URI_LIST, out text)) {


### PR DESCRIPTION
Fixes #681 

After a previous change a while back,  DirectoryAsync objects that cannot load are removed from the directory cache but were not being added back after being created and reloaded. The linked PR is a side-effect of that (there may be others).

This PR fixes that.