### PR TITLE
Prevent possible crash when selecting single image by rubberbanding

### DIFF
--- a/src/View/Widgets/OverlayBar.vala
+++ b/src/View/Widgets/OverlayBar.vala
@@ -365,6 +365,9 @@ namespace Marlin.View {
         }
 
         private void on_size_prepared (int width, int height) {
+            if (goffile == null) { /* This can occur during rapid rubberband selection */
+                return;
+            }
             image_size_loaded = true;
             goffile.width = width;
             goffile.height = height;


### PR DESCRIPTION
Fixes #991 

Check for possible null goffile in OverlayBar.vala on_size_prepared () caused by race condition when rapidly selecting image by rubberbanding immediately after opening view and with end point of rectangle outside view.