### PR TITLE
Window: Fix first run coords

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -116,21 +116,23 @@ namespace Marlin.View {
                     var default_x = Preferences.settings.get_int ("window-x");
                     var default_y = Preferences.settings.get_int ("window-y");
 
-                    int shadow_size = 64; // An approximation. TODO retrieve from style context?
+                    if (default_x != -1 && default_y != -1) {
+                        int shadow_size = 64; // An approximation. TODO retrieve from style context?
 
-                    // Will be created as a normal window even if saved tiled so allow for added shadow
-                    // and approximate a tiled window on restoration
-                    if (state == Marlin.WindowState.TILED_START ||
-                        state == Marlin.WindowState.TILED_END) {
+                        // Will be created as a normal window even if saved tiled so allow for added shadow
+                        // and approximate a tiled window on restoration
+                        if (state == Marlin.WindowState.TILED_START ||
+                            state == Marlin.WindowState.TILED_END) {
 
-                        default_x -= shadow_size;
-                        default_y -= shadow_size;
+                            default_x -= shadow_size;
+                            default_y -= shadow_size;
 
-                        default_width += shadow_size * 2;
-                        default_height += shadow_size * 2;
+                            default_width += shadow_size * 2;
+                            default_height += shadow_size * 2;
+                        }
+
+                        move (default_x, default_y);
                     }
-
-                    move (default_x, default_y);
                 }
             }
 


### PR DESCRIPTION
Checks that the window coordinates are not `-1` (the default) before moving. This way the first time you open Files it spawns its window in the center of the primary display.