### PR TITLE
Use GLib.Source.REMOVE and  GLib.Source.CONTINUE

### DIFF
--- a/libcore/Thumbnailer.vala
+++ b/libcore/Thumbnailer.vala
@@ -280,7 +280,7 @@ namespace Marlin {
             /* TODO batch up errors? */
             idle.id = GLib.Idle.add_full (GLib.Priority.LOW, () => {
                 handle_error_idle (idle);
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -301,7 +301,7 @@ namespace Marlin {
                 /* TODO batch up errors? */
                 idle.id = GLib.Idle.add_full (GLib.Priority.HIGH, () => {
                     handle_ready_idle (idle);
-                    return false;
+                    return GLib.Source.REMOVE;
                 });
             } else {
                 warning ("no ready uris");
@@ -317,7 +317,7 @@ namespace Marlin {
             /* TODO batch up errors? */
             idle.id = GLib.Idle.add_full (GLib.Priority.LOW, () => {
                 handle_finished_idle (idle);
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -318,7 +318,7 @@ public class Async : Object {
 
                     return GLib.Source.REMOVE;
                 } else {
-                    return true;
+                    return GLib.Source.CONTINUE;
                 }
             });
 

--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -271,8 +271,9 @@ public class Async : Object {
                 cancellable.cancel ();
                 last_error_message = "Timed out while querying file info";
             }
+
             load_timeout_id = 0;
-            return false;
+            return GLib.Source.REMOVE;
         });
 
         bool success = yield query_info_async (file, null, cancellable);
@@ -315,7 +316,7 @@ public class Async : Object {
                     state = State.TIMED_OUT;
                     cancellable.cancel ();
 
-                    return false;
+                    return GLib.Source.REMOVE;
                 } else {
                     return true;
                 }
@@ -651,7 +652,7 @@ public class Async : Object {
                         load_timeout_id = 0;
                         cancellable.cancel ();
                         load_timeout_id = 0;
-                        return false;
+                        return GLib.Source.REMOVE;
                     });
 
                     var files = yield e.next_files_async (1000, GLib.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, cancellable);
@@ -957,7 +958,7 @@ public class Async : Object {
             idle_consume_changes_id = Timeout.add (10, () => {
                 MarlinFile.changes_consume_changes (true);
                 idle_consume_changes_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
     }

--- a/libcore/tests/MarlinIconInfoTests/MarlinIconInfoTests.vala
+++ b/libcore/tests/MarlinIconInfoTests/MarlinIconInfoTests.vala
@@ -66,7 +66,7 @@ void themed_cache_and_ref_test () {
         /* Icons should NOT be reaped yet */
         assert (Marlin.IconInfo.themed_icon_cache_info () == 1);
         loop.quit ();
-        return false;
+        return GLib.Source.REMOVE;
     });
     loop.run ();
 
@@ -77,7 +77,7 @@ void themed_cache_and_ref_test () {
         /* Icon should be reaped by now */
         assert (Marlin.IconInfo.themed_icon_cache_info () == 0);
         loop.quit ();
-        return false;
+        return GLib.Source.REMOVE;
     });
     loop.run ();
 }
@@ -113,7 +113,7 @@ void loadable_cache_and_ref_test () {
         /* Icons should NOT be reaped yet */
         assert (Marlin.IconInfo.loadable_icon_cache_info () == 1);
         loop.quit ();
-        return false;
+        return GLib.Source.REMOVE;
     });
     loop.run ();
 
@@ -124,7 +124,7 @@ void loadable_cache_and_ref_test () {
         /* Icon should be reaped by now */
         assert (Marlin.IconInfo.loadable_icon_cache_info () == 0);
         loop.quit ();
-        return false;
+        return GLib.Source.REMOVE;
     });
     loop.run ();
 }

--- a/libwidgets/Animations/Animations.vala
+++ b/libwidgets/Animations/Animations.vala
@@ -39,14 +39,14 @@ namespace Marlin.Animation {
             /* If the user move it at the same time, just stop the animation */
             if (old_adj_value != adj.value) {
                 timeout_source_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             }
 
             if (newvalue >= to_do - 10) {
                 /* to be sure that there is not a little problem */
                 adj.value = final;
                 timeout_source_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             }
 
             newvalue += 10;

--- a/libwidgets/Animations/Animations.vala
+++ b/libwidgets/Animations/Animations.vala
@@ -55,7 +55,7 @@ namespace Marlin.Animation {
                         Math.sin (((double) newvalue / (double) to_do) * Math.PI / 2) * to_do;
 
             old_adj_value = adj.value;
-            return true;
+            return GLib.Source.CONTINUE;
         });
     }
 }

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -303,6 +303,7 @@ namespace Marlin.View.Chrome {
                     focus_out_event (event);
                     return GLib.Source.REMOVE;
                 });
+
                 return true;
             } else {
                 /* This the delayed propagated event */
@@ -605,7 +606,7 @@ namespace Marlin.View.Chrome {
                     }
 
                     queue_draw ();
-                    return true;
+                    return GLib.Source.CONTINUE;
                 }
             });
 

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -301,7 +301,7 @@ namespace Marlin.View.Chrome {
                 /* Delay acting on focus out - may be temporary, due to keyboard layout change */
                 focus_out_timeout_id = GLib.Timeout.add (10, () => {
                     focus_out_event (event);
-                    return false;
+                    return GLib.Source.REMOVE;
                 });
                 return true;
             } else {
@@ -594,18 +594,21 @@ namespace Marlin.View.Chrome {
                     foreach (BreadcrumbElement bread in els) {
                         bread.offset = final_offset;
                     }
+
                     old_elements = null;
                     queue_draw ();
                     animation_timeout_id = 0;
-                    return false;
+                    return GLib.Source.REMOVE;
                 } else {
                     foreach (BreadcrumbElement bread in els) {
                         bread.offset = anim_state;
                     }
+
                     queue_draw ();
                     return true;
                 }
             });
+
             return anim;
         }
 

--- a/libwidgets/Chrome/ButtonWithMenu.vala
+++ b/libwidgets/Chrome/ButtonWithMenu.vala
@@ -178,7 +178,7 @@ namespace Marlin.View.Chrome {
                     /* long click */
                     timeout = 0;
                     popup_menu (ev);
-                    return false;
+                    return GLib.Source.REMOVE;
                 });
             }
 

--- a/libwidgets/View/SearchResults.vala
+++ b/libwidgets/View/SearchResults.vala
@@ -328,7 +328,7 @@ namespace Marlin.View.Chrome {
                 }
 
                 send_search_finished ();
-                return false;
+                return GLib.Source.REMOVE;
             });
 
             new Thread<void*> (null, () => {

--- a/libwidgets/View/SearchResults.vala
+++ b/libwidgets/View/SearchResults.vala
@@ -980,7 +980,7 @@ namespace Marlin.View.Chrome {
                 /* use a closure here to get vala to pass the userdata that we actually want */
                 Idle.add (() => {
                     add_results (new_results, in_root ? local_results : deep_results);
-                    return false;
+                    return GLib.Source.REMOVE;
                 });
 
                 if (category_count >= MAX_RESULTS) {

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -183,7 +183,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         t_consume_knowns = Timeout.add (300, () => {
                                         consume_knowns_queue.begin ();
                                         t_consume_knowns = 0;
-                                        return false;
+                                        return GLib.Source.REMOVE;
                                         });
     }
 

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -195,10 +195,10 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
 
             if (idle_consume_unknowns == 0) {
                 idle_consume_unknowns = Idle.add (() => {
-                                                  consume_unknowns_queue.begin ();
-                                                  idle_consume_unknowns = 0;
-                                                  return false;
-                                                  });
+                      consume_unknowns_queue.begin ();
+                      idle_consume_unknowns = 0;
+                      return GLib.Source.REMOVE;
+                  });
             }
         }
     }

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -835,7 +835,7 @@ public class PropertiesWindow : AbstractPropertiesDialog {
                 }
                 timeout_perm = 0;
 
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
     }

--- a/src/ProgressUIHandler.vala
+++ b/src/ProgressUIHandler.vala
@@ -81,14 +81,14 @@ public class Marlin.Progress.UIHandler : Object {
             if (info == null || !(info is PF.Progress.Info) ||
                 info.get_is_finished () || info.get_cancellable ().is_cancelled ()) {
 
-                return false;
+                return GLib.Source.REMOVE;
             }
 
             if (info.get_is_paused ()) {
                 return true;
             } else if (operation_running && !info.get_is_finished ()) {
                 add_progress_info_to_window (info);
-                return false;
+                return GLib.Source.REMOVE;
             } else {
                 operation_running = true;
                 return true;
@@ -162,7 +162,8 @@ public class Marlin.Progress.UIHandler : Object {
                 if (!application.get_active_window ().has_toplevel_focus) {
                     show_operation_complete_notification (info, active_infos < 1);
                 }
-                return false;
+
+                return GLib.Source.REMOVE;
             });
         } else {
             warning ("Attempt to decrement zero active infos");

--- a/src/ProgressUIHandler.vala
+++ b/src/ProgressUIHandler.vala
@@ -85,13 +85,13 @@ public class Marlin.Progress.UIHandler : Object {
             }
 
             if (info.get_is_paused ()) {
-                return true;
+                return GLib.Source.CONTINUE;
             } else if (operation_running && !info.get_is_finished ()) {
                 add_progress_info_to_window (info);
                 return GLib.Source.REMOVE;
             } else {
                 operation_running = true;
-                return true;
+                return GLib.Source.CONTINUE;
             }
         });
     }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -918,7 +918,7 @@ namespace FM {
                     if (signal_free_space_change) {
                         add_remove_file_timeout_id = 0;
                         window.free_space_change ();
-                        return false;
+                        return GLib.Source.REMOVE;
                     } else {
                         signal_free_space_change = true;
                         return true;
@@ -1782,7 +1782,7 @@ namespace FM {
 
                             load_location (file.get_target_location ());
                             drag_enter_timer_id = 0;
-                            return false;
+                            return GLib.Source.REMOVE;
                         });
                     }
                 }
@@ -1850,7 +1850,7 @@ namespace FM {
                                                    drag_delay,
                                                    () => {
                 on_drag_timeout_button_release ((Gdk.EventButton)event);
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -2478,7 +2478,7 @@ namespace FM {
                 }
                 thaw_child_notify ();
                 freeze_source_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             });
 
             /* Views with a large number of files take longer to redraw (especially IconView) so
@@ -2545,7 +2545,7 @@ namespace FM {
 
                 /* This is the only place that new thumbnail files are created */
                 /* Do not trigger a thumbnail request unless there are unthumbnailed files actually visible
-                 * and there has not been another event (which would zero the thumbnail_source_if) */
+                 * and there has not been another event (which would zero the thumbnail_source_id) */
                 if (actually_visible > 0 && thumbnail_source_id > 0) {
                     thumbnailer.queue_files (visible_files, out thumbnail_request, large_thumbnails);
                 } else {
@@ -2554,7 +2554,7 @@ namespace FM {
 
                 thumbnail_source_id = 0;
 
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -2570,7 +2570,7 @@ namespace FM {
             draw_timeout_id = Timeout.add (100, () => {
                 draw_timeout_id = 0;
                 view.queue_draw ();
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -3494,7 +3494,7 @@ namespace FM {
                 /* set cursor_on_cell also triggers editing-started */
                 name_renderer.editable = true;
                 set_cursor_on_cell (path, name_renderer as Gtk.CellRenderer, true, false);
-                return false;
+                return GLib.Source.REMOVE;
             });
 
         }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -921,7 +921,7 @@ namespace FM {
                         return GLib.Source.REMOVE;
                     } else {
                         signal_free_space_change = true;
-                        return true;
+                        return GLib.Source.CONTINUE;
                     }
                 });
             } else {
@@ -2474,7 +2474,7 @@ namespace FM {
             freeze_child_notify ();
             freeze_source_id = Timeout.add (100, () => {
                 if (thumbnail_source_id > 0) {
-                    return true;
+                    return GLib.Source.CONTINUE;
                 }
                 thaw_child_notify ();
                 freeze_source_id = 0;
@@ -2616,7 +2616,7 @@ namespace FM {
 
                 scroll_if_near_edge (y, h, 20, get_vadjustment ());
                 scroll_if_near_edge (x, w, 20, get_hadjustment ());
-                return true;
+                return GLib.Source.CONTINUE;
             });
         }
 
@@ -3485,10 +3485,10 @@ namespace FM {
                 if (start_path == null || (count < 20 && start.compare (start_path) != 0)) {
                     start_path = start;
                     ok_next_time = false;
-                    return true;
+                    return GLib.Source.CONTINUE;
                 } else if (!ok_next_time) {
                     ok_next_time = true;
-                    return true;
+                    return GLib.Source.CONTINUE;
                 }
 
                 /* set cursor_on_cell also triggers editing-started */

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -425,9 +425,9 @@ namespace FM {
                 Idle.add_full (GLib.Priority.LOW, () => {
                     if (!tree_frozen) {
                         set_cursor (new Gtk.TreePath.from_indices (0), false, select, true);
-                        return false;
+                        return GLib.Source.REMOVE;
                     } else {
-                        return true;
+                        return GLib.Source.CONTINUE;
                     }
                 });
             }
@@ -447,9 +447,9 @@ namespace FM {
             Idle.add_full (GLib.Priority.LOW, () => {
                 if (!tree_frozen) {
                     select_file_paths (file_list, focus);
-                    return false;
+                    return GLib.Source.REMOVE;
                 } else {
-                    return true;
+                    return GLib.Source.CONTINUE;
                 }
             });
         }
@@ -548,19 +548,19 @@ namespace FM {
 
                             GLib.Idle.add (() => {
                                 activate_file (file, screen, flag, false);
-                                return false;
+                                return GLib.Source.REMOVE;
                             });
                         } else {
                             GLib.Idle.add (() => {
                                 open_file (file, screen, null);
-                                return false;
+                                return GLib.Source.REMOVE;
                             });
                         }
                     }
                 } else if (default_app != null) {
                     GLib.Idle.add (() => {
                         open_files_with (default_app, selection);
-                        return false;
+                        return GLib.Source.REMOVE;
                     });
                 }
             } else {
@@ -1003,7 +1003,7 @@ namespace FM {
             Idle.add (() => {
                 view.set_cursor (view.deleted_path, false, false, false);
                 view.unblock_directory_monitor ();
-                return false;
+                return GLib.Source.REMOVE;
             });
 
         }
@@ -1013,7 +1013,7 @@ namespace FM {
              * and one via marlin-file-changes. */
             GLib.Idle.add_full (GLib.Priority.LOW, () => {
                 slot.directory.unblock_monitor ();
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -1256,7 +1256,7 @@ namespace FM {
                 });
 
                 view.select_glib_files_when_thawed (pasted_files_list, pasted_files_list.first ().data);
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -2982,7 +2982,7 @@ namespace FM {
 
             Idle.add (() => {
                 update_selected_files_and_menu ();
-                return false;
+                return GLib.Source.REMOVE;
             });
 
             return res;
@@ -3425,14 +3425,14 @@ namespace FM {
                                                                        Marlin.OpenFlag.DEFAULT;
 
                         activate_selected_items (flag);
-                        return false;
+                        return GLib.Source.REMOVE;
                     });
                 } else if (should_deselect && click_path != null) {
                     unselect_path (click_path);
                     /* Only need to update selected files if changed by this handler */
                     Idle.add (() => {
                         update_selected_files_and_menu ();
-                        return false;
+                        return GLib.Source.REMOVE;
                     });
                 } else if (event.button == Gdk.BUTTON_SECONDARY) {
                     show_context_menu (event);

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -151,7 +151,7 @@ namespace FM {
                     is_frozen = true;
                     double_click_timeout_id = GLib.Timeout.add (drag_delay, () => {
                         not_double_click (event, path);
-                        return false;
+                        return GLib.Source.REMOVE;
                     });
                 }
             } else if (event.type == Gdk.EventType.@2BUTTON_PRESS) {

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -466,7 +466,7 @@ namespace Marlin.View {
             scroll_to_slot_timeout_id = GLib.Timeout.add (200, () => {
                 if (scroll_to_slot (slot, animate)) {
                     scroll_to_slot_timeout_id = 0;
-                    return false;
+                    return GLib.Source.REMOVE;
                 } else {
                     return true;
                 }

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -468,7 +468,7 @@ namespace Marlin.View {
                     scroll_to_slot_timeout_id = 0;
                     return GLib.Source.REMOVE;
                 } else {
-                    return true;
+                    return GLib.Source.CONTINUE;
                 }
             });
         }

--- a/src/View/Sidebar.vala
+++ b/src/View/Sidebar.vala
@@ -301,12 +301,12 @@ namespace Marlin.Places {
                 bool spinner_active;
 
                 if (!store.iter_is_valid (iter)) {
-                    return false;
+                    return GLib.Source.REMOVE;
                 }
 
                 store.@get (iter, Column.SHOW_SPINNER, out spinner_active);
                 if (!spinner_active) {
-                    return false;
+                    return GLib.Source.REMOVE;
                 }
 
                 store.@get (iter, Column.SPINNER_PULSE, out val);
@@ -2170,7 +2170,7 @@ namespace Marlin.Places {
             Timeout.add (300, () => {
                 connect_volume_monitor_signals ();
                 update_places ();
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 

--- a/src/View/Sidebar.vala
+++ b/src/View/Sidebar.vala
@@ -311,7 +311,7 @@ namespace Marlin.Places {
 
                 store.@get (iter, Column.SPINNER_PULSE, out val);
                 store.@set (iter, Column.SPINNER_PULSE, ++val);
-                return true;
+                return GLib.Source.CONTINUE;
             });
         }
 

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -212,10 +212,10 @@ namespace Marlin.View {
                 return;
             }
 
-            reload_timeout_id = Timeout.add (100, ()=> {
+            reload_timeout_id = Timeout.add (100, () => {
                 directory.reload ();
                 reload_timeout_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -570,7 +570,7 @@ namespace Marlin.View.Chrome {
                     button_press_timeout_id = Timeout.add (Marlin.BUTTON_LONG_PRESS, () => {
                         load_right_click_menu (event, el);
                         button_press_timeout_id = 0;
-                        return false;
+                        return GLib.Source.REMOVE;
                     });
                 }
             }

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -274,7 +274,7 @@ namespace Marlin.View.Chrome {
             focus_timeout_id = GLib.Timeout.add (300, () => {
                 focus_file_request (file);
                 focus_timeout_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
     }

--- a/src/View/Widgets/OverlayBar.vala
+++ b/src/View/Widgets/OverlayBar.vala
@@ -67,7 +67,7 @@ namespace Marlin.View {
 
                 real_update (selected_files);
                 update_timeout_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -110,7 +110,7 @@ namespace Marlin.View {
                 }
 
                 hover_timeout_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -262,7 +262,7 @@ namespace Marlin.View {
                 });
 
                 deep_count_timeout_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -552,7 +552,7 @@ namespace Marlin.View {
             closing_timeout_id = Timeout.add (50, () => {
                 tab.close ();
                 closing_timeout_id = 0;
-                return false;
+                return GLib.Source.REMOVE;
             });
         }
 
@@ -611,7 +611,7 @@ namespace Marlin.View {
                 add_window ();
                 GLib.Timeout.add (500, () => {
                     adding_window = false;
-                    return false;
+                    return GLib.Source.REMOVE;
                 });
             }
         }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -307,7 +307,7 @@ namespace Marlin.View {
 
                 Idle.add (() => {
                     remove_tab (vc);
-                    return false;
+                    return GLib.Source.REMOVE;
                 });
             });
 
@@ -466,7 +466,7 @@ namespace Marlin.View {
                                 Idle.add_full (GLib.Priority.LOW, () => {
                                     var unique_name = disambiguate_name (content_label, content_path, path);
                                     set_tab_label (unique_name, tab, content_path);
-                                    return false;
+                                    return GLib.Source.REMOVE;
                                 });
                             }
                         }
@@ -477,7 +477,7 @@ namespace Marlin.View {
                         /* Revert to short label when possible */
                         Idle.add_full (GLib.Priority.LOW, () => {
                             set_tab_label (content_label, tab, content_path);
-                            return false;
+                            return GLib.Source.REMOVE;
                         });
                     }
                 }


### PR DESCRIPTION
To improve clarity, `return false` and ` return true` are replaced by `return GLib.Source.REMOVE` and  `return GLib.Source.CONTINUE` in Source closures.

A few drive-by code-style improvements are made.