### PR TITLE
Show tag color even when selected

### DIFF
--- a/libcore/gof-preferences.vala
+++ b/libcore/gof-preferences.vala
@@ -21,8 +21,8 @@ namespace GOF {
 
     public class Preferences : Object {
 
-        /* First color not actually used but for safety make non-null */
-        public const string[] TAGS_COLORS = { "#ffffff", "#fff394", "#ffc27d", "#a3907c", "#d1ff82", "#8cd5ff", "#e4c6fa", "#ff8c82", "#d4d4d4", "#95a3ab" };
+        /* First element set to null in order that the text renderer background is not set */
+        public const string?[] TAGS_COLORS = { null, "#fff394", "#ffc27d", "#a3907c", "#d1ff82", "#8cd5ff", "#e4c6fa", "#ff8c82", "#d4d4d4", "#95a3ab" };
 
         public bool show_hidden_files {get; set; default=false;}
         public bool show_remote_thumbnails {set; get; default=false;}

--- a/src/TextRenderer.vala
+++ b/src/TextRenderer.vala
@@ -299,7 +299,7 @@ namespace Marlin {
                 int y0 = cell_area.y + y_offset;
                 var provider = new Gtk.CssProvider ();
                 string data;
-                if (selected) {
+                if (selected && !background_set) {
                     data = "* {border-radius: 5px;}";
                 } else {
                     data = "* {border-radius: 5px; background-color: %s;}".printf (background_rgba.to_string ());


### PR DESCRIPTION
Pushed for comment.  It is a little annoying that when setting tag colors you cannot see the result because the file is selected.  You have to move the cursor off the file to confirm that the color has been set correctly.