### PR TITLE
Use Granite for tooltip accels

### DIFF
--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -117,12 +117,12 @@ namespace Marlin.View.Chrome {
 
         protected void set_action_icon_tooltip (string? tip) {
             if (secondary_icon_pixbuf != null && tip != null && tip.length > 0) {
-                set_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY, tip);
+                set_icon_tooltip_markup (Gtk.EntryIconPosition.SECONDARY, tip);
             }
         }
         public string? get_action_icon_tooltip () {
             if (secondary_icon_pixbuf != null) {
-                return get_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY);
+                return get_icon_tooltip_markup (Gtk.EntryIconPosition.SECONDARY);
             } else {
                 return null;
             }
@@ -276,21 +276,21 @@ namespace Marlin.View.Chrome {
 
             string? tip = null;
             if (secondary_icon_pixbuf != null) {
-                tip = get_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY);
+                tip = get_icon_tooltip_markup (Gtk.EntryIconPosition.SECONDARY);
             }
-            set_tooltip_text ("");
+            set_tooltip_markup ("");
             var el = get_element_from_coordinates ((int)event.x, (int)event.y);
             if (el != null) {
-                set_tooltip_text (_("Go to %s").printf (el.text_for_display));
+                set_tooltip_markup (_("Go to %s").printf (el.text_for_display));
                 set_entry_cursor (new Gdk.Cursor.from_name (Gdk.Display.get_default (), "default"));
             } else {
                 set_entry_cursor (null);
-                set_tooltip_text (_("Search or Type Path"));
+                set_tooltip_markup (_("Search or Type Path"));
             }
 
             if (tip != null) {
             /* We must reset the icon tooltip as the above line turns all tooltips off */
-                set_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY, tip);
+                set_icon_tooltip_markup (Gtk.EntryIconPosition.SECONDARY, tip);
             }
             return false;
         }

--- a/libwidgets/Chrome/ViewSwitcher.vala
+++ b/libwidgets/Chrome/ViewSwitcher.vala
@@ -77,17 +77,17 @@ namespace Marlin.View.Chrome {
             switcher.halign = switcher.valign = Gtk.Align.CENTER;
 
             icon = new Gtk.Image.from_icon_name ("view-grid-symbolic", Gtk.IconSize.MENU);
-            icon.tooltip_text = _("View as Grid")+" (Ctrl + 1)";
+            icon.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>1"}, _("View as Grid"));
             switcher.append (icon);
             icon_sv = new GLib.Variant.string ("ICON");
 
             list = new Gtk.Image.from_icon_name ("view-list-symbolic", Gtk.IconSize.MENU);
-            list.tooltip_text = _("View as List")+" (Ctrl + 2)";
+            list.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>2"}, _("View as List"));
             switcher.append (list);
             list_sv = new GLib.Variant.string ("LIST");
 
             miller = new Gtk.Image.from_icon_name ("view-column-symbolic", Gtk.IconSize.MENU);
-            miller.tooltip_text = _("View in Columns")+" (Ctrl + 3)";
+            miller.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>3"}, _("View in Columns"));
             switcher.append (miller);
             miller_sv = new GLib.Variant.string ("MILLER");
 
@@ -111,3 +111,4 @@ namespace Marlin.View.Chrome {
         }
     }
 }
+

--- a/src/View/Sidebar.vala
+++ b/src/View/Sidebar.vala
@@ -516,7 +516,7 @@ namespace Marlin.Places {
                        null,
                        null,
                        0,
-                       _("Open your personal folder") + " (Alt + Home)");
+                       Granite.markup_accel_tooltip ({"<Alt>Home"}, _("Open your personal folder")));
 
             n_builtins_before++;
 
@@ -564,7 +564,7 @@ namespace Marlin.Places {
                            null,
                            null,
                            index + n_builtins_before,
-                           _("Open the Trash") + " (Alt + T)");
+                           Granite.markup_accel_tooltip ({"<Alt>T"}, _("Open the Trash")));
             }
 
             /* ADD STORAGE CATEGORY*/
@@ -737,10 +737,10 @@ namespace Marlin.Places {
                            null,
                            null,
                            0,
-                           _("Browse the contents of the network") + " (Alt + N)");
+                           Granite.markup_accel_tooltip ({"<Alt>N"}, _("Browse the contents of the network")));
 
                 /* Add ConnectServer BUILTIN */
-                add_extra_network_item (_("Connect Server"), _("Connect to a network server") + " (Alt + C)", new ThemedIcon.with_default_fallbacks ("network-server"), side_bar_connect_server);
+                add_extra_network_item (_("Connect Server"), Granite.markup_accel_tooltip ({"<Alt>C"}, _("Connect to a network server")), new ThemedIcon.with_default_fallbacks ("network-server"), side_bar_connect_server);
 
                 plugins.update_sidebar ((Gtk.Widget)this);
             }

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -189,7 +189,7 @@ namespace Marlin.View.Chrome {
         protected void show_refresh_icon () {
             bread.get_style_context ().remove_class ("spin");
             bread.action_icon_name = Marlin.ICON_PATHBAR_SECONDARY_REFRESH_SYMBOLIC;
-            bread.set_action_icon_tooltip (_("Reload this folder") + " (Ctrl + R)");
+            bread.set_action_icon_tooltip (Granite.markup_accel_tooltip ({"F5", "<Ctrl>R"}, _("Reload this folder")));
         }
 
         private void show_placeholder () {

--- a/src/View/Widgets/TopMenu.vala
+++ b/src/View/Widgets/TopMenu.vala
@@ -58,16 +58,15 @@ namespace Marlin.View.Chrome {
         public TopMenu (ViewSwitcher switcher) {
             button_back = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
             button_forward = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-            button_back.tooltip_text = _("Previous") + " (Alt + ←)";
+            button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
             button_back.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
             button_back.show_all ();
             pack_start (button_back);
 
-            button_forward.tooltip_text = _("Next") + " (Alt + →)";
+            button_forward.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Right"}, _("Next"));
             button_forward.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
             button_forward.show_all ();
             pack_start (button_forward);
-
 
             button_forward.slow_press.connect (() => {
                 forward (1);


### PR DESCRIPTION
- [ ] Depends on new Granite release for `Granite.markup_accel_tooltip ()`.