### PR TITLE
Fix GLib.Action naming

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -54,11 +54,11 @@ namespace FM {
         /* Menu Handling */
         const GLib.ActionEntry [] selection_entries = {
             {"open", on_selection_action_open_executable},
-            {"open_with_app", on_selection_action_open_with_app, "s"},
-            {"open_with_default", on_selection_action_open_with_default},
-            {"open_with_other_app", on_selection_action_open_with_other_app},
+            {"open-with-app", on_selection_action_open_with_app, "u"},
+            {"open-with-default", on_selection_action_open_with_default},
+            {"open-with-other-app", on_selection_action_open_with_other_app},
             {"rename", on_selection_action_rename},
-            {"view_in_location", on_selection_action_view_in_location},
+            {"view-in-location", on_selection_action_view_in_location},
             {"forget", on_selection_action_forget},
             {"cut", on_selection_action_cut},
             {"trash", on_selection_action_trash},
@@ -68,21 +68,21 @@ namespace FM {
 
         const GLib.ActionEntry [] background_entries = {
             {"new", on_background_action_new, "s"},
-            {"create_from", on_background_action_create_from, "s"},
-            {"sort_by", on_background_action_sort_by_changed, "s", "'name'"},
+            {"create-from", on_background_action_create_from, "s"},
+            {"sort-by", on_background_action_sort_by_changed, "s", "'name'"},
             {"reverse", on_background_action_reverse_changed, null, "false"},
-            {"folders_first", on_background_action_folders_first_changed, null, "true"},
-            {"show_hidden", null, null, "false", change_state_show_hidden},
-            {"show_remote_thumbnails", null, null, "false", change_state_show_remote_thumbnails}
+            {"folders-first", on_background_action_folders_first_changed, null, "true"},
+            {"show-hidden", null, null, "false", change_state_show_hidden},
+            {"show-remote-thumbnails", null, null, "false", change_state_show_remote_thumbnails}
         };
 
         const GLib.ActionEntry [] common_entries = {
             {"copy", on_common_action_copy},
-            {"paste_into", on_common_action_paste_into},
-            {"open_in", on_common_action_open_in, "s"},
+            {"paste-into", on_common_action_paste_into},
+            {"open-in", on_common_action_open_in, "s"},
             {"bookmark", on_common_action_bookmark},
             {"properties", on_common_action_properties},
-            {"copy_link", on_common_action_copy_link}
+            {"copy-link", on_common_action_copy_link}
         };
 
         GLib.SimpleActionGroup common_actions;
@@ -223,7 +223,7 @@ namespace FM {
                 if (value && !_is_frozen) {
                     action_set_enabled (selection_actions, "cut", false);
                     action_set_enabled (common_actions, "copy", false);
-                    action_set_enabled (common_actions, "paste_into", false);
+                    action_set_enabled (common_actions, "paste-into", false);
 
                     /* Fix problems when navigating away from directory with large number
                      * of selected files (e.g. OverlayBar critical errors)
@@ -395,10 +395,10 @@ namespace FM {
             common_actions.add_action_entries (common_entries, this);
             insert_action_group ("common", common_actions);
 
-            action_set_state (background_actions, "show_hidden",
+            action_set_state (background_actions, "show-hidden",
                               Preferences.settings.get_boolean ("show-hiddenfiles"));
 
-            action_set_state (background_actions, "show_remote_thumbnails",
+            action_set_state (background_actions, "show-remote-thumbnails",
                               Preferences.settings.get_boolean ("show-remote-thumbnails"));
         }
 
@@ -1098,8 +1098,7 @@ namespace FM {
         }
 
         private void on_selection_action_open_with_app (GLib.SimpleAction action, GLib.Variant? param) {
-            var index = int.parse (param.get_string ());
-            open_files_with (open_with_apps.nth_data ((uint)index), get_files_for_action ());
+            open_files_with (open_with_apps.nth_data (param.get_uint32 ()), get_files_for_action ());
         }
 
         private void on_selection_action_open_with_other_app () {
@@ -1386,12 +1385,12 @@ namespace FM {
                 unblock_model ();
             }
 
-            action_set_state (background_actions, "show_hidden", show);
+            action_set_state (background_actions, "show-hidden", show);
         }
 
         private void on_show_remote_thumbnails_changed (GLib.Object prefs, GLib.ParamSpec pspec) {
             show_remote_thumbnails = (prefs as GOF.Preferences).show_remote_thumbnails;
-            action_set_state (background_actions, "show_remote_thumbnails", show_remote_thumbnails);
+            action_set_state (background_actions, "show-remote-thumbnails", show_remote_thumbnails);
             if (show_remote_thumbnails) {
                 slot.reload ();
             }
@@ -1934,7 +1933,7 @@ namespace FM {
                      * selection menu definition in directory_view_popup.ui may necessitate changing
                      * the index below.
                      */
-                    if (!action_get_enabled (common_actions, "paste_into") ||
+                    if (!action_get_enabled (common_actions, "paste-into") ||
                         clipboard == null || !clipboard.can_paste) {
                         clipboard_menu.remove (3); /* Paste into*/
                         clipboard_menu.remove (3); /* Past Link into*/
@@ -2061,7 +2060,7 @@ namespace FM {
                 } else if (default_app != null) {
                     if (default_app.get_id () != Marlin.APP_ID + ".desktop") {
                         label = (_("Open in %s")).printf (default_app.get_display_name ());
-                        menu.append (label, "selection.open_with_default");
+                        menu.append (label, "selection.open-with-default");
                     }
                 }
             }
@@ -2086,7 +2085,7 @@ namespace FM {
             var open_with_submenu = new GLib.Menu ();
             open_with_apps = null;
 
-            if (common_actions.get_action_enabled ("open_in")) {
+            if (common_actions.get_action_enabled ("open-in")) {
                 open_with_submenu.append_section (null, builder.get_object ("open-in") as GLib.MenuModel);
                 if (selection.data.is_mountable () || selection.data.is_root_network_folder ()) {
                     return open_with_submenu;
@@ -2104,35 +2103,33 @@ namespace FM {
 
                 if (open_with_apps != null && open_with_apps.data != null) {
                     var apps_section = new GLib.Menu ();
-                    int index = -1;
-                    int count = 0;
-                    string last_label = "";
-                    string last_exec = "";
+                    unowned string last_label = "";
+                    unowned string last_exec = "";
+                    uint count = 0;
 
                     foreach (unowned AppInfo app_info in open_with_apps) {
-                        index++;
                         /* Ensure no duplicate items */
                         unowned string label = app_info.get_display_name ();
                         unowned string exec = app_info.get_executable ().split (" ")[0];
                         if (label != last_label || exec != last_exec) {
-                             var menu_item = new GLib.MenuItem (app_info.get_name (), GLib.Action.print_detailed_name ("selection.open_with_app", new GLib.Variant.int32 (index)));
+                             var menu_item = new GLib.MenuItem (label, GLib.Action.print_detailed_name ("selection.open-with-app", new GLib.Variant.uint32 (count)));
                             menu_item.set_icon (app_info.get_icon ());
                             apps_section.append_item (menu_item);
-                            count++;
                         }
 
                         last_label = label;
                         last_exec = exec;
+                        count++;
                     };
 
-                    if (count >= 0) {
+                    if (apps_section.get_n_items () > 0) {
                         open_with_submenu.append_section (null, apps_section);
                     }
                 }
 
                 if (selection != null && selection.first ().next == null) { // Only one selected
                     var other_app_menu = new GLib.Menu ();
-                    other_app_menu.append ( _("Other Application…"), "selection.open_with_other_app");
+                    other_app_menu.append ( _("Other Application…"), "selection.open-with-other-app");
                     open_with_submenu.append_section (null, other_app_menu);
                 }
             }
@@ -2168,7 +2165,7 @@ namespace FM {
                     templates_menu.append_item (submenu);
                     templates_submenu = new GLib.Menu ();
                 } else {
-                    templates_submenu.append (label, "background.create_from::" + index.to_string ());
+                    templates_submenu.append (label, "background.create-from::" + index.to_string ());
                     count ++;
                 }
 
@@ -2229,21 +2226,21 @@ namespace FM {
             can_open = can_open_file (file);
             can_show_properties = !(in_recent && more_than_one_selected);
 
-            action_set_enabled (common_actions, "paste_into", can_paste_into);
-            action_set_enabled (common_actions, "open_in", only_folders);
+            action_set_enabled (common_actions, "paste-into", can_paste_into);
+            action_set_enabled (common_actions, "open-in", only_folders);
             action_set_enabled (selection_actions, "rename", is_selected && !more_than_one_selected && can_rename);
-            action_set_enabled (selection_actions, "view_in_location", is_selected);
+            action_set_enabled (selection_actions, "view-in-location", is_selected);
             action_set_enabled (selection_actions, "open", is_selected && !more_than_one_selected && can_open);
-            action_set_enabled (selection_actions, "open_with_app", can_open);
-            action_set_enabled (selection_actions, "open_with_default", can_open);
-            action_set_enabled (selection_actions, "open_with_other_app", can_open);
+            action_set_enabled (selection_actions, "open-with-app", can_open);
+            action_set_enabled (selection_actions, "open-with-default", can_open);
+            action_set_enabled (selection_actions, "open-with-other-app", can_open);
             action_set_enabled (selection_actions, "cut", is_writable && is_selected);
             action_set_enabled (selection_actions, "trash", is_writable && slot.directory.has_trash_dirs);
             action_set_enabled (selection_actions, "delete", is_writable);
             action_set_enabled (common_actions, "properties", can_show_properties);
             action_set_enabled (common_actions, "bookmark", can_bookmark);
             action_set_enabled (common_actions, "copy", !in_trash && can_copy);
-            action_set_enabled (common_actions, "copy_link", !in_trash && !in_recent && can_copy);
+            action_set_enabled (common_actions, "copy-link", !in_trash && !in_recent && can_copy);
             action_set_enabled (common_actions, "bookmark", !more_than_one_selected);
 
             update_default_app (selection);
@@ -2256,11 +2253,11 @@ namespace FM {
 
             if (model.get_sort_column_id (out sort_column_id, out sort_order)) {
                 GLib.Variant val = new GLib.Variant.string (get_string_from_column_id (sort_column_id));
-                action_set_state (background_actions, "sort_by", val);
+                action_set_state (background_actions, "sort-by", val);
                 val = new GLib.Variant.boolean (sort_order == Gtk.SortType.DESCENDING);
                 action_set_state (background_actions, "reverse", val);
                 val = new GLib.Variant.boolean (GOF.Preferences.get_default ().sort_directories_first);
-                action_set_state (background_actions, "folders_first", val);
+                action_set_state (background_actions, "folders-first", val);
             }
         }
 
@@ -2896,7 +2893,7 @@ namespace FM {
                         var cap_c = keyval == Gdk.Key.C;
 
                         if (caps_on != cap_c) { /* Shift key pressed */
-                            common_actions.activate_action ("copy_link", null);
+                            common_actions.activate_action ("copy-link", null);
                         } else {
                         /* Should not copy files in the trash - cut instead */
                             if (in_trash) {
@@ -2920,9 +2917,9 @@ namespace FM {
                     if (only_control_pressed) {
                         if (!in_recent && is_writable) {
                             /* Will drop any existing selection and paste into current directory */
-                            action_set_enabled (common_actions, "paste_into", true);
+                            action_set_enabled (common_actions, "paste-into", true);
                             unselect_all ();
-                            common_actions.activate_action ("paste_into", null);
+                            common_actions.activate_action ("paste-into", null);
                         } else {
                             PF.Dialogs.show_warning_dialog (_("Cannot paste files here"),
                                                             _("You do not have permission to change this location"),

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -25,21 +25,21 @@ namespace Marlin.View {
 
     public class Window : Gtk.ApplicationWindow {
         const GLib.ActionEntry [] win_entries = {
-            {"new_window", action_new_window},
+            {"new-window", action_new_window},
             {"quit", action_quit},
             {"refresh", action_reload},
             {"undo", action_undo},
             {"redo", action_redo},
             {"bookmark", action_bookmark},
             {"find", action_find},
-            {"edit_path", action_edit_path},
+            {"edit-path", action_edit_path},
             {"tab", action_tab, "s"},
-            {"go_to", action_go_to, "s"},
+            {"go-to", action_go_to, "s"},
             {"zoom", action_zoom, "s"},
             {"info", action_info, "s"},
-            {"view_mode", action_view_mode, "s", "'MILLER'"},
-            {"show_hidden", null, null, "false", change_state_show_hidden},
-            {"show_remote_thumbnails", null, null, "false", change_state_show_remote_thumbnails}
+            {"view-mode", action_view_mode, "s", "'MILLER'"},
+            {"show-hidden", null, null, "false", change_state_show_hidden},
+            {"show-remote-thumbnails", null, null, "false", change_state_show_remote_thumbnails}
         };
 
         const string [] mode_strings = {
@@ -138,7 +138,7 @@ namespace Marlin.View {
         }
 
         private void build_window () {
-            view_switcher = new Chrome.ViewSwitcher (lookup_action ("view_mode") as SimpleAction);
+            view_switcher = new Chrome.ViewSwitcher (lookup_action ("view-mode") as SimpleAction);
             view_switcher.mode = Preferences.settings.get_enum ("default-viewmode");
 
             top_menu = new Chrome.TopMenu (view_switcher);
@@ -173,8 +173,8 @@ namespace Marlin.View {
 
             /** Apply preferences */
             var prefs = Preferences.settings;
-            get_action ("show_hidden").set_state (prefs.get_boolean ("show-hiddenfiles"));
-            get_action ("show_remote_thumbnails").set_state (prefs.get_boolean ("show-remote-thumbnails"));
+            get_action ("show-hidden").set_state (prefs.get_boolean ("show-hiddenfiles"));
+            get_action ("show-remote-thumbnails").set_state (prefs.get_boolean ("show-remote-thumbnails"));
         }
 
         private void connect_signals () {
@@ -1031,7 +1031,7 @@ namespace Marlin.View {
             var mode = current_tab.view_mode;
             view_switcher.mode = mode;
             view_switcher.sensitive = current_tab.can_show_folder;
-            get_action ("view_mode").set_state (mode_strings [(int)mode]);
+            get_action ("view-mode").set_state (mode_strings [(int)mode]);
             Preferences.settings.set_enum ("default-viewmode", mode);
         }
 
@@ -1111,31 +1111,31 @@ namespace Marlin.View {
 
         private void set_accelerators () {
             application.set_accels_for_action ("win.quit", {"<Ctrl>Q"});
-            application.set_accels_for_action ("win.new_window", {"<Ctrl>N"});
+            application.set_accels_for_action ("win.new-window", {"<Ctrl>N"});
             application.set_accels_for_action ("win.undo", {"<Ctrl>Z"});
             application.set_accels_for_action ("win.redo", {"<Ctrl><Shift>Z"});
             application.set_accels_for_action ("win.bookmark", {"<Ctrl>D"});
             application.set_accels_for_action ("win.find", {"<Ctrl>F"});
-            application.set_accels_for_action ("win.edit_path", {"<Ctrl>L"});
+            application.set_accels_for_action ("win.edit-path", {"<Ctrl>L"});
             application.set_accels_for_action ("win.tab::NEW", {"<Ctrl>T"});
             application.set_accels_for_action ("win.tab::CLOSE", {"<Ctrl>W"});
             application.set_accels_for_action ("win.tab::NEXT", {"<Ctrl>Page_Down", "<Ctrl>Tab"});
             application.set_accels_for_action ("win.tab::PREVIOUS", {"<Ctrl>Page_Up", "<Shift><Ctrl>Tab"});
-            application.set_accels_for_action ("win.view_mode::ICON", {"<Ctrl>1"});
-            application.set_accels_for_action ("win.view_mode::LIST", {"<Ctrl>2"});
-            application.set_accels_for_action ("win.view_mode::MILLER", {"<Ctrl>3"});
+            application.set_accels_for_action ("win.view-mode::ICON", {"<Ctrl>1"});
+            application.set_accels_for_action ("win.view-mode::LIST", {"<Ctrl>2"});
+            application.set_accels_for_action ("win.view-mode::MILLER", {"<Ctrl>3"});
             application.set_accels_for_action ("win.zoom::ZOOM_IN", {"<Ctrl>plus", "<Ctrl>equal"});
             application.set_accels_for_action ("win.zoom::ZOOM_OUT", {"<Ctrl>minus"});
             application.set_accels_for_action ("win.zoom::ZOOM_NORMAL", {"<Ctrl>0"});
-            application.set_accels_for_action ("win.show_hidden", {"<Ctrl>H"});
+            application.set_accels_for_action ("win.show-hidden", {"<Ctrl>H"});
             application.set_accels_for_action ("win.refresh", {"<Ctrl>R", "F5"});
-            application.set_accels_for_action ("win.go_to::HOME", {"<Alt>Home"});
-            application.set_accels_for_action ("win.go_to::TRASH", {"<Alt>T"});
-            application.set_accels_for_action ("win.go_to::NETWORK", {"<Alt>N"});
-            application.set_accels_for_action ("win.go_to::SERVER", {"<Alt>C"});
-            application.set_accels_for_action ("win.go_to::UP", {"<Alt>Up"});
-            application.set_accels_for_action ("win.go_to::FORWARD", {"<Alt>Right", "XF86Forward"});
-            application.set_accels_for_action ("win.go_to::BACK", {"<Alt>Left", "XF86Back"});
+            application.set_accels_for_action ("win.go-to::HOME", {"<Alt>Home"});
+            application.set_accels_for_action ("win.go-to::TRASH", {"<Alt>T"});
+            application.set_accels_for_action ("win.go-to::NETWORK", {"<Alt>N"});
+            application.set_accels_for_action ("win.go-to::SERVER", {"<Alt>C"});
+            application.set_accels_for_action ("win.go-to::UP", {"<Alt>Up"});
+            application.set_accels_for_action ("win.go-to::FORWARD", {"<Alt>Right", "XF86Forward"});
+            application.set_accels_for_action ("win.go-to::BACK", {"<Alt>Left", "XF86Back"});
             application.set_accels_for_action ("win.info::HELP", {"F1"});
         }
     }

--- a/src/View/directory_view_popup.ui
+++ b/src/View/directory_view_popup.ui
@@ -14,7 +14,7 @@
     <menu id='view-in-location'>
         <item>
             <attribute name='label' translatable='yes'>Open Parent Folder</attribute>
-            <attribute name='action'>selection.view_in_location</attribute>
+            <attribute name='action'>selection.view-in-location</attribute>
         </item>
     </menu>
 
@@ -65,23 +65,23 @@
     <menu id='show'>
         <item>
             <attribute name='label' translatable='yes'>Show Hidden Files</attribute>
-            <attribute name='action'>background.show_hidden</attribute>
+            <attribute name='action'>background.show-hidden</attribute>
         </item>
         <item>
             <attribute name='label' translatable='yes'>Show Remote Thumbnails</attribute>
-            <attribute name='action'>background.show_remote_thumbnails</attribute>
+            <attribute name='action'>background.show-remote-thumbnails</attribute>
         </item>
     </menu>
 
     <menu id='open-in'>
         <item>
             <attribute name='label' translatable='yes'>New Tab</attribute>
-            <attribute name='action'>common.open_in</attribute>
+            <attribute name='action'>common.open-in</attribute>
             <attribute name="target">TAB</attribute>
         </item>
         <item>
             <attribute name='label' translatable='yes'>New Window</attribute>
-            <attribute name='action'>common.open_in</attribute>
+            <attribute name='action'>common.open-in</attribute>
             <attribute name="target">WINDOW</attribute>
         </item>
     </menu>
@@ -103,13 +103,13 @@
     <menu id='paste'>
         <item>
             <attribute name='label' translatable='yes'>Paste</attribute>
-            <attribute name='action'>common.paste_into</attribute>
+            <attribute name='action'>common.paste-into</attribute>
         </item>
     </menu>
     <menu id='paste-link'>
         <item>
             <attribute name='label' translatable='yes'>Paste Link</attribute>
-            <attribute name='action'>common.paste_into</attribute>
+            <attribute name='action'>common.paste-into</attribute>
         </item>
     </menu>
 
@@ -124,15 +124,15 @@
         </item>
         <item>
             <attribute name='label' translatable='yes'>Copy as Link</attribute>
-            <attribute name='action'>common.copy_link</attribute>
+            <attribute name='action'>common.copy-link</attribute>
         </item>
         <item>
             <attribute name='label' translatable='yes'>Paste into Folder</attribute>
-            <attribute name='action'>common.paste_into</attribute>
+            <attribute name='action'>common.paste-into</attribute>
         </item>
         <item>
             <attribute name='label' translatable='yes'>Paste Link into Folder</attribute>
-            <attribute name='action'>common.paste_into</attribute>
+            <attribute name='action'>common.paste-into</attribute>
         </item>
     </menu>
 
@@ -142,22 +142,22 @@
             <section>
                 <item>
                     <attribute name='label' translatable='yes'>Name</attribute>
-                    <attribute name='action'>background.sort_by</attribute>
+                    <attribute name='action'>background.sort-by</attribute>
                     <attribute name="target">name</attribute>
                 </item>
                 <item>
                     <attribute name='label' translatable='yes'>Size</attribute>
-                    <attribute name='action'>background.sort_by</attribute>
+                    <attribute name='action'>background.sort-by</attribute>
                     <attribute name="target">size</attribute>
                 </item>
                 <item>
                     <attribute name='label' translatable='yes'>Type</attribute>
-                    <attribute name='action'>background.sort_by</attribute>
+                    <attribute name='action'>background.sort-by</attribute>
                     <attribute name="target">type</attribute>
                 </item>
                 <item>
                     <attribute name='label' translatable='yes'>Date</attribute>
-                    <attribute name='action'>background.sort_by</attribute>
+                    <attribute name='action'>background.sort-by</attribute>
                     <attribute name="target">modified</attribute>
                 </item>
             </section>
@@ -168,7 +168,7 @@
                 </item>
                 <item>
                     <attribute name='label' translatable='yes'>Folders Before Files</attribute>
-                    <attribute name='action'>background.folders_first</attribute>
+                    <attribute name='action'>background.folders-first</attribute>
                 </item>
             </section>
         </submenu>


### PR DESCRIPTION
It seems that action_name is valid if it consists only of alphanumeric characters, plus '-' and '.'. (according to https://developer.gnome.org/gio/stable/GAction.html#g-action-name-is-valid )
This commit makes all action name valid. Some change has been done to simplify `open-with-app`.
Supersedes #797