### PR TITLE
Add subdir to pkg.generate so header is found by dependent apps

### DIFF
--- a/libcore/meson.build
+++ b/libcore/meson.build
@@ -86,6 +86,7 @@ pantheon_files_core_dep = declare_dependency(
 
 pantheon_files_core_pkgconfig = pkg.generate(
     libraries: pantheon_files_core_library,
+    subdirs: pantheon_files_core_name,
     filebase: pantheon_files_core_name,
     name: 'elementary Files Core Library',
     description: 'Core library io.elementary.files and io.elementary.filechooser',

--- a/libwidgets/meson.build
+++ b/libwidgets/meson.build
@@ -41,6 +41,7 @@ pantheon_files_widgets_dep = declare_dependency(
 
 pkg.generate(
     libraries: pantheon_files_widgets_library,
+    subdirs:  pantheon_files_widgets_name,
     filebase: pantheon_files_widgets_name,
     name: 'elementary Files Widgets Library',
     description: 'Common widgets for io.elementary.files and io.elementary.filechooser',


### PR DESCRIPTION
Attempts to use pantheon-files-core library with an external app failed to compile because the pantheon-files-core header was not being found.  This was traced to a fault in the pkgconfig file for pantheon-files-core.

This PR fixes that.

It was also noticed that pantheon-files-core and pantheon-files-widgets differed in the location their header was installed.  This makes them consistent - they both now install in a subdirectory of /usr/include.