### PR TITLE
Fix back button accel tooltip

### DIFF
--- a/src/View/Widgets/TopMenu.vala
+++ b/src/View/Widgets/TopMenu.vala
@@ -60,7 +60,7 @@ namespace Marlin.View.Chrome {
                                                                                 Gtk.IconSize.LARGE_TOOLBAR);
             button_forward = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name ("go-next-symbolic",
                                                                                    Gtk.IconSize.LARGE_TOOLBAR);
-            button_back.tooltip_text = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
+            button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
             button_back.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
             button_back.show_all ();
             pack_start (button_back);


### PR DESCRIPTION
Fixes back button tooltip markup being set as `tooltip_text` instead of `tooltip_markup`:

![prev_tooltip](https://user-images.githubusercontent.com/2003017/49130830-d1bca080-f2e6-11e8-9584-b539e090e1e1.png)
