### PR TITLE
File.vala: Fix inverted logic in get_default_handler

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -795,7 +795,7 @@ public class GOF.File : GLib.Object {
     public GLib.AppInfo? get_default_handler () {
         unowned string? content_type = get_ftype ();
         if (content_type != null) {
-            return GLib.AppInfo.get_default_for_type (content_type, location.get_path () != null);
+            return GLib.AppInfo.get_default_for_type (content_type, location.get_path () == null);
         }
 
         if (target_location != null) {


### PR DESCRIPTION
Refixes the regression from https://github.com/elementary/files/commit/8f1606ffb0fe22358b4935f7d3cc24cb7198edeb#diff-9978ad64c4d1a777ecc7a89ee3811b1e