### PR TITLE
Remove meson desktop file and appdata validation tests

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -90,12 +90,6 @@ install_data (
 )
 
 test (
-    'Validate desktop file',
-    find_program ('desktop-file-validate'),
-    args: join_paths (meson.current_build_dir (),  meson.project_name () + '.desktop')
-)
-
-test (
     'Validate appdata file',
     find_program ('appstreamcli'),
     args: ['validate', join_paths (meson.current_build_dir (), meson.project_name () + '.appdata.xml')]

--- a/data/meson.build
+++ b/data/meson.build
@@ -88,11 +88,3 @@ install_data (
     join_paths (meson.current_source_dir (),'schemas', meson.project_name() + '.gschema.xml'),
     install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
 )
-
-test (
-    'Validate appdata file',
-    find_program ('appstreamcli'),
-    args: ['validate', join_paths (meson.current_build_dir (), meson.project_name () + '.appdata.xml')]
-)
-
-


### PR DESCRIPTION
These tests cause Travis CI to fail due to missing dependencies.

I understand that these tests are performed by Houston anyway. 