### PR TITLE
Put Files CSD on a diet

### DIFF
--- a/libwidgets/Chrome/BasicLocationBar.vala
+++ b/libwidgets/Chrome/BasicLocationBar.vala
@@ -58,9 +58,8 @@ namespace Marlin.View.Chrome {
         }
 
         construct {
-            margin_top = 4;
-            margin_bottom = 4;
-            margin_start = 3;
+            margin_start = 24;
+            margin_end = 6;
         }
 
         public BasicLocationBar (Navigatable? _bread = null) {


### PR DESCRIPTION
This allows Files CSD to match thickness with Terminal and Epiphany (from which I borrowed those [margin specs](https://github.com/elementary/os-patches/blob/dbc305d506a3fae94395513bf0b038a3517ea50b/src/ephy-header-bar.c#L733#L734)).

CSD margins should be handled by the css anyway, as discussed in [Terminal Issue #270](https://github.com/elementary/terminal/issues/270).

[Matching CSD](https://postimg.cc/1n58LTtC)