### PR TITLE
Add library libcloudproviders

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Build-Depends: meson,
                libsqlite3-dev,
                libunity-dev (>= 4.0.0),
                libzeitgeist-2.0-dev,
+               libcloudproviders-dev,
                valac (>= 0.28)
 Homepage: https://github.com/elementary/files
 Standards-Version: 4.1.1


### PR DESCRIPTION
In order to push the new cloudproviders plugin is required to add libcloudproviders to the dependency list