### PR TITLE
Fix open with default for folders

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1111,7 +1111,7 @@ namespace FM {
         }
 
         private void on_selection_action_open_with_default (GLib.SimpleAction action, GLib.Variant? param) {
-            activate_selected_items (Marlin.OpenFlag.APP);
+            activate_selected_items (Marlin.OpenFlag.APP, get_files_for_action ());
         }
 
         private void on_selection_action_open_with_app (GLib.SimpleAction action, GLib.Variant? param) {


### PR DESCRIPTION
Open in Terminal is not working when you're not selecting any folder, but if you choose to Open in -> Terminal it works fine and opens Terminal in the (Not selected but current) Folder.