### PR TITLE
Draw frame around prelit/focussed icon.

### DIFF
--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -176,10 +176,6 @@ namespace Marlin {
                         }
                     }
                 }
-
-                if (prelit || focused) {
-                    pb = PF.PixbufUtils.lighten (pb);
-                }
             }
 
             if (file.is_image () ) {
@@ -187,9 +183,24 @@ namespace Marlin {
                 style_context.add_class (Granite.STYLE_CLASS_CARD);
             }
 
+            style_context.set_junction_sides (Gtk.JunctionSides.TOP | Gtk.JunctionSides.BOTTOM);
+
             cr.scale (1.0 / icon_scale, 1.0 / icon_scale);
-            style_context.render_background (cr, draw_rect.x * icon_scale, draw_rect.y * icon_scale, draw_rect.width * icon_scale, draw_rect.height * icon_scale);
+            style_context.render_background (cr, draw_rect.x * icon_scale,
+                                             draw_rect.y * icon_scale,
+                                             draw_rect.width * icon_scale,
+                                             draw_rect.height * icon_scale);
+
             style_context.render_icon (cr, pb, draw_rect.x * icon_scale, draw_rect.y * icon_scale);
+
+            if (prelit || focused) {
+                style_context.add_class ("frame");
+                style_context.render_frame (cr, draw_rect.x * icon_scale,
+                                            draw_rect.y * icon_scale,
+                                            draw_rect.width * icon_scale,
+                                            draw_rect.height * icon_scale);
+            }
+
 
             style_context.restore ();
 


### PR DESCRIPTION
Fixes #846.

The first commit draws a subtle frame around the edge of the icon, which is not very obvious until you move it.  A more visualy obvious solution would be to make the frame larger, thicker or different colour.

Suggestions welcome.