### PR TITLE
Breadcrumb animation tweaks

### DIFF
--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -593,6 +593,11 @@ namespace Marlin.View.Chrome {
                                      double initial_offset,
                                      double final_offset,
                                      uint64 time_usec) {
+            if (!get_settings ().gtk_enable_animations) {
+                prepare_to_animate (els, final_offset);
+                return 0;
+            }
+
             prepare_to_animate (els, initial_offset);
             var anim_state = initial_offset;
             int64 start_time = get_frame_clock ().get_frame_time ();

--- a/libwidgets/Resources.vala
+++ b/libwidgets/Resources.vala
@@ -68,7 +68,7 @@ namespace Marlin {
     public const string PROTOCOL_NAME_FILE = N_("File System");
 
     public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 36;
-    public const uint64 LOCATION_BAR_ANIMATION_TIME_USEC = 300000;
+    public const uint64 LOCATION_BAR_ANIMATION_TIME_USEC = 200000;
     public const uint BUTTON_LONG_PRESS = 300;
 
     public const int16 DEFAULT_POPUP_MENU_DISPLACEMENT = 2;


### PR DESCRIPTION
Ok, this is probably the last one :)

Change the duration to 200ms and don't animate it if animations are disabled in GTK.