### PR TITLE
Fix high CPU regression in v4.1.4

### DIFF
--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -201,10 +201,13 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             if (row_iter.n_children () == 3) {
                 uint64 modified = int64.parse (row_iter.next_value ().get_string ());
                 unowned string type = row_iter.next_value ().get_string ();
-                file.color = int.parse (row_iter.next_value ().get_string ());
+                var color = int.parse (row_iter.next_value ().get_string ());
+                if (file.color != color) {
+                    file.color = color;
+                    file.icon_changed (); /* Just need to trigger redraw - the underlying GFile has not changed */
+                }
                 /* check modified time field only on user dirs. We don't want to query again and
                  * again system directories */
-                file.icon_changed (); /* Just need to trigger redraw - the underlying GFile has not changed */
 
                 /* Is this necessary ? */
                 if (file.info.get_attribute_uint64 (FileAttribute.TIME_MODIFIED) > modified &&
@@ -254,6 +257,7 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
     }
 
     public override void update_file_info (GOF.File file) {
+
         return_if_fail (file != null);
 
         if (file.info != null && !f_ignore_dir (file.directory) &&
@@ -303,9 +307,10 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
                 target_file = file;
             }
 
-            target_file.color = n;
-            entries = new GenericArray<Variant> ();
-            add_entry (target_file, entries);
+            if (target_file.color != n) {
+                target_file.color = n;
+                add_entry (target_file, entries);
+            }
         }
 
         if (entries != null) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2514,11 +2514,12 @@ namespace FM {
                             /* Ask thumbnailer only if ThumbState UNKNOWN */
                             if ((GOF.File.ThumbState.UNKNOWN in (GOF.File.ThumbState)(file.flags))) {
                                 visible_files.prepend (file);
+                                if (plugins != null) {
+                                    plugins.update_file_info (file);
+                                }
+
                                 if (path.compare (sp) >= 0 && path.compare (ep) <= 0) {
                                     actually_visible++;
-                                    if (plugins != null) {
-                                        plugins.update_file_info (file);
-                                    }
                                 }
                             }
                         }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -230,7 +230,6 @@ namespace FM {
                      * of selected files (e.g. OverlayBar critical errors)
                      */
                     disconnect_tree_signals ();
-                    size_allocate.disconnect (on_size_allocate);
                     clipboard.changed.disconnect (on_clipboard_changed);
                     view.key_press_event.disconnect (on_view_key_press_event);
                 } else if (!value && _is_frozen) {
@@ -238,7 +237,6 @@ namespace FM {
                     connect_tree_signals ();
                     on_view_selection_changed ();
 
-                    size_allocate.connect (on_size_allocate);
                     clipboard.changed.connect (on_clipboard_changed);
                     view.key_press_event.connect (on_view_key_press_event);
                 }
@@ -357,8 +355,6 @@ namespace FM {
             set_policy (Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC);
             set_shadow_type (Gtk.ShadowType.NONE);
 
-            size_allocate.connect_after (on_size_allocate);
-
             popup_menu.connect (on_popup_menu);
 
             unrealize.connect (() => {
@@ -372,7 +368,9 @@ namespace FM {
 
             scroll_event.connect (on_scroll_event);
 
-            get_vadjustment ().value_changed.connect_after (schedule_thumbnail_timeout);
+            get_vadjustment ().value_changed.connect_after (() => {
+                schedule_thumbnail_timeout ();
+            });
 
             var prefs = (GOF.Preferences.get_default ());
             prefs.notify["show-hidden-files"].connect (on_show_hidden_files_changed);
@@ -1483,11 +1481,6 @@ namespace FM {
             queue_draw ();
         }
 
-    /** Handle size allocation event */
-        private void on_size_allocate (Gtk.Allocation allocation) {
-            schedule_thumbnail_timeout ();
-        }
-
 /** DRAG AND DROP */
 
     /** Handle Drag source signals*/
@@ -2523,13 +2516,11 @@ namespace FM {
                                 visible_files.prepend (file);
                                 if (path.compare (sp) >= 0 && path.compare (ep) <= 0) {
                                     actually_visible++;
+                                    if (plugins != null) {
+                                        plugins.update_file_info (file);
+                                    }
                                 }
                             }
-
-                            if (plugins != null) {
-                                plugins.update_file_info (file);
-                            }
-
                         }
                         /* check if we've reached the end of the visible range */
                         if (path.compare (end_path) != 0) {


### PR DESCRIPTION
Fixes #878 

This was traced to an obscure bug causing an endless loop between the color-tag plugin and the thumbnailing code via a "size-allocate" signal.  The reason why this signal kept getting emitted when the size was not changing is not clear.  However, no adverse effect of not scheduling a thumbnail update on size-allocate signal was found (enough off-screen thumbnails are preloaded and an update is triggered on scrolling).  Also the "icon-changed" is no longer emitted unless the color actually changed.

* No need to update thumbnails on size allocate
* Do not signal icon-changed unnecessarily in color-tag plugin
* Do not update plugins while thumbnailing unnecessarily