### PR TITLE
Reduces gap at the right of the Breadcrumbs element

### DIFF
--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -40,10 +40,10 @@ namespace Marlin.View.Chrome {
         }
 
         public bool hide_breadcrumbs { get; set; default = false; }
-        public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 36;
+        public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 10;
         public const double MINIMUM_BREADCRUMB_WIDTH = 12;
         public const double COMPLETION_ALPHA = 0.5;
-        public const int ICON_WIDTH = 48;
+        public const int ICON_WIDTH = 6;
         protected string placeholder = ""; /*Note: This is not the same as the Gtk.Entry placeholder_text */
         protected BreadcrumbElement? clicked_element = null;
         protected string? current_dir_path = null;

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -40,10 +40,10 @@ namespace Marlin.View.Chrome {
         }
 
         public bool hide_breadcrumbs { get; set; default = false; }
-        public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 10;
+        public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 16;
         public const double MINIMUM_BREADCRUMB_WIDTH = 12;
         public const double COMPLETION_ALPHA = 0.5;
-        public const int ICON_WIDTH = 6;
+        public const int ICON_WIDTH = 32;
         protected string placeholder = ""; /*Note: This is not the same as the Gtk.Entry placeholder_text */
         protected BreadcrumbElement? clicked_element = null;
         protected string? current_dir_path = null;


### PR DESCRIPTION
Fixes issue #885 
The space has shrunk quite a bit, should this be an UX discussion ?
![screenshot from 2019-02-26 00 34 41](https://user-images.githubusercontent.com/1344696/53376644-54451280-395f-11e9-9198-84d294cfcdd0.png)
