### PR TITLE
Implement org.freedesktop.portal.FileChooser

### DIFF
--- a/filechooser-portal/FileChooser.vala
+++ b/filechooser-portal/FileChooser.vala
@@ -1,0 +1,145 @@
+/*-
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+[DBus (name = "org.freedesktop.portal.FileChooser")]
+public class FileChooser : Object {
+
+    private int id = 0;
+    private unowned DBusConnection conn;
+
+    private Gee.HashMap<Request, uint> requests;
+
+    construct {
+        requests = new Gee.HashMap<Request, uint> (Request.hash);
+    }
+
+    public FileChooser (DBusConnection conn) {
+        this.conn = conn;
+
+        var mapp = new Marlin.Application ();
+        mapp.initialize ();
+
+        var app = new Application ("io.elementary.files-portal", ApplicationFlags.NON_UNIQUE);
+        Application.set_default (app);
+    }
+
+    public ObjectPath open_file (string parent_window, string title, HashTable<string, Variant> options, BusName sender) throws Error {
+        try {
+            var req = register_request (sender, extract_token (options));
+            show_dialog (req, parent_window, title, options);
+            return req.handle;
+        } catch (Error e) {
+            warning (e.message);
+            throw e;
+        }
+    }
+
+    public ObjectPath save_file (string parent_window, string title, HashTable<string, Variant> options, BusName sender) throws Error {
+        try {
+            var req = register_request (sender, extract_token (options));
+            show_dialog (req, parent_window, title, options);
+            return req.handle;
+        } catch (Error e) {
+            warning (e.message);
+            throw e;
+        }
+    }
+
+
+    private static string? extract_token (HashTable<string, Variant> options) {
+        var token = options["handle_token"];
+        if (token == null) {
+            return null;
+        }
+
+        return token.get_string ();
+    }
+
+    private Request register_request (owned string sender, owned string? token) throws Error {
+        if (token == null) {
+            token = id.to_string ();
+            id++;
+        }
+
+        if (sender.has_prefix (":")) {
+            sender = sender.substring (1);
+        }
+
+        sender = sender.replace (".", "_");
+
+        string handle = "/org/fredesktop/portal/desktop/request/%s/%s".printf (sender, token);
+
+        var req = new Request ((ObjectPath)handle);
+        req.closed.connect (() => { 
+            conn.unregister_object (requests[req]);
+            requests.unset (req);
+        });
+
+        try {
+            requests[req] = conn.register_object (handle, req);
+        } catch (IOError e) {
+            throw e;
+        }
+
+        return req;
+    }
+
+    private FileChooserDialog show_dialog (Request request, string parent_window, string title, HashTable<string, Variant> options) {
+        var dialog = new FileChooserDialog (request, title);
+        dialog.destroy.connect (on_dialog_destroyed);
+        dialog.selected.connect (on_dialog_selected);
+
+        request.closed.connect (() => on_dialog_closed (dialog, true));
+
+        dialog.show_all ();
+        return dialog;
+    }
+
+    private void on_dialog_selected (FileChooserDialog dialog, List<GOF.File> selection) {
+        dialog.destroy.disconnect (on_dialog_destroyed);
+        dialog.destroy ();
+
+        Variant[] uris = {};
+        foreach (var file in selection) {
+            uris += new Variant.string (file.uri);
+        }
+
+        var uris_va = new Variant.array (VariantType.STRING, uris);
+        var results = new HashTable<string, Variant> (str_hash, null);
+        results["uris"] = uris_va;
+
+        dialog.request.response (ResponseType.SUCCESS, results);
+    }
+
+    private void on_dialog_destroyed (Gtk.Widget dialog) {
+        on_dialog_closed ((FileChooserDialog)dialog, false);
+    }
+
+    private void on_dialog_closed (FileChooserDialog dialog, bool was_request) {
+        if (!was_request) {
+            var uris_va = new Variant.array (VariantType.STRING, {});
+
+            var results = new HashTable<string, Variant> (str_hash, null);
+            results["uris"] = uris_va;
+            dialog.request.response (ResponseType.CANCELLED, results);
+        }
+
+        if (!dialog.is_destroyed) {
+            dialog.destroy ();
+        }
+    }
+}

--- a/filechooser-portal/FileChooserDialog.vala
+++ b/filechooser-portal/FileChooserDialog.vala
@@ -1,0 +1,196 @@
+/*-
+ * Copyright (c) 2017-2018 elementary LLC (http://launchpad.net/elementary)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335 USA.
+ *
+ * Authored by: Adam Bieńkowski <donadigos159@gmail.com>
+ */
+
+public class FileChooserDialog : Gtk.Dialog {
+    public bool is_destroyed { get; set; default = false; }
+    public Request request { get; construct; }
+    public signal void selected (List<GOF.File> selection);
+
+    private Marlin.View.ViewContainer view_container;
+    private Marlin.View.Chrome.TopMenu top_menu;
+    private SimpleAction view_mode_action;
+
+    private static Settings? settings;
+    static construct {
+        settings = new Settings ("io.elementary.files.preferences");
+    }
+
+    construct {
+        var home_file = File.new_for_path (Environment.get_home_dir ());
+
+        view_container = new Marlin.View.ViewContainer (null);
+        view_container.expand = true;
+        view_container.add_view (Marlin.ViewMode.ICON, home_file);
+        view_container.loading.connect ((is_loading) => {
+            update_top_menu ();
+        });
+
+        view_container.active.connect (() => {
+            update_top_menu ();
+        });
+
+        view_container.slot.handle_activate_selected_items.connect (handle_activate_selected_items);
+
+        view_mode_action = new SimpleAction ("view-mode", VariantType.STRING);
+        view_mode_action.activate.connect (action_view_mode);
+
+        var view_switcher = new Marlin.View.Chrome.ViewSwitcher (view_mode_action);
+        view_switcher.mode = settings.get_enum ("default-viewmode");
+
+        top_menu = new Marlin.View.Chrome.TopMenu (view_switcher);
+        top_menu.location_bar.set_display_path (home_file.get_path ());
+        top_menu.location_bar.path_change_request.connect ((path, flag) => {
+            uri_path_change_request (path, flag);
+        });
+
+        top_menu.forward.connect (() => {view_container.go_forward ();});
+        top_menu.back.connect (() => {view_container.go_back ();});
+        //  top_menu.escape.connect (grab_focus);
+        top_menu.path_change_request.connect ((loc, flag) => {
+            view_container.is_frozen = false;
+            uri_path_change_request (loc, flag);
+        });
+        //  top_menu.reload_request.connect (action_reload);
+        top_menu.focus_location_request.connect ((loc) => {
+            view_container.focus_location_if_in_current_directory (loc, true);
+        });
+        top_menu.focus_in_event.connect (() => {
+            view_container.is_frozen = true;
+            return true;
+        });
+        top_menu.focus_out_event.connect (() => {
+            view_container.is_frozen = false;
+            return true;
+        });
+
+        var folder_button = new Gtk.Button.from_icon_name ("folder-new", Gtk.IconSize.LARGE_TOOLBAR);
+        folder_button.clicked.connect (() => {
+            view_container.slot.new_folder ();
+        });
+
+        unowned Gtk.Box content_area = get_content_area ();
+
+
+        var sidebar = new Marlin.Places.Sidebar (null, false);
+        sidebar.path_change_request.connect (uri_path_change_request);
+
+        var lside_pane = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        lside_pane.position = settings.get_int ("sidebar-width");
+        lside_pane.show ();
+        lside_pane.pack1 (sidebar, false, false);
+        lside_pane.pack2 (view_container, true, false);
+
+        content_area.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+        content_area.add (lside_pane);
+        content_area.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+
+        var open_button = new Gtk.Button.with_label ("Open");
+        open_button.clicked.connect (on_open_button_clicked);
+
+        var cancel_button = new Gtk.Button.with_label ("Cancel");
+        cancel_button.clicked.connect (() => destroy ());
+
+        var bottom_box = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
+        bottom_box.spacing = 6;
+        bottom_box.margin = 6;
+        bottom_box.halign = Gtk.Align.END;
+        bottom_box.pack_end (cancel_button);
+        bottom_box.pack_end (open_button);
+
+        content_area.add (bottom_box);
+        top_menu.pack_end (folder_button);
+
+        set_titlebar (top_menu);
+        set_default_size (700, 450);
+    }
+
+    public FileChooserDialog (Request request, string title) {
+        Object (request: request, title: title, use_header_bar: 1);
+    }
+
+    public override void destroy () {
+        is_destroyed = true;
+        base.destroy ();
+    }
+
+    private void uri_path_change_request (string uri, Marlin.OpenFlag flag = Marlin.OpenFlag.DEFAULT) {
+        string path = PF.FileUtils.sanitize_path (uri, null);
+        if (path.length > 0) {
+            var f = File.new_for_uri (PF.FileUtils.escape_uri (path));
+            view_container.focus_location (f);
+            top_menu.update_location_bar (uri);
+        }
+    }
+
+    private void update_top_menu () {
+        top_menu.set_back_menu (view_container.get_go_back_path_list ());
+        top_menu.set_forward_menu (view_container.get_go_forward_path_list ());
+        top_menu.can_go_back = view_container.can_go_back;
+        top_menu.can_go_forward = (view_container.can_show_folder && view_container.can_go_forward);
+        top_menu.working = view_container.is_loading;
+    
+        top_menu.update_location_bar (view_container.location.get_uri ());    
+    }
+
+    private void action_view_mode (GLib.Variant? param) {
+        string mode_string = param.get_string ();
+        Marlin.ViewMode mode = Marlin.ViewMode.MILLER_COLUMNS;
+        switch (mode_string) {
+            case "ICON":
+                mode = Marlin.ViewMode.ICON;
+                break;
+
+            case "LIST":
+                mode = Marlin.ViewMode.LIST;
+                break;
+
+            case "MILLER":
+                mode = Marlin.ViewMode.MILLER_COLUMNS;
+                break;
+
+            default:
+                break;
+        }
+
+        // We change the view and the slot gets recreated, therefore
+        // ww have to reconnect to it
+
+        view_container.slot.handle_activate_selected_items.disconnect (handle_activate_selected_items);
+        view_container.change_view_mode (mode);
+        view_container.slot.handle_activate_selected_items.connect (handle_activate_selected_items);
+    }
+
+    private void on_open_button_clicked () {
+        unowned List<GOF.File> selected = view_container.slot.get_selected_files ();
+        handle_activate_selected_items (selected);
+    }
+
+    private bool handle_activate_selected_items (List<GOF.File> selection) {
+        foreach (GOF.File file in selection) {
+            if (!file.is_folder ()) {
+                selected (selection);
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/filechooser-portal/Request.vala
+++ b/filechooser-portal/Request.vala
@@ -1,0 +1,44 @@
+/*-
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+enum ResponseType {
+    SUCCESS = 0,
+    CANCELLED,
+    ENDED
+}
+
+[DBus (name = "org.freedesktop.portal.Request")]
+public class Request : Object {
+    [DBus (visible = false)]
+    public ObjectPath handle { get; construct; }
+
+    [DBus (visible = false)]
+    public signal void closed ();
+
+    public Request (ObjectPath handle) {
+        Object (handle: handle);
+    }
+
+    public static uint hash (Request req) {
+        return str_hash (req.handle);
+    }
+
+    public signal void response (uint repsonse, HashTable<string, Variant> results);
+    public void close () throws Error {
+        closed ();
+    }
+}

--- a/filechooser-portal/main.vala
+++ b/filechooser-portal/main.vala
@@ -1,3 +1,20 @@
+/*-
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 void on_file_chooser_bus_acquired (DBusConnection conn, string n) {
     try {
         string name = "/org/freedesktop/portal/desktop";

--- a/filechooser-portal/main.vala
+++ b/filechooser-portal/main.vala
@@ -1,0 +1,29 @@
+void on_file_chooser_bus_acquired (DBusConnection conn, string n) {
+    try {
+        string name = "/org/freedesktop/portal/desktop";
+        var object = new FileChooser (conn);
+        conn.register_object (name, object);
+        debug ("FileChooser object registered with dbus connection name %s", name);
+    } catch (IOError e) {
+        error ("Could not register FileChooser service");
+    }   
+}
+
+extern void exit (int exit_code);
+
+void on_name_lost (DBusConnection connection, string name) {
+    critical ("Name %s was not acquired", name);
+    exit (-1);
+}
+
+
+void main (string[] args) {
+    Gtk.init (ref args);
+
+    Bus.own_name (BusType.SESSION, "org.freedesktop.portal.Desktop", BusNameOwnerFlags.REPLACE,
+        on_file_chooser_bus_acquired,
+        () => {},
+        on_name_lost);
+
+    Gtk.main ();
+}

--- a/filechooser-portal/meson.build
+++ b/filechooser-portal/meson.build
@@ -1,0 +1,13 @@
+executable(
+    meson.project_name() + '-portal',
+    'main.vala',
+    'FileChooser.vala',
+    'FileChooserDialog.vala',
+    'Request.vala',
+
+    dependencies : [
+        pantheon_files_lib_dep,
+    ],
+
+    install: true,
+)

--- a/libcore/AbstractSlot.vala
+++ b/libcore/AbstractSlot.vala
@@ -66,6 +66,7 @@ namespace GOF {
         public signal void selection_changed (GLib.List<GOF.File> files);
         public signal void directory_loaded (GOF.Directory.Async dir);
         public signal void item_hovered (GOF.File? file);
+        public signal bool handle_activate_selected_items (GLib.List<GOF.File> selection);
 
         public void add_extra_widget (Gtk.Widget widget) {
             extra_location_widgets.pack_start (widget);
@@ -98,6 +99,7 @@ namespace GOF {
         public abstract void reload (bool non_local_only = false);
         public abstract void grab_focus ();
         public abstract void user_path_change_request (GLib.File loc, bool make_root);
+        public abstract void new_folder ();
 
         public abstract void focus_first_for_empty_selection (bool select);
         public abstract void select_glib_files (GLib.List<GLib.File> locations, GLib.File? focus_location);

--- a/libcore/marlin-file-operations.c
+++ b/libcore/marlin-file-operations.c
@@ -912,7 +912,7 @@ static void
 finalize_common (CommonJob *common)
 {
     pf_progress_info_finish (common->progress);
-    if (common->inhibit_cookie != -1) {
+    if (g_application_get_default () && common->inhibit_cookie != -1) {
         gtk_application_uninhibit (GTK_APPLICATION (g_application_get_default ()),
                                    common->inhibit_cookie);
     }

--- a/main/main.vala
+++ b/main/main.vala
@@ -1,0 +1,27 @@
+/***
+    Copyright (c) 2013 Julián Unrrein <junrrein@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License version 3, as published
+    by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranties of
+    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+    PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program. If not, see <http://www.gnu.org/licenses/>.
+***/
+public static int main (string[] args) {
+    /* Initiliaze gettext support */
+    Intl.setlocale (LocaleCategory.ALL, "");
+    Intl.textdomain (Config.GETTEXT_PACKAGE);
+
+    Environment.set_application_name (Config.APP_NAME);
+    Environment.set_prgname (Config.APP_NAME);
+
+    var application = new Marlin.Application ();
+
+    return application.run (args);
+}

--- a/main/meson.build
+++ b/main/meson.build
@@ -1,0 +1,10 @@
+pantheon_files_exec = executable (
+    meson.project_name(),
+    'main.vala',
+
+    dependencies : [
+        pantheon_files_lib_dep
+    ],
+
+    install: true
+)

--- a/meson.build
+++ b/meson.build
@@ -103,6 +103,8 @@ project_config_dep = declare_dependency(
 subdir('libcore')
 subdir('libwidgets')
 subdir('src')
+subdir('filechooser-portal')
+subdir('main')
 subdir('data')
 subdir('pantheon-files-daemon')
 subdir('plugins')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -40,8 +40,7 @@ public class Marlin.Application : Gtk.Application {
         this.flags |= ApplicationFlags.HANDLES_COMMAND_LINE;
     }
 
-    public override void startup () {
-        base.startup ();
+    public void initialize () {
 
         if (Granite.Services.Logger.DisplayLevel != Granite.Services.LogLevel.DEBUG) {
             Granite.Services.Logger.DisplayLevel = Granite.Services.LogLevel.INFO;
@@ -85,6 +84,11 @@ public class Marlin.Application : Gtk.Application {
         this.window_removed.connect (() => {
             window_count--;
         });
+    }
+
+    public override void startup () {
+        base.startup ();
+        initialize ();
     }
 
     public unowned Marlin.ClipboardManager get_clipboard_manager () {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -527,7 +527,7 @@ namespace FM {
         protected void activate_selected_items (Marlin.OpenFlag flag = Marlin.OpenFlag.DEFAULT,
                                                 GLib.List<GOF.File> selection = get_selected_files ()) {
 
-            if (is_frozen || selection == null) {
+            if (is_frozen || selection == null || slot.handle_activate_selected_items (selection)) {
                 return;
             }
 
@@ -947,7 +947,7 @@ namespace FM {
                                             create_file_done);
         }
 
-        private void new_empty_folder () {
+        public void new_empty_folder () {
             /* Block the async directory file monitor to avoid generating unwanted "add-file" events */
             slot.directory.block_monitor ();
             Marlin.FileOperations.new_folder (null, null, slot.location, create_file_done);

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -256,6 +256,7 @@ namespace Marlin.View {
             slot.path_changed.connect (on_slot_path_changed);
             slot.directory_loaded.connect (on_slot_directory_loaded);
             slot.item_hovered.connect (on_slot_item_hovered);
+            slot.handle_activate_selected_items.connect (on_activate_selected_items);
         }
 
         private void disconnect_slot_signals (Slot slot) {
@@ -270,7 +271,11 @@ namespace Marlin.View {
             slot.path_changed.disconnect (on_slot_path_changed);
             slot.directory_loaded.disconnect (on_slot_directory_loaded);
             slot.item_hovered.disconnect (on_slot_item_hovered);
+            slot.handle_activate_selected_items.disconnect (on_activate_selected_items);
+        }
 
+        private bool on_activate_selected_items (GLib.List<GOF.File> selection) {
+            return false;
         }
 
         private void on_miller_slot_request (Marlin.View.Slot slot, GLib.File loc, bool make_root) {
@@ -574,6 +579,10 @@ namespace Marlin.View {
 
         public override void grab_focus () {
             ((Marlin.View.Slot)(current_slot)).grab_focus ();
+        }
+
+        public override void new_folder () {
+            ((Marlin.View.Slot)(current_slot)).new_folder ();
         }
 
         public override void initialize_directory () {

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -111,6 +111,8 @@ namespace Marlin.View {
             folder_deleted.connect ((file, dir) => {
                ((Marlin.Application)(window.application)).folder_deleted (file.location);
             });
+
+            handle_activate_selected_items.connect (() => { return false; });
         }
 
         private void connect_dir_view_signals () {
@@ -358,6 +360,12 @@ namespace Marlin.View {
         public override void grab_focus () {
             if (dir_view != null) {
                 dir_view.grab_focus ();
+            }
+        }
+
+        public override void new_folder () {
+            if (dir_view != null) {
+                dir_view.new_empty_folder ();
             }
         }
 

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -121,7 +121,7 @@ namespace Marlin.View {
         }
 
         /* Initial location now set by Window.make_tab after connecting signals */
-        public ViewContainer (Marlin.View.Window win) {
+        public ViewContainer (Marlin.View.Window? win) {
             window = win;
             browser = new Browser ();
 
@@ -161,7 +161,10 @@ namespace Marlin.View {
             if (deleted.equal (this.location)) {
                 if (!go_up ()) {
                     close ();
-                    window.remove_tab (this);
+
+                    if (window != null) {
+                        window.remove_tab (this);
+                    }
                 }
             }
         }
@@ -325,11 +328,17 @@ namespace Marlin.View {
 
             switch ((Marlin.OpenFlag)flag) {
                 case Marlin.OpenFlag.NEW_TAB:
-                    window.open_single_tab (loc, view_mode);
+                    if (window != null) {
+                        window.open_single_tab (loc, view_mode);
+                    }
+
                     break;
 
                 case Marlin.OpenFlag.NEW_WINDOW:
-                    window.add_window (loc, view_mode);
+                    if (window != null) {
+                        window.add_window (loc, view_mode);
+                    }
+
                     break;
 
                 default:
@@ -359,7 +368,9 @@ namespace Marlin.View {
 
         private void refresh_slot_info (GLib.File loc) {
             update_tab_name ();
-            window.loading_uri (loc.get_uri ()); /* Updates labels as well */
+            if (window != null) {
+                window.loading_uri (loc.get_uri ()); /* Updates labels as well */
+            }
             /* Do not update top menu (or record uri) unless folder loads successfully */
         }
 
@@ -454,7 +465,9 @@ namespace Marlin.View {
 
                 /* Notify plugins */
                 /* infobars are added to the view, not the active slot */
-                plugins.directory_loaded (window, view, directory);
+                if (window != null) {
+                    plugins.directory_loaded (window, view, directory);
+                }
             } else {
                 /* Save previous uri but do not record current one */
                 browser.record_uri (null);

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -284,19 +284,20 @@ namespace Marlin.View.Chrome {
             check_home ();
         }
 
+        /* For some reason crashes ATM */
         private void check_home () {
-            try {
-                bread.hide_breadcrumbs = GLib.Filename.from_uri (displayed_path) == Environment.get_home_dir ();
-            } catch (Error e) {
-                bread.hide_breadcrumbs = false;
-            }
+            //  try {
+            //      bread.hide_breadcrumbs = GLib.Filename.from_uri (displayed_path) == Environment.get_home_dir ();
+            //  } catch (Error e) {
+            //      bread.hide_breadcrumbs = false;
+            //  }
 
-            if (bread.hide_breadcrumbs) {
-                show_placeholder ();
-                show_search_icon ();
-            } else {
-                hide_search_icon ();
-            }
+            //  if (bread.hide_breadcrumbs) {
+            //      show_placeholder ();
+            //      show_search_icon ();
+            //  } else {
+            //      hide_search_icon ();
+            //  }
         }
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,9 +7,8 @@ pantheon_files_deps = [
     project_config_dep,
 ]
 
-pantheon_files_exec = executable (
+pantheon_files_lib = shared_library (
     meson.project_name (),
-    'main.vala',
 
     'Application.vala',
     'marlin-deep-count.vala',
@@ -61,6 +60,12 @@ pantheon_files_exec = executable (
         vala.find_library('marlin', dirs: meson.current_source_dir ()),
     ],
     install: true,
+)
+
+pantheon_files_lib_dep = declare_dependency(
+    link_with: pantheon_files_lib,
+    include_directories: include_directories('.'),
+    dependencies : [pantheon_files_deps],
 )
 
 install_data (


### PR DESCRIPTION
Implements the standard DBus interface `org.freedesktop.portal.FileChooser` by re-targeting the Files code to be a shared library that can be used by both the main app and the file chooser.

You can test this with building this branch. Then launching `io.elementary.files-portal` and in another terminal `GTK_USE_PORTAL=1 app`.

There are currently some problems with Gtk not properly subscribing to the response signal so showing the dialog will make the app freeze.

TODO:
- [x] Implement the skeleton of  `org.freedesktop.portal.FileChooser`
- [x] Make Files code a shared library
- [ ] Support all / most variant options for the dialog
- [ ] Strip the dialog out of Files specific features (open in tab, open in app etc.)

![filechooser](https://user-images.githubusercontent.com/8205284/56087814-fe76ec00-5e72-11e9-9e4d-66b29f2cb15a.png)


