### PR TITLE
Fix breadcrumb animation

### DIFF
--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -584,6 +584,11 @@ namespace Marlin.View.Chrome {
             }
         }
 
+        private double ease_out_cubic (double t) {
+            double p = t - 1;
+            return 1 + p * p * p;
+        }
+
         private uint make_animation (Gee.Collection<BreadcrumbElement> els,
                                      double initial_offset,
                                      double final_offset,
@@ -594,7 +599,8 @@ namespace Marlin.View.Chrome {
             var anim = add_tick_callback ((widget, frame_clock) => {
                 int64 time = frame_clock.get_frame_time ();
                 double t = (double) (time - start_time) / LOCATION_BAR_ANIMATION_TIME_USEC;
-                t = 1 - t.clamp (0, 1);
+                t = 1 - ease_out_cubic (t.clamp (0, 1));
+
                 anim_state = final_offset + (initial_offset - final_offset) * t;
 
                 foreach (BreadcrumbElement bread in els) {

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -552,7 +552,7 @@ namespace Marlin.View.Chrome {
         private void replace_elements (Gee.ArrayList<BreadcrumbElement> new_elements) {
             /* Stop any animation */
             if (animation_timeout_id > 0) {
-                Source.remove (animation_timeout_id);
+                remove_tick_callback (animation_timeout_id);
                 animation_timeout_id = 0;
             }
             old_elements = null;
@@ -587,30 +587,27 @@ namespace Marlin.View.Chrome {
         private uint make_animation (Gee.Collection<BreadcrumbElement> els,
                                      double initial_offset,
                                      double final_offset,
-                                     uint time_msec) {
+                                     uint64 time_usec) {
             prepare_to_animate (els, initial_offset);
             var anim_state = initial_offset;
-            double frame_time_msec = 1000 / Marlin.FRAME_RATE_HZ;
-            double frames = time_msec / frame_time_msec;
-            double step = (final_offset - initial_offset) / frames;
-            var anim = Timeout.add ((uint)frame_time_msec, () => {
-                anim_state += step;
+            int64 start_time = get_frame_clock ().get_frame_time ();
+            var anim = add_tick_callback ((widget, frame_clock) => {
+                int64 time = frame_clock.get_frame_time ();
+                double t = (double) (time - start_time) / LOCATION_BAR_ANIMATION_TIME_USEC;
+                t = 1 - t.clamp (0, 1);
+                anim_state = final_offset + (initial_offset - final_offset) * t;
 
-                if (Math.fabs (final_offset - anim_state) < Math.fabs (step)) {
-                    foreach (BreadcrumbElement bread in els) {
-                        bread.offset = final_offset;
-                    }
+                foreach (BreadcrumbElement bread in els) {
+                    bread.offset = anim_state;
+                }
 
+                queue_draw ();
+
+                if (time >= start_time + LOCATION_BAR_ANIMATION_TIME_USEC) {
                     old_elements = null;
-                    queue_draw ();
                     animation_timeout_id = 0;
                     return GLib.Source.REMOVE;
                 } else {
-                    foreach (BreadcrumbElement bread in els) {
-                        bread.offset = anim_state;
-                    }
-
-                    queue_draw ();
                     return GLib.Source.CONTINUE;
                 }
             });
@@ -619,11 +616,11 @@ namespace Marlin.View.Chrome {
         }
 
         private void animate_adding_elements (Gee.Collection<BreadcrumbElement> els) {
-            animation_timeout_id = make_animation (els, 1.0, 0.0, Marlin.LOCATION_BAR_ANIMATION_TIME_MSEC);
+            animation_timeout_id = make_animation (els, 1.0, 0.0, Marlin.LOCATION_BAR_ANIMATION_TIME_USEC);
         }
 
         private void animate_removing_elements (Gee.Collection<BreadcrumbElement> els) {
-            animation_timeout_id = make_animation (els, 0.0, 1.0, Marlin.LOCATION_BAR_ANIMATION_TIME_MSEC);
+            animation_timeout_id = make_animation (els, 0.0, 1.0, Marlin.LOCATION_BAR_ANIMATION_TIME_USEC);
         }
 
         public override bool draw (Cairo.Context cr) {

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -109,11 +109,11 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         if (offset > 0.0) {
             double x_frame_width, x_half_height, x_frame_width_half_height;
             if (is_rtl) {
-                x_frame_width = x - frame_width;
+                x_frame_width = x - frame_width - line_width;
                 x_half_height = x + half_height;
                 x_frame_width_half_height = x_frame_width - half_height;
             } else {
-                x_frame_width = x + frame_width;
+                x_frame_width = x + frame_width + line_width;
                 x_half_height = x - half_height;
                 x_frame_width_half_height = x_frame_width + half_height;
             }

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -79,6 +79,24 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         this.icon_info = icon_info;
     }
 
+    private Cairo.Surface? get_mask (double x1, double y1, double x2, double y2, int scale, Cairo.Path? clip_path) {
+        if (clip_path == null) {
+            return null;
+        }
+
+        int w = (int) (Math.ceil (x2) - Math.floor (x1)) * scale;
+        int h = (int) (Math.ceil (y2) - Math.floor (y1)) * scale;
+        var mask = new Cairo.ImageSurface (Cairo.Format.A8, w, h);
+
+        var cr = new Cairo.Context (mask);
+        cr.translate (-x1, -y1);
+        cr.set_source_rgb (0, 0, 0);
+        cr.append_path (clip_path);
+        cr.fill ();
+
+        return mask;
+    }
+
     public double draw (Cairo.Context cr, double x, double y, double height, Gtk.Widget widget) {
         weak Gtk.StyleContext button_context = widget.get_style_context ();
         var state = button_context.get_state ();
@@ -106,6 +124,11 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         var frame_width = width - padding.right;
 
         /* Erase area for drawing and outline */
+        Cairo.Path clip_path = null;
+        double clip_x1 = 0;
+        double clip_y1 = 0;
+        double clip_x2 = 0;
+        double clip_y2 = 0;
         if (offset > 0.0) {
             double x_frame_width, x_half_height, x_frame_width_half_height;
             if (is_rtl) {
@@ -118,6 +141,7 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
                 x_frame_width_half_height = x_frame_width + half_height;
             }
 
+            cr.new_path ();
             cr.move_to (x_half_height, y);
             cr.line_to (x, y_half_height);
             cr.line_to (x_half_height, y_height);
@@ -125,7 +149,9 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
             cr.line_to (x_frame_width_half_height, y_half_height);
             cr.line_to (x_frame_width, y);
             cr.close_path ();
+            clip_path = cr.copy_path ();
             cr.clip ();
+            cr.clip_extents (out clip_x1, out clip_y1, out clip_x2, out clip_y2);
         }
 
         if (pressed) {/* Highlight the breadcrumb */
@@ -197,6 +223,10 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
             icon_to_draw = PF.PixbufUtils.lucent (icon_to_draw, 50);
         }
 
+        cr.save ();
+        var mask = get_mask (clip_x1, clip_y1, clip_x2, clip_y2, scale, clip_path);
+        cr.push_group ();
+
         /* Draw the text and icon (if present and there is room) */
         if (is_rtl) {
             if (icon_to_draw == null) {
@@ -249,6 +279,16 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
 
             cr.restore ();
         }
+
+        var group = cr.pop_group ();
+        cr.set_source (group);
+        if (mask != null) {
+            cr.mask_surface (mask, clip_x1, clip_y1);
+        } else {
+            cr.paint ();
+        }
+
+        cr.restore ();
 
         /* Move to end of breadcrumb */
         if (is_rtl) {

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -168,10 +168,10 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
 
         if (is_rtl) {
             x -= padding.left;
-            x += Math.sin (offset * Math.PI_2) * width;
+            x += offset * width;
         } else {
             x += padding.left;
-            x -= Math.sin (offset * Math.PI_2) * width;
+            x -= offset * width;
         }
 
         if (layout_width < iw) {

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -194,10 +194,10 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
 
         if (is_rtl) {
             x -= padding.left;
-            x += offset * width;
+            x += offset * Math.round (offset * (width + half_height) * scale) / scale;
         } else {
             x += padding.left;
-            x -= offset * width;
+            x -= offset * Math.round (offset * (width + half_height) * scale) / scale;
         }
 
         if (layout_width < iw) {

--- a/libwidgets/Resources.vala
+++ b/libwidgets/Resources.vala
@@ -68,8 +68,7 @@ namespace Marlin {
     public const string PROTOCOL_NAME_FILE = N_("File System");
 
     public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 36;
-    public const uint LOCATION_BAR_ANIMATION_TIME_MSEC = 300;
-    public const uint FRAME_RATE_HZ = 60;
+    public const uint64 LOCATION_BAR_ANIMATION_TIME_USEC = 300000;
     public const uint BUTTON_LONG_PRESS = 300;
 
     public const int16 DEFAULT_POPUP_MENU_DISPLACEMENT = 2;


### PR DESCRIPTION
* Use add_tick_callback() instead of counting frames manually
* Use easeOutCubic interpolator
* Don't clip the arrow at the end to avoid blinking
* Don't stop the animation until the element is fully hidden, i.e. animate it going under the arrow of the previous element as well.
* Align arrow position to pixel grid.

![Peek 2019-10-06 23-45_1](https://user-images.githubusercontent.com/1510457/66274067-1f405d00-e86a-11e9-9916-1f0ae8f62c29.gif)

It still blinks when changing location though, but that's a different issue.