### PR TITLE
Reduce DiskRenderer contrast when inactive

### DIFF
--- a/data/styles/DiskRenderer.css
+++ b/data/styles/DiskRenderer.css
@@ -6,9 +6,17 @@
     border-radius: 99px;
 }
 
+.source-list.level-bar:backdrop {
+    background-color: alpha (@text_color, 0.1);
+}
+
 .source-list.fill-block,
 .source-list.fill-block:hover,
 .source-list.fill-block:selected,
 .source-list.fill-block:selected:focus {
     background-color: alpha (@text_color, 0.6);
+}
+
+.source-list.fill-block:backdrop {
+    background-color: alpha (@text_color, 0.2);
 }


### PR DESCRIPTION
Sidebars in inactive windows have reduced icon & text contrast, but the new DiskRenderer style retains its high contrast:

![files1](https://user-images.githubusercontent.com/70772/66217213-2f6c0700-e6c7-11e9-93a6-2bd79aa33608.png)

This PR reduces the contrast when inactive:

![files2](https://user-images.githubusercontent.com/70772/66217245-3bf05f80-e6c7-11e9-901a-52d3b830bf2f.png)
