### PR TITLE
Fix some timing issues around adding and removing files

### DIFF
--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -817,6 +817,7 @@ public class Async : Object {
             }
         }
 
+        result.is_gone = false;
         return (!) result;
     }
 
@@ -844,11 +845,6 @@ public class Async : Object {
     }
 
     private void changed_and_refresh (GOF.File gof) {
-        if (gof.is_gone) {
-            critical ("File marked as gone when refreshing change");
-            return;
-        }
-
         gof.update ();
 
         if (!gof.is_hidden || Preferences.get_default ().show_hidden_files) {
@@ -858,11 +854,6 @@ public class Async : Object {
     }
 
     private void add_and_refresh (GOF.File gof) {
-        if (gof.is_gone) {
-            critical ("Add and refresh file which is gone");
-            return;
-        }
-
         if (gof.info == null) {
             critical ("FILE INFO null");
         }
@@ -891,6 +882,8 @@ public class Async : Object {
     }
 
     private void notify_file_removed (GOF.File gof) {
+        remove_file_from_cache (gof);
+
         if (!gof.is_hidden || Preferences.get_default ().show_hidden_files) {
             file_deleted (gof);
         }
@@ -1093,7 +1086,7 @@ public class Async : Object {
         return from_gfile (gof.get_target_location ());
     }
 
-    public static void remove_file_from_cache (GOF.File gof) {
+    private static void remove_file_from_cache (GOF.File gof) {
         assert (gof != null);
         Async? dir = cache_lookup (gof.directory);
         if (dir != null) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1271,6 +1271,8 @@ namespace FM {
             if (file != null) {
                 add_file (file, dir);
                 handle_free_space_change ();
+            } else {
+                critical ("Null file added");
             }
         }
 
@@ -1328,6 +1330,7 @@ namespace FM {
                     slot.folder_deleted (file, file_dir);
                 }
             }
+
             handle_free_space_change ();
         }
 
@@ -2487,10 +2490,10 @@ namespace FM {
                     /* iterate over the range to collect all files */
                     valid_iter = model.get_iter (out iter, start_path);
                     while (valid_iter && thumbnail_source_id > 0) {
-                        file = model.file_for_iter (iter); // Maybe null if dummy row
+                        file = model.file_for_iter (iter); // Maybe null if dummy row or file being deleted
                         path = model.get_path (iter);
 
-                        if (file != null) {
+                        if (file != null && !file.is_gone) {
                             file.query_thumbnail_update (); // Ensure thumbstate up to date
                             /* Ask thumbnailer only if ThumbState UNKNOWN */
                             if ((GOF.File.ThumbState.UNKNOWN in (GOF.File.ThumbState)(file.flags))) {


### PR DESCRIPTION
Fixes #863

* GOF.Directory.Async now responsible for removing file from its cache
* Mark file added (back) to GOF.Directory.Async cache `is_gone = false`
* Do not update or send to plugin files being deleted (`is_gone = true`)