### PR TITLE
Contrasting name text

### DIFF
--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -340,7 +340,8 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
         public signal void color_changed (int ncolor);
 
         public ColorWidget () {
-            set_size_request (150, 20);
+            set_size_request (MARGIN_START + (GOF.Preferences.TAGS_COLORS.length - 1) * (BUTTON_WIDTH + SPACING),
+                              BUTTON_HEIGHT * 2);
 
             button_press_event.connect (button_pressed_cb);
             draw.connect (on_draw);

--- a/src/TextRenderer.vala
+++ b/src/TextRenderer.vala
@@ -126,12 +126,24 @@ namespace Marlin {
                 x_offset += border_radius;
             }
 
+            var provider = new Gtk.CssProvider ();
+            if (background_set) {
+                string data = "* {color: %s;}".printf (Granite.contrasting_foreground_color (background_rgba).to_string ());
+                try {
+                    provider.load_from_data (data);
+                    style_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+                } catch (Error e) {
+                    critical (e.message);
+                }
+            }
+
             style_context.render_layout (cr,
                                          cell_area.x + x_offset,
                                          cell_area.y + y_offset,
                                          layout);
 
-            style_context.restore ();
+            style_context.restore (); /* NOTE: This does not remove added classes */
+            style_context.remove_provider (provider); /* No error if provider not added */
 
             /* The render call should always be preceded by a set_property call
                from GTK. It should be safe to unreference or free the allocated

--- a/src/TextRenderer.vala
+++ b/src/TextRenderer.vala
@@ -24,6 +24,7 @@ namespace Marlin {
         private int double_border_radius;
         private Gtk.CssProvider text_css;
         private Gdk.RGBA previous_background_rgba;
+        private Gdk.RGBA previous_contrasting_rgba;
 
         private Marlin.ZoomLevel _zoom_level;
         public Marlin.ZoomLevel zoom_level {
@@ -73,6 +74,7 @@ namespace Marlin {
             this.mode = Gtk.CellRendererMode.EDITABLE;
             text_css = new Gtk.CssProvider ();
             previous_background_rgba = { 0, 0, 0, 0 };
+            previous_contrasting_rgba = { 0, 0, 0, 0 };
         }
 
         public TextRenderer (Marlin.ViewMode viewmode) {
@@ -138,11 +140,19 @@ namespace Marlin {
                     previous_background_rgba.blue = background_rgba.blue;
                     previous_background_rgba.alpha = background_rgba.alpha;
 
-                    string data = "* {color: %s;}".printf (Granite.contrasting_foreground_color (background_rgba).to_string ());
-                    try {
-                        text_css.load_from_data (data);
-                    } catch (Error e) {
-                        critical (e.message);
+                    var contrasting_foreground_rgba = Granite.contrasting_foreground_color (background_rgba);
+                    if (!contrasting_foreground_rgba.equal (previous_contrasting_rgba)) {
+                    /* Using Gdk.RGBA copy () causes a segfault for some reason */
+                        previous_contrasting_rgba.red = contrasting_foreground_rgba.red;
+                        previous_contrasting_rgba.green = contrasting_foreground_rgba.green;
+                        previous_contrasting_rgba.blue = contrasting_foreground_rgba.blue;
+                        previous_contrasting_rgba.alpha = contrasting_foreground_rgba.alpha;
+                        string data = "* {color: %s;}".printf (contrasting_foreground_rgba.to_string ());
+                        try {
+                            text_css.load_from_data (data);
+                        } catch (Error e) {
+                            critical (e.message);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes #937 

* Relies on unreleased version of Granite for the `Granite.contrasting_foreground_color (Gdk.RGBA background_color)` function, which should be released before this. (CI will fail until Travis CI has latest Granite)

* Also fixes a problem with the ColorWidget size request, although this will be superceded when the Gtk Widget version (#973) is merged.

* The existing tag colors are all pale so result in black text.  To test with darker tag colors, amend the `GOF.Preferences.TAGS_COLORS` array before compiling. Darker tag colors should have white text.

* Works for both light and dark theme variants.