### PR TITLE
Avoid mistranslation of datetime format strings

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -520,32 +520,32 @@ namespace PF.FileUtils {
         switch (now_weekday - disp_weekday) {
             case 0:
                 if (clock_is_24h) {
-                    ///TRANSLATORS Used when 24h clock has been selected
-                    format_string = _("Today at %-H:%M");
+                    ///TRANSLATORS '%s' is a placeholder time in 24hr format. It may be moved but not changed.
+                    format_string = _("Today at %s").printf ("%R");
                 } else {
-                    ///TRANSLATORS Used when 12h clock has been selected
-                    format_string = _("Today at %-I:%M %p");
+                    ///TRANSLATORS '%s' is a placeholder time in 12hr format. It may be moved but not changed.
+                    format_string = _("Today at %s").printf ("%-I:%M %p");
                 }
 
                 break;
             case 1:
                 if (clock_is_24h) {
-                    ///TRANSLATORS Used when 24h clock has been selected
-                    format_string = _("Yesterday at %-H:%M");
+                    ///TRANSLATORS '%s' is a placeholder time in 24hr format. It may be moved but not changed.
+                    format_string = _("Yesterday at %s").printf ("%R");
                 } else {
-                    ///TRANSLATORS Used when 12h clock has been selected
-                    format_string = _("Yesterday at %-I:%M %p");
+                    ///TRANSLATORS '%s' is a placeholder time in 12hr format. It may be moved but not changed.
+                    format_string = _("Yesterday at %s").printf ("%-I:%M %p");
                 }
 
                 break;
 
             default:
                 if (clock_is_24h) {
-                    ///TRANSLATORS Used when 24h clock has been selected
-                    format_string = _("%A at %-H:%M");
+                    ///TRANSLATORS '%s' are a placeholders for the day name and the time in 24hr format. They may be moved but not changed.
+                    format_string = _("%s at %s").printf ("%A","%R");
                 } else {
-                    ///TRANSLATORS Used when 12h clock has been selected
-                    format_string = _("%A at %-I:%M %p");
+                    ///TRANSLATORS '%s' are a placeholders for the day name and the time in 12hr format. They may be moved but not changed.
+                    format_string = _("%s at %s").printf ("%A"," %-I:%M %p");
                 }
 
                 break;

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -519,11 +519,13 @@ namespace PF.FileUtils {
 
         switch (now_weekday - disp_weekday) {
             case 0:
+                ///TRANSLATORS '%s' is a placeholder for the time. It may be moved but not changed.
                 format_string = _("Today at %s").printf (Granite.DateTime.get_default_time_format (!clock_is_24h, false));
 
                 break;
             case 1:
             case -6: /* Yesterday is Sunday */
+                ///TRANSLATORS '%s' is a placeholder for the time. It may be moved but not changed.
                 format_string = _("Yesterday at %s").printf (Granite.DateTime.get_default_time_format (!clock_is_24h, false));
 
                 break;

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -519,34 +519,18 @@ namespace PF.FileUtils {
 
         switch (now_weekday - disp_weekday) {
             case 0:
-                if (clock_is_24h) {
-                    ///TRANSLATORS '%s' is a placeholder time in 24hr format. It may be moved but not changed.
-                    format_string = _("Today at %s").printf ("%R");
-                } else {
-                    ///TRANSLATORS '%s' is a placeholder time in 12hr format. It may be moved but not changed.
-                    format_string = _("Today at %s").printf ("%-I:%M %p");
-                }
+                format_string = _("Today at %s").printf (Granite.DateTime.get_default_time_format (!clock_is_24h, false));
 
                 break;
             case 1:
-                if (clock_is_24h) {
-                    ///TRANSLATORS '%s' is a placeholder time in 24hr format. It may be moved but not changed.
-                    format_string = _("Yesterday at %s").printf ("%R");
-                } else {
-                    ///TRANSLATORS '%s' is a placeholder time in 12hr format. It may be moved but not changed.
-                    format_string = _("Yesterday at %s").printf ("%-I:%M %p");
-                }
+            case -6: /* Yesterday is Sunday */
+                format_string = _("Yesterday at %s").printf (Granite.DateTime.get_default_time_format (!clock_is_24h, false));
 
                 break;
 
             default:
-                if (clock_is_24h) {
-                    ///TRANSLATORS '%s' are a placeholders for the day name and the time in 24hr format. They may be moved but not changed.
-                    format_string = _("%s at %s").printf ("%A","%R");
-                } else {
-                    ///TRANSLATORS '%s' are a placeholders for the day name and the time in 12hr format. They may be moved but not changed.
-                    format_string = _("%s at %s").printf ("%A"," %-I:%M %p");
-                }
+                ///TRANSLATORS '%%A' is a placeholder for the day name, '%s' is a placeholder for the time. These may be moved and reordered but not changed.
+                format_string = _("%%A at %s").printf (Granite.DateTime.get_default_time_format (!clock_is_24h, false));
 
                 break;
         }


### PR DESCRIPTION
Fixes #998 

Date format strings have been mistranslated (or not updated) in some locales.

For example, in en_GB:

```
#. TRANSLATORS Used when 12h clock has been selected
#: libcore/FileUtils.vala:533
msgid "Yesterday at %-I:%M %p"
msgstr "Yesterday at %-H:%M"
```

This PR replaces all non-translatable (but movable) parts of the strings with %s, which is substituted appropriately in code.

This will require new translations.  An alternative would be to review and correct all translations of relevant strings.

An advantage of this approach is that the formats could be changed without retranslations.