### PR TITLE
Lose trash confirm setting

### DIFF
--- a/data/schemas/io.elementary.files.gschema.xml
+++ b/data/schemas/io.elementary.files.gschema.xml
@@ -116,11 +116,6 @@
       <summary>Minimum width of the side pane</summary>
       <description>The minimum width of the side pane.</description>
     </key>
-    <key type="b" name="confirm-trash">
-      <default>true</default>
-      <summary>Confirm trash</summary>
-      <description>Confirm when permanently deleting files and emptying trash</description>
-    </key>
     <key type="b" name="restore-tabs">
       <default>true</default>
       <summary>Whether to restore tabs on start up</summary>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -261,7 +261,6 @@ public class Marlin.Application : Gtk.Application {
                                    prefs, "show-remote-thumbnails", GLib.SettingsBindFlags.DEFAULT);
         Preferences.settings.bind ("hide-local-thumbnails",
                                    prefs, "hide-local-thumbnails", GLib.SettingsBindFlags.DEFAULT);
-        Preferences.settings.bind ("confirm-trash", prefs, "confirm-trash", GLib.SettingsBindFlags.DEFAULT);
         Preferences.settings.bind ("date-format", prefs, "date-format", GLib.SettingsBindFlags.DEFAULT);
         Preferences.gnome_interface_settings.bind ("clock-format",
                                    GOF.Preferences.get_default (), "clock-format", GLib.SettingsBindFlags.GET);


### PR DESCRIPTION
Based on PR #1023 

As per discussion on Slack, the dconf setting "confirm-trash" is removed since it is unneeded by Files and changing it externally has no effect.  Whether or not to show a permanently delete confirmation dialog is decided by the circumstances, not user preference.  