### PR TITLE
Draw checkerboard background for image items

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -228,6 +228,20 @@ public class GOF.File : GLib.Object {
         return is_desktop_file && !basename.has_suffix (".directory");
     }
 
+    public bool is_image () {
+        if (info == null) {
+            return false;
+        }
+
+        bool is_image = false;
+        unowned string? content_type = get_ftype ();
+        if (content_type != null) {
+            is_image = GLib.ContentType.is_mime_type (content_type, "image/*");
+        }
+
+        return is_image;
+    }
+
     public bool is_trashed () {
         return PF.FileUtils.location_is_in_trash (get_target_location ());
     }

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -167,10 +167,8 @@ namespace Marlin {
 
                 if (focused) {
                     var bg = style_context.get_property ("background-color", state);
-
                     if (bg.holds (typeof (Gdk.RGBA))) {
                         var color = (Gdk.RGBA) bg;
-
                         /* if background-color is black something probably is wrong */
                         if (color.red != 0 || color.green != 0 || color.blue != 0) {
                             pb = PF.PixbufUtils.colorize (pb, color);
@@ -183,14 +181,17 @@ namespace Marlin {
                 }
             }
 
-            if (pb == null) {
-                return;
+            if (file.is_image () ) {
+                style_context.add_class (Granite.STYLE_CLASS_CARD);
+                style_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
             }
 
             cr.scale (1.0 / icon_scale, 1.0 / icon_scale);
-
+            style_context.render_background (cr, background_area.x, background_area.y, background_area.width, background_area.height);
+            style_context.render_frame (cr, cell_area.x, cell_area.y, cell_area.width, cell_area.height);
             style_context.render_icon (cr, pb, draw_rect.x * icon_scale, draw_rect.y * icon_scale);
             style_context.restore ();
+
             int h_overlap = int.min (draw_rect.width, Marlin.IconSize.EMBLEM) / 2;
             int v_overlap = int.min (draw_rect.height, Marlin.IconSize.EMBLEM) / 2;
 
@@ -224,7 +225,6 @@ namespace Marlin {
                         helper_rect.y = int.max (cell_area.y, draw_rect.y - helper_size + v_overlap);
 
                         style_context.render_icon (cr, pix, helper_rect.x * icon_scale, helper_rect.y * icon_scale);
-                        cr.paint ();
                     }
                 }
 
@@ -272,7 +272,6 @@ namespace Marlin {
                     emblem_area.x = int.min (emblem_area.x, cell_area.x + cell_area.width - emblem_size);
 
                     style_context.render_icon (cr, pix, emblem_area.x * icon_scale, emblem_area.y * icon_scale);
-                    cr.paint ();
                     pos++;
                 }
             }

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -29,7 +29,6 @@
 namespace Marlin {
 
     public class IconRenderer : Gtk.CellRenderer {
-        private Gtk.CssProvider shadow_provider;
         public Gdk.Rectangle hover_helper_rect;
         public Gdk.Rectangle hover_rect;
         public bool follow_state {get; set;}
@@ -72,17 +71,6 @@ namespace Marlin {
         private ClipboardManager clipboard;
 
         construct {
-            shadow_provider = new Gtk.CssProvider ();
-            var data = """
-
-            """;
-
-            try {
-                shadow_provider.load_from_data ("* {-gtk-icon-shadow: 3px 6px 2px alpha(#000, 0.22);}");
-            } catch (Error e) {
-                critical (e.message);
-            }
-
             clipboard = Marlin.ClipboardManager.get_for_display ();
             hover_rect = {0, 0, (int) Marlin.IconSize.NORMAL, (int) Marlin.IconSize.NORMAL};
             hover_helper_rect = {0, 0, (int) Marlin.IconSize.EMBLEM, (int) Marlin.IconSize.EMBLEM};
@@ -196,13 +184,11 @@ namespace Marlin {
 
             if (file.is_image () ) {
                 style_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
-                style_context.remove_provider (shadow_provider);
-            } else {
-                style_context.add_provider (shadow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+                style_context.add_class (Granite.STYLE_CLASS_CARD);
             }
 
             cr.scale (1.0 / icon_scale, 1.0 / icon_scale);
-            style_context.render_background (cr, cell_area.x, cell_area.y, cell_area.width, cell_area.height);
+            style_context.render_background (cr, draw_rect.x * icon_scale, draw_rect.y * icon_scale, draw_rect.width * icon_scale, draw_rect.height * icon_scale);
             style_context.render_icon (cr, pb, draw_rect.x * icon_scale, draw_rect.y * icon_scale);
 
             style_context.restore ();

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -29,6 +29,7 @@
 namespace Marlin {
 
     public class IconRenderer : Gtk.CellRenderer {
+        private Gtk.CssProvider shadow_provider;
         public Gdk.Rectangle hover_helper_rect;
         public Gdk.Rectangle hover_rect;
         public bool follow_state {get; set;}
@@ -71,6 +72,17 @@ namespace Marlin {
         private ClipboardManager clipboard;
 
         construct {
+            shadow_provider = new Gtk.CssProvider ();
+            var data = """
+
+            """;
+
+            try {
+                shadow_provider.load_from_data ("* {-gtk-icon-shadow: 3px 6px 2px alpha(#000, 0.22);}");
+            } catch (Error e) {
+                critical (e.message);
+            }
+
             clipboard = Marlin.ClipboardManager.get_for_display ();
             hover_rect = {0, 0, (int) Marlin.IconSize.NORMAL, (int) Marlin.IconSize.NORMAL};
             hover_helper_rect = {0, 0, (int) Marlin.IconSize.EMBLEM, (int) Marlin.IconSize.EMBLEM};
@@ -143,6 +155,7 @@ namespace Marlin {
                 /* 50% translucent for cutted files */
                 pb = PF.PixbufUtils.lucent (pixbuf, 50);
             }
+
             if (file.is_hidden) {
                 /* 75% translucent for hidden files */
                 pb = PF.PixbufUtils.lucent (pixbuf, 75);
@@ -182,14 +195,16 @@ namespace Marlin {
             }
 
             if (file.is_image () ) {
-                style_context.add_class (Granite.STYLE_CLASS_CARD);
                 style_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
+                style_context.remove_provider (shadow_provider);
+            } else {
+                style_context.add_provider (shadow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             }
 
             cr.scale (1.0 / icon_scale, 1.0 / icon_scale);
-            style_context.render_background (cr, background_area.x, background_area.y, background_area.width, background_area.height);
-            style_context.render_frame (cr, cell_area.x, cell_area.y, cell_area.width, cell_area.height);
+            style_context.render_background (cr, cell_area.x, cell_area.y, cell_area.width, cell_area.height);
             style_context.render_icon (cr, pb, draw_rect.x * icon_scale, draw_rect.y * icon_scale);
+
             style_context.restore ();
 
             int h_overlap = int.min (draw_rect.width, Marlin.IconSize.EMBLEM) / 2;


### PR DESCRIPTION
Fixes #712 

Pushed for comment.  No solution to adding a frame or drop shadow to the background using css has yet) been found, but it is possible to add a shadow to the icon itself.  It was considered improper to do this when the icon represents an icon since that may already have a drop shadow incorporated.  At the moment all images have no drop shadow but it would be possible to test if the image is in an icon directory (or is svg?)