### PR TITLE
Remove vertical margins from locationbar

### DIFF
--- a/libwidgets/Chrome/BasicLocationBar.vala
+++ b/libwidgets/Chrome/BasicLocationBar.vala
@@ -58,9 +58,8 @@ namespace Marlin.View.Chrome {
         }
 
         construct {
-            margin_top = 4;
-            margin_bottom = 4;
             margin_start = 3;
+            valign = Gtk.Align.CENTER;
         }
 
         public BasicLocationBar (Navigatable? _bread = null) {


### PR DESCRIPTION
This removes the hardcoded margins from the locationbar, instead relying on the other widgets for the sizing. Consequently the locationbar is also set to valign CENTER so it doesn't expand to fill the space. The result is an almost-identical UI but it works a bit more consistently with other stylesheets.

This supersedes #914 

## Before

### elementary Stylesheet

![files-pictures-master@2x](https://user-images.githubusercontent.com/611168/55264067-c51a6b80-5238-11e9-89d5-20cb9ceeca8b.png)

### Adwaita

![files-master-adwaita@2x](https://user-images.githubusercontent.com/611168/55264077-cba8e300-5238-11e9-8c8e-757d59ab7b5f.png)

## After

### elementary

![files-tweaked-pictures@2x](https://user-images.githubusercontent.com/611168/55264081-d19ec400-5238-11e9-8c73-4e1af3aa3985.png)

### Adwaita

![files-tweaked-adwaita@2x](https://user-images.githubusercontent.com/611168/55264087-d82d3b80-5238-11e9-92c7-05b99df5d556.png)
