### PR TITLE
Fixes compilation in Vala 0.43.2

### DIFF
--- a/libcore/AbstractSidebar.vala
+++ b/libcore/AbstractSidebar.vala
@@ -18,8 +18,9 @@
 ***/
 
 namespace Marlin {
-
+    [CCode (has_target = false)]
     public delegate void PluginCallbackFunc (Gtk.Widget widget);
+
     public enum PlaceType {
         BUILT_IN,
         MOUNTED_VOLUME,

--- a/libcore/SidebarPluginItem.vala
+++ b/libcore/SidebarPluginItem.vala
@@ -33,5 +33,5 @@ public class Marlin.SidebarPluginItem : Object {
     public uint64 free_space { get; set; default = 0; }
     public uint64 disk_size { get; set; default = 0; }
     public MenuModel? menu_model { get; set; }
-    public PluginCallbackFunc? cb;
+    public PluginCallbackFunc? cb { get; set; }
 }


### PR DESCRIPTION
Fixes #844 

Removes delegate's target from PluginCallbackFunc to fix compilation in vala 0.43:
- Add has_target=false attribute on AbstractSidebar
- Make SidebarPluginItem's cb a property

Everything looks okay, the 'Connect to server' is the only menu entry using this callback.

Does Dropbox use this sidebar plugin?