### PR TITLE
Clarify GOF.File can only have one thumbstate

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -25,10 +25,10 @@ public class GOF.File : GLib.Object {
     }
 
     public enum ThumbState {
-        UNKNOWN = 0x00,
-        NONE = 0x01,
-        READY = 0x02,
-        LOADING = 0x03
+        UNKNOWN,
+        NONE,
+        READY,
+        LOADING
     }
 
     public const string GIO_DEFAULT_ATTRIBUTES = "standard::is-hidden,standard::is-backup,standard::is-symlink,standard::type,standard::name,standard::display-name,standard::content-type,standard::fast-content-type,standard::size,standard::symlink-target,standard::target-uri,access::*,time::*,owner::*,trash::*,unix::*,id::filesystem,thumbnail::*,mountable::*,metadata::marlin-sort-column-id,metadata::marlin-sort-reversed";
@@ -70,7 +70,7 @@ public class GOF.File : GLib.Object {
     public bool is_expanded = false;
     [CCode (cname = "can_unmount")]
     public bool _can_unmount;
-    public uint flags = GOF.File.ThumbState.UNKNOWN;
+    public uint thumbstate = GOF.File.ThumbState.UNKNOWN;
     public string thumbnail_path = null;
     public bool is_mounted = true;
     public bool exists = true;
@@ -395,7 +395,7 @@ public class GOF.File : GLib.Object {
         }
 
         GLib.Icon? gicon = null;
-        if (GOF.File.IconFlags.USE_THUMBNAILS in flags && this.flags == GOF.File.ThumbState.LOADING) {
+        if (GOF.File.IconFlags.USE_THUMBNAILS in flags && this.thumbstate == GOF.File.ThumbState.LOADING) {
             gicon = new GLib.ThemedIcon ("image-loading");
         } else {
             gicon = this.icon;
@@ -527,7 +527,7 @@ public class GOF.File : GLib.Object {
         /* mark the thumb flags as state none, we'll load the thumbs once the directory
          * would be loaded on a thread */
         if (get_thumbnail_path () != null) {
-            flags = GOF.File.ThumbState.UNKNOWN;  /* UNKNOWN means thumbnail not known to be unobtainable */
+            thumbstate = GOF.File.ThumbState.UNKNOWN;  /* UNKNOWN means thumbnail not known to be unobtainable */
         }
 
         /* formated type */
@@ -1180,7 +1180,7 @@ public class GOF.File : GLib.Object {
             }
         }
 
-        if (GOF.File.IconFlags.USE_THUMBNAILS in flags && this.flags == GOF.File.ThumbState.READY) {
+        if (GOF.File.IconFlags.USE_THUMBNAILS in flags && this.thumbstate == GOF.File.ThumbState.READY) {
             unowned string? thumb_path = get_thumbnail_path ();
             if (thumb_path != null) {
                 return Marlin.IconInfo.lookup_from_path (thumb_path, size, scale);

--- a/libcore/Thumbnailer.vala
+++ b/libcore/Thumbnailer.vala
@@ -181,10 +181,10 @@ namespace Marlin {
             foreach (var file in files) {
                 if (is_supported (file)) {
                     supported_files.prepend (file);
-                    file.flags = GOF.File.ThumbState.LOADING;
+                    file.thumbstate = GOF.File.ThumbState.LOADING;
                     file_count++;
                 } else {
-                    file.flags = GOF.File.ThumbState.NONE;
+                    file.thumbstate = GOF.File.ThumbState.NONE;
                 }
             }
 
@@ -354,7 +354,7 @@ namespace Marlin {
         private static void update_file_thumbstate (string uri, GOF.File.ThumbState state) {
             var goffile = GOF.File.get_by_uri (uri);
             if (goffile != null) {
-                goffile.flags = state;
+                goffile.thumbstate = state;
                 goffile.query_thumbnail_update ();
             }
         }

--- a/libcore/tests/MarlinIconInfoTests/MarlinIconInfoTests.vala
+++ b/libcore/tests/MarlinIconInfoTests/MarlinIconInfoTests.vala
@@ -92,7 +92,7 @@ void loadable_cache_and_ref_test () {
     /* file.pix might exist if tests run while Files instance was recently run and displayed test image */
     file.pix = null;
     file.query_update ();
-    file.flags |= GOF.File.ThumbState.READY;
+    file.thumbstate = GOF.File.ThumbState.READY;
     /* We need to provide our own thumbnail and path for CI */
     file.thumbnail_path = Path.build_filename (Config.TESTDATA_DIR, "images", "testimage.jpg.thumb.png");
     file.update_icon (128, 1);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2515,7 +2515,7 @@ namespace FM {
                         if (file != null && !file.is_gone) {
                             file.query_thumbnail_update (); // Ensure thumbstate up to date
                             /* Ask thumbnailer only if ThumbState UNKNOWN */
-                            if ((GOF.File.ThumbState.UNKNOWN in (GOF.File.ThumbState)(file.flags))) {
+                            if (file.thumbstate == GOF.File.ThumbState.UNKNOWN) {
                                 visible_files.prepend (file);
                                 if (plugins != null) {
                                     plugins.update_file_info (file);


### PR DESCRIPTION
* Rename GOF.File member `flags` to `thumbstate`
* Reduce unneeded thumbnailing

It was noticed that the thumbnailer was being called unnecessarily on scrolling. This fixes that and makes the code clearer.