### PR TITLE
Add test to check icons haven't been translated

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -3,6 +3,8 @@ config_data.set('install_prefix', get_option('prefix'))
 config_data.set('bin_dir', get_option('bindir'))
 config_data.set('exec_name', meson.project_name())
 
+icon_test_script = find_program(join_paths(meson.source_root(), 'meson', 'test_icon_translations.py'))
+
 configure_file(
     input: meson.project_name() + '.service.in',
     output: meson.project_name() + '.service',
@@ -69,6 +71,8 @@ i18n.merge_file(
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     type: 'desktop'
 )
+
+test('check icons haven\'t been translated', icon_test_script, args: join_paths(meson.current_build_dir(), meson.project_name() + '.desktop'))
 
 i18n.merge_file(
     'appdata',

--- a/meson/test_icon_translations.py
+++ b/meson/test_icon_translations.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+with open(sys.argv[1], 'r') as desktop_file:
+    #Find original icon name
+    pattern = re.compile("^Icon=(.*)$")
+    original_icon_name = ""
+    for line in desktop_file:
+        result = pattern.search(line)
+        if result is not None:
+            original_icon_name = result.group(1)
+
+    #Couldn't find original icon name, assume everything is OK
+    if original_icon_name == "":
+        exit(0)
+
+    desktop_file.seek(0)
+
+    failed = False
+    pattern = re.compile("^Icon\[(.*?)\]=(.*)$")
+    for line in desktop_file:
+        result = pattern.search(line)
+        if result is not None:
+            if result.group(2) != original_icon_name:
+                print("Icon in %s.po has been translated!" % (result.group(1)))
+                failed = True
+
+    if failed:
+        exit(1)
+
+exit(0)


### PR DESCRIPTION
This creates a meson/ninja test that fails when someone has erroneously translated the icon name in one of the `.po` files. I had meant to open this PR in my own fork of files to see if it would fail travis or not, but I accidentally opened it here, so it may as well stay here for visibility.