### PR TITLE
Icon in "Open with" menus

### DIFF
--- a/src/Utils/MimeActions.vala
+++ b/src/Utils/MimeActions.vala
@@ -101,10 +101,6 @@ public class Marlin.MimeActions {
             }
         }
 
-        if (result == null) {
-            return null;
-        }
-
         if (!file_has_local_path (file)) {
             filter_non_uri_apps (result);
         }
@@ -138,7 +134,7 @@ public class Marlin.MimeActions {
         return result;
     }
 
-    public static List<AppInfo>? get_applications_for_files (GLib.List<GOF.File> files) {
+    public static List<AppInfo> get_applications_for_files (GLib.List<GOF.File> files) {
         assert (files != null);
         /* Need to make a new list to avoid corrupting the selection */
         GLib.List<unowned GOF.File> sorted_files = null;
@@ -171,21 +167,17 @@ public class Marlin.MimeActions {
             GLib.List<AppInfo> one_result = get_applications_for_file (file);
             one_result.sort (application_compare_by_id);
 
-            if (result != null) {
+            if (result.length () > 0) {
                 result = intersect_application_lists (result, one_result);
             } else {
                 result = (owned) one_result;
             }
 
-            if (result == null) {
-                return null;
+            if (result.length () == 0) {
+                return result;
             }
 
             previous_file = file;
-        }
-
-        if (result == null) {
-            return null;
         }
 
         result.sort (application_compare_by_name);

--- a/src/Utils/MimeActions.vala
+++ b/src/Utils/MimeActions.vala
@@ -167,13 +167,13 @@ public class Marlin.MimeActions {
             GLib.List<AppInfo> one_result = get_applications_for_file (file);
             one_result.sort (application_compare_by_id);
 
-            if (result.length () > 0) {
+            if (result.data != null) {
                 result = intersect_application_lists (result, one_result);
             } else {
                 result = (owned) one_result;
             }
 
-            if (result.length () == 0) {
+            if (result.data == null) {
                 return result;
             }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2115,7 +2115,7 @@ namespace FM {
                         unowned string label = app_info.get_display_name ();
                         unowned string exec = app_info.get_executable ().split (" ")[0];
                         if (label != last_label || exec != last_exec) {
-                             var menu_item = new GLib.MenuItem (app_info.get_name (), "selection.open_with_app::" + index.to_string ());
+                             var menu_item = new GLib.MenuItem (app_info.get_name (), GLib.Action.print_detailed_name ("selection.open_with_app", new GLib.Variant.int32 (index)));
                             menu_item.set_icon (app_info.get_icon ());
                             apps_section.append_item (menu_item);
                             count++;

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2102,14 +2102,14 @@ namespace FM {
 
                 filter_this_app_from_open_with_apps ();
 
-                if (open_with_apps.length () > 0) {
+                if (open_with_apps.data != null) {
                     var apps_section = new GLib.Menu ();
                     int index = -1;
                     int count = 0;
                     string last_label = "";
                     string last_exec = "";
 
-                    foreach (var app_info in open_with_apps) {
+                    foreach (unowned AppInfo app_info in open_with_apps) {
                         index++;
                         /* Ensure no duplicate items */
                         unowned string label = app_info.get_display_name ();
@@ -2121,8 +2121,8 @@ namespace FM {
                             count++;
                         }
 
-                        last_label = label.dup ();
-                        last_exec = exec.dup ();
+                        last_label = label;
+                        last_exec = exec;
                     };
 
                     if (count >= 0) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2083,7 +2083,6 @@ namespace FM {
 
         private GLib.MenuModel? build_submenu_open_with_applications (ref Gtk.Builder builder,
                                                                       GLib.List<GOF.File> selection) {
-
             var open_with_submenu = new GLib.Menu ();
             open_with_apps = null;
 
@@ -2103,26 +2102,27 @@ namespace FM {
 
                 filter_this_app_from_open_with_apps ();
 
-                if (open_with_apps != null) {
+                if (open_with_apps.length () > 0) {
                     var apps_section = new GLib.Menu ();
                     int index = -1;
                     int count = 0;
                     string last_label = "";
                     string last_exec = "";
 
-                    foreach (var app in open_with_apps) {
+                    foreach (var app_info in open_with_apps) {
                         index++;
-                        if (app != null && app is AppInfo) {
-                            var label = app.get_display_name ();
-                            var exec = app.get_executable ().split (" ")[0];
-                            if (label != last_label || exec != last_exec) {
-                                apps_section.append (label, "selection.open_with_app::" + index.to_string ());
-                                count++;
-                            }
-
-                            last_label = label.dup ();
-                            last_exec = exec.dup ();
+                        /* Ensure no duplicate items */
+                        unowned string label = app_info.get_display_name ();
+                        unowned string exec = app_info.get_executable ().split (" ")[0];
+                        if (label != last_label || exec != last_exec) {
+                             var menu_item = new GLib.MenuItem (app_info.get_name (), "selection.open_with_app::" + index.to_string ());
+                            menu_item.set_icon (app_info.get_icon ());
+                            apps_section.append_item (menu_item);
+                            count++;
                         }
+
+                        last_label = label.dup ();
+                        last_exec = exec.dup ();
                     };
 
                     if (count >= 0) {

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -464,22 +464,19 @@ namespace Marlin.View.Chrome {
             foreach (AppInfo app_info in app_info_list) {
                 if (app_info != null && app_info.get_executable () != Environment.get_application_name ()) {
                     at_least_one = true;
-                    var menu_item = new Gtk.ImageMenuItem.with_label (app_info.get_name ());
+                     var item_grid = new Gtk.Grid ();
+                    item_grid.add (new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.MENU));
+                    item_grid.add (new Gtk.Label (app_info.get_name ()));
+                     var menu_item = new Gtk.MenuItem ();
+                    menu_item.add (item_grid);
                     menu_item.set_data ("appinfo", app_info);
-                    Icon icon;
-                    icon = app_info.get_icon ();
-                    if (icon == null) {
-                        icon = new ThemedIcon ("application-x-executable");
-                    }
-
-                    menu_item.set_image (new Gtk.Image.from_gicon (icon, Gtk.IconSize.MENU));
-                    menu_item.always_show_image = true;
                     menu_item.activate.connect (() => {
                         open_with_request (loc, app_info);
                     });
                     submenu_open_with.append (menu_item);
                 }
             }
+
             if (at_least_one) {
                 /* Then the "Open with" menuitem is added to the menu. */
                 var menu_open_with = new Gtk.MenuItem.with_label (_("Open with"));

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -465,7 +465,9 @@ namespace Marlin.View.Chrome {
                 if (app_info != null && app_info.get_executable () != Environment.get_application_name ()) {
                     at_least_one = true;
                      var item_grid = new Gtk.Grid ();
-                    item_grid.add (new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.MENU));
+                    var img = new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.MENU);
+                    img.pixel_size = 16;
+                    item_grid.add (img);
                     item_grid.add (new Gtk.Label (app_info.get_name ()));
                      var menu_item = new Gtk.MenuItem ();
                     menu_item.add (item_grid);


### PR DESCRIPTION
Icons are added to the "Open with" submenus in both the pathbar and view.

The simplest (smallest diff) method is used for each.  In the pathbar a grid is added to a GtkMenuItem.  In the view, a GLib.MenuItem is used, linked to the appropriate pre-existing action.

If necessary, GLibMenuItems and actions can be used in the pathbar too.

The unnecessary use of null instead of an empty list in a related function is removed.