### PR TITLE
Fix open with menu

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2115,7 +2115,7 @@ namespace FM {
                         unowned string label = app_info.get_display_name ();
                         unowned string exec = app_info.get_executable ().split (" ")[0];
                         if (label != last_label || exec != last_exec) {
-                             var menu_item = new GLib.MenuItem (app_info.get_name (), GLib.Action.print_detailed_name ("selection.open_with_app", new GLib.Variant.int32 (index)));
+                            var menu_item = new GLib.MenuItem (app_info.get_name (), "selection.open_with_app::" + index.to_string ());
                             menu_item.set_icon (app_info.get_icon ());
                             apps_section.append_item (menu_item);
                             count++;


### PR DESCRIPTION
#788 Uses GLib.Action.print_detailed_name instead of string, but GLib.Action.print_detailed_name doesn't work for action groups and returns null, so the whole "open with" menu isn't working.