### PR TITLE
Initial port of FileOperations to GTask

### DIFF
--- a/libcore/marlin-file-operations.c
+++ b/libcore/marlin-file-operations.c
@@ -1876,12 +1876,12 @@ delete_job (GIOSchedulerJob *io_job,
     return FALSE;
 }
 
-static void
-trash_or_delete_internal (GList                  *files,
-                          GtkWindow              *parent_window,
-                          gboolean                try_trash,
-                          MarlinDeleteCallback  done_callback,
-                          gpointer                done_callback_data)
+void
+marlin_file_operations_delete (GList                    *files,
+                               GtkWindow                *parent_window,
+                               gboolean                 try_trash,
+                               MarlinDeleteCallback     done_callback,
+                               gpointer                 done_callback_data)
 {
     g_return_if_fail (files != NULL);
 
@@ -1913,28 +1913,6 @@ trash_or_delete_internal (GList                  *files,
                              NULL,
                              0,
                              NULL);
-}
-
-void
-marlin_file_operations_trash_or_delete (GList                   *files,
-                                        GtkWindow               *parent_window,
-                                        MarlinDeleteCallback    done_callback,
-                                        gpointer                done_callback_data)
-{
-    trash_or_delete_internal (files, parent_window,
-                              TRUE,
-                              done_callback,  done_callback_data);
-}
-
-void
-marlin_file_operations_delete (GList                    *files,
-                               GtkWindow                *parent_window,
-                               MarlinDeleteCallback     done_callback,
-                               gpointer                 done_callback_data)
-{
-    trash_or_delete_internal (files, parent_window,
-                              FALSE,
-                              done_callback,  done_callback_data);
 }
 
 
@@ -5682,10 +5660,11 @@ marlin_file_operations_copy_move_link   (GList                  *files,
         if (g_file_has_uri_scheme (target_dir, "trash")) {
             /* done_callback is (or should be) a DeleteCallBack or null in this case */
 
-            marlin_file_operations_trash_or_delete (files,
-                                                    parent_window,
-                                                    (MarlinDeleteCallback)done_callback,
-                                                    done_callback_data);
+            marlin_file_operations_delete (files,
+                                           parent_window,
+                                           TRUE,
+                                           (MarlinDeleteCallback)done_callback,
+                                           done_callback_data);
         } else {
             /* done_callback is (or should be) a CopyCallBack or null in this case */
             marlin_file_operations_move (files,

--- a/libcore/marlin-file-operations.h
+++ b/libcore/marlin-file-operations.h
@@ -46,14 +46,9 @@ void marlin_file_operations_mount_volume_full (GVolume                        *v
 gboolean marlin_file_operations_mount_volume_full_finish (GAsyncResult  *result,
                                                           GError       **error);
 
-void marlin_file_operations_trash_or_delete (GList                  *files,
-                                             GtkWindow              *parent_window,
-                                             MarlinDeleteCallback   done_callback,
-                                             gpointer               done_callback_data);
-
-/* TODO:  Merge with marlin_file_operations_trash_or_delete */
 void marlin_file_operations_delete          (GList                  *files,
                                              GtkWindow              *parent_window,
+                                             gboolean               try_trash,
                                              MarlinDeleteCallback   done_callback,
                                              gpointer               done_callback_data);
 

--- a/libcore/marlin-file-operations.h
+++ b/libcore/marlin-file-operations.h
@@ -28,12 +28,6 @@
 #include <gtk/gtk.h>
 #include <gio/gio.h>
 
-typedef void (* MarlinCreateCallback)    (GFile      *new_file,
-                                          gpointer    callback_data);
-typedef void (* MarlinDeleteCallback)    (gboolean    user_cancel,
-                                          gpointer    callback_data);
-
-
 /* Sidebar uses Marlin.FileOperations to mount volumes but handles unmounting itself */
 void marlin_file_operations_mount_volume  (GVolume   *volume,
                                            GtkWindow *parent_window);
@@ -46,50 +40,69 @@ void marlin_file_operations_mount_volume_full (GVolume                        *v
 gboolean marlin_file_operations_mount_volume_full_finish (GAsyncResult  *result,
                                                           GError       **error);
 
-void marlin_file_operations_delete          (GList                  *files,
-                                             GtkWindow              *parent_window,
-                                             gboolean               try_trash,
-                                             MarlinDeleteCallback   done_callback,
-                                             gpointer               done_callback_data);
+void marlin_file_operations_delete (GList               *files,
+                                    GtkWindow           *parent_window,
+                                    gboolean             try_trash,
+                                    GCancellable        *cancellable,
+                                    GAsyncReadyCallback  callback,
+                                    gpointer             user_data);
 
+gboolean marlin_file_operations_delete_finish (GAsyncResult  *result,
+                                               GError       **error);
 
 gboolean marlin_file_operations_has_trash_files (GMount *mount);
 
 GList *marlin_file_operations_get_trash_dirs_for_mount (GMount *mount);
 
-void marlin_file_operations_empty_trash (GtkWidget                 *parent_view);
+void marlin_file_operations_empty_trash (GtkWidget *parent_view);
 
-void marlin_file_operations_copy_move_link   (GList                  *files,
-                                              GArray                 *relative_item_points,
-                                              GFile                  *target_dir,
-                                              GdkDragAction          copy_action,
-                                              GtkWidget              *parent_view,
-                                              GCallback              done_callback,
-                                              gpointer               done_callback_data);
+void marlin_file_operations_copy_move_link (GList               *files,
+                                            GArray              *relative_item_points,
+                                            GFile               *target_dir,
+                                            GdkDragAction        copy_action,
+                                            GtkWidget           *parent_view,
+                                            GCancellable        *cancellable,
+                                            GAsyncReadyCallback  callback,
+                                            gpointer             user_data);
+
+gboolean marlin_file_operations_copy_move_link_finish (GAsyncResult  *result,
+                                                       GError       **error);
 
 
-void marlin_file_operations_new_file    (GtkWidget                 *parent_view,
-                                         GdkPoint                  *target_point,
-                                         const char                *parent_dir,
-                                         const char                *target_filename,
-                                         const char                *initial_contents,
-                                         int                        length,
-                                         MarlinCreateCallback     done_callback,
-                                         gpointer                   data);
+void marlin_file_operations_new_file (GtkWidget           *parent_view,
+                                      GdkPoint            *target_point,
+                                      const gchar         *parent_dir,
+                                      const gchar         *target_filename,
+                                      const gchar         *initial_contents,
+                                      gint                 length,
+                                      GCancellable        *cancellable,
+                                      GAsyncReadyCallback  callback,
+                                      gpointer             user_data);
+
+GFile *marlin_file_operations_new_file_finish (GAsyncResult  *result,
+                                               GError       **error);
 
 /* TODO: Merge with marlin_file_operations_new_file */
-void marlin_file_operations_new_folder  (GtkWidget                 *parent_view,
-                                         GdkPoint                  *target_point,
-                                         GFile                     *parent_dir,
-                                         MarlinCreateCallback     done_callback,
-                                         gpointer                   done_callback_data);
+void marlin_file_operations_new_folder (GtkWidget           *parent_view,
+                                        GdkPoint            *target_point,
+                                        GFile               *parent_dir,
+                                        GCancellable        *cancellable,
+                                        GAsyncReadyCallback  callback,
+                                        gpointer             user_data);
 
-void marlin_file_operations_new_file_from_template (GtkWidget               *parent_view,
-                                                    GdkPoint                *target_point,
-                                                    GFile                   *parent_dir,
-                                                    const char              *target_filename,
-                                                    GFile                   *template,
-                                                    MarlinCreateCallback     done_callback,
-                                                    gpointer                 data);
+GFile *marlin_file_operations_new_folder_finish (GAsyncResult  *result,
+                                                 GError       **error);
+
+void marlin_file_operations_new_file_from_template (GtkWidget           *parent_view,
+                                                    GdkPoint            *target_point,
+                                                    GFile               *parent_dir,
+                                                    const gchar         *target_filename,
+                                                    GFile               *template,
+                                                    GCancellable        *cancellable,
+                                                    GAsyncReadyCallback  callback,
+                                                    gpointer             user_data);
+
+GFile *marlin_file_operations_new_file_from_template_finish (GAsyncResult  *result,
+                                                             GError       **error);
 
 #endif /* MARLIN_FILE_OPERATIONS_H */

--- a/libcore/marlin-undostack-manager.c
+++ b/libcore/marlin-undostack-manager.c
@@ -172,15 +172,6 @@ static void undostack_dispose_all (GQueue *queue);
 static void undo_redo_done_transfer_callback (GHashTable *debuting_uris,
                                               gpointer data);
 
-static void undo_redo_done_rename_callback (GObject      *object,
-                                            GAsyncResult *result,
-                                            gpointer      user_data);
-
-static void undo_redo_done_delete_callback (gboolean user_cancel, gpointer callback_data);
-
-static void undo_redo_done_create_callback (GFile * new_file,
-                                            gpointer callback_data);
-
 static void clear_redo_actions (MarlinUndoManager *self);
 
 static gchar *get_first_target_short_name (MarlinUndoActionData *action);
@@ -366,15 +357,138 @@ marlin_undo_manager_is_undo_redo (MarlinUndoManager *manager)
   do_menu_update (manager);
   }*/
 
+static void
+marlin_undo_action_data_done (MarlinUndoActionData *action)
+{
+    MarlinUndoManager *manager;
+
+    g_return_if_fail (action != NULL);
+
+    manager = action->manager;
+    /* If the action needed to be freed but was locked, free now */
+    if (action->freed) {
+        free_undo_action (action, NULL);
+    } else {
+        action->locked = FALSE;
+    }
+
+    manager->undo_redo_flag = FALSE;
+
+    /* Update menus */
+    do_menu_update (manager);
+}
+
+static void
+marlin_undo_manager_on_copy_move_link (GObject *source_object,
+                                       GAsyncResult *res,
+                                       gpointer user_data)
+{
+    GError *error = NULL;
+    GTask *task = (GTask *)user_data;
+    MarlinUndoActionData *action = g_task_get_task_data (task);
+    marlin_undo_action_data_done (action);
+
+    if (!marlin_file_operations_copy_move_link_finish (res, &error)) {
+        g_task_return_error (task, error);
+    } else {
+        g_task_return_boolean (task, TRUE);
+    }
+}
+
+static void
+marlin_undo_manager_on_new_file (GObject *source_object,
+                                 GAsyncResult *res,
+                                 gpointer user_data)
+{
+    GError *error = NULL;
+    GFile *file;
+    GTask *task = (GTask *)user_data;
+    MarlinUndoActionData *action = g_task_get_task_data (task);
+    marlin_undo_action_data_done (action);
+
+    file = marlin_file_operations_new_file_finish (res, &error);
+    if (error) {
+        g_task_return_error (task, error);
+    } else {
+        g_task_return_boolean (task, TRUE);
+    }
+
+    g_object_unref (file);
+    g_object_unref (task);
+}
+
+static void
+marlin_undo_manager_on_new_folder (GObject *source_object,
+                                   GAsyncResult *res,
+                                   gpointer user_data)
+{
+    GError *error = NULL;
+    GFile *file;
+    GTask *task = (GTask *)user_data;
+    MarlinUndoActionData *action = g_task_get_task_data (task);
+    marlin_undo_action_data_done (action);
+
+    file = marlin_file_operations_new_folder_finish (res, &error);
+    if (error) {
+        g_task_return_error (task, error);
+    } else {
+        g_task_return_boolean (task, TRUE);
+    }
+
+    g_object_unref (file);
+    g_object_unref (task);
+}
+
+static void
+marlin_undo_manager_on_delete_finished (GObject *source_object,
+                                        GAsyncResult *res,
+                                        gpointer user_data)
+{
+    GError *error = NULL;
+    GTask *task = (GTask *)user_data;
+    MarlinUndoActionData *action = g_task_get_task_data (task);
+    marlin_undo_action_data_done (action);
+
+    if (!marlin_file_operations_delete_finish (res, &error)) {
+        g_task_return_error (task, error);
+    } else {
+        g_task_return_boolean (task, TRUE);
+    }
+}
+
+static void
+marlin_undo_manager_on_renamed_finished (GObject *source_object,
+                                         GAsyncResult *res,
+                                         gpointer user_data)
+{
+    GError *error = NULL;
+    GFile *file;
+    GTask *task = (GTask *)user_data;
+    MarlinUndoActionData *action = g_task_get_task_data (task);
+    marlin_undo_action_data_done (action);
+
+    file = pf_file_utils_set_file_display_name_finish (res, &error);
+    if (error) {
+        g_task_return_error (task, error);
+    } else {
+        g_task_return_boolean (task, TRUE);
+    }
+
+    g_object_unref (file);
+    g_object_unref (task);
+}
+
 /** ****************************************************************
  * Redoes the last file operation
 ** ****************************************************************/
 void
-marlin_undo_manager_redo (MarlinUndoManager *self,
-                          GtkWidget *parent_view,
-                          MarlinUndoFinishCallback cb,
-                          gpointer callback_data)
+marlin_undo_manager_redo (MarlinUndoManager   *self,
+                          GtkWidget           *parent_view,
+                          GCancellable        *cancellable,
+                          GAsyncReadyCallback  callback,
+                          gpointer             user_data)
 {
+    GTask *task;
     GList *uris;
     GFile *file;
     char *new_name;
@@ -382,6 +496,9 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
     GFile *fparent;
 
     g_return_if_fail (MARLIN_IS_UNDO_MANAGER (self));
+
+    task = g_task_new (self, cancellable, callback, user_data);
+    g_task_set_source_tag (task, marlin_undo_manager_undo);
 
     g_mutex_lock (&self->mutex);
 
@@ -394,6 +511,7 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
 
     g_mutex_unlock (&self->mutex);
 
+    g_task_set_task_data (task, action, NULL);
     do_menu_update (self);
 
     if (action != NULL) {
@@ -404,7 +522,9 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
             uris = construct_gfile_list (action->sources, action->src_dir);
             marlin_file_operations_copy_move_link (uris, NULL, action->dest_dir,
                                                    GDK_ACTION_COPY, NULL,
-                                                   G_CALLBACK (undo_redo_done_transfer_callback), action);
+                                                   cancellable,
+                                                   marlin_undo_manager_on_copy_move_link,
+                                                   task);
 
             g_list_free_full (uris, g_object_unref); /* marlin-file-operation takes deep copy */
             break;
@@ -412,7 +532,9 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
             uris = construct_gfile_list (action->sources, action->src_dir);
             marlin_file_operations_copy_move_link (uris, NULL, NULL,
                                                    GDK_ACTION_COPY, NULL,
-                                                   G_CALLBACK (undo_redo_done_transfer_callback), action);
+                                                   cancellable,
+                                                   marlin_undo_manager_on_copy_move_link,
+                                                   task);
 
             g_list_free_full (uris, g_object_unref); /* marlin-file-operation takes deep copy */
             break;
@@ -422,7 +544,9 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
             uris = construct_gfile_list (action->sources, action->src_dir);
             marlin_file_operations_copy_move_link (uris, NULL, action->dest_dir,
                                                    GDK_ACTION_MOVE, NULL,
-                                                   G_CALLBACK (undo_redo_done_transfer_callback), action);
+                                                   cancellable,
+                                                   marlin_undo_manager_on_copy_move_link,
+                                                   task);
 
             g_list_free_full (uris, g_object_unref); /* marlin-file-operation takes deep copy */
             break;
@@ -433,8 +557,8 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
             pf_file_utils_set_file_display_name (file,
                                                  new_name,
                                                  NULL,
-                                                 undo_redo_done_rename_callback,
-                                                 action);
+                                                 marlin_undo_manager_on_renamed_finished,
+                                                 task);
             g_free (new_name);
             g_object_unref (file);
             break;
@@ -445,14 +569,19 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
             marlin_file_operations_new_file (NULL, NULL, puri,
                                              new_name,
                                              action->template,
-                                             0, undo_redo_done_create_callback, action);
+                                             0,
+                                             cancellable,
+                                             marlin_undo_manager_on_new_file,
+                                             task);
             g_free (puri);
             g_free (new_name);
             break;
         case MARLIN_UNDO_CREATEFOLDER:
             fparent = get_file_parent_from_uri (action->target_uri);
             marlin_file_operations_new_folder (NULL, NULL, fparent,
-                                               undo_redo_done_create_callback, action);
+                                               cancellable,
+                                               marlin_undo_manager_on_new_folder,
+                                               task);
             g_object_unref (fparent);
             break;
         case MARLIN_UNDO_MOVETOTRASH:
@@ -460,40 +589,48 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
                 GList *uri_to_trash = g_hash_table_get_keys (action->trashed);
                 uris = uri_list_to_gfile_list (uri_to_trash);
                 self->undo_redo_flag = TRUE;
-                marlin_file_operations_delete
-                    (uris, NULL, TRUE, undo_redo_done_delete_callback, action);
+                marlin_file_operations_delete (uris, NULL, TRUE,
+                                               cancellable,
+                                               marlin_undo_manager_on_delete_finished,
+                                               task);
                 g_list_free (uri_to_trash);
                 g_list_free_full (uris, g_object_unref);
+            } else {
+                g_task_return_boolean (task, TRUE);
+                g_object_unref (task);
             }
             break;
         case MARLIN_UNDO_CREATELINK:
             uris = construct_gfile_list (action->sources, action->src_dir);
             marlin_file_operations_copy_move_link (uris, NULL, action->dest_dir,
                                                    GDK_ACTION_LINK, NULL,
-                                                   G_CALLBACK (undo_redo_done_transfer_callback), action);
+                                                   cancellable,
+                                                   marlin_undo_manager_on_copy_move_link,
+                                                   task);
 
             g_list_free_full (uris, g_object_unref); /* marlin-file-operation takes deep copy */
             break;
         case MARLIN_UNDO_DELETE:
         default:
             self->undo_redo_flag = FALSE;
+            g_task_return_boolean (task, TRUE);
+            g_object_unref (task);
             break;                  /* We shouldn't be here */
         }
     }
-
-    if (cb != NULL)
-        (*cb) ((gpointer) parent_view);
 }
 
 /** ****************************************************************
  * Undoes the last file operation
 ** ****************************************************************/
 void
-marlin_undo_manager_undo (MarlinUndoManager *self,
-                          GtkWidget *parent_view,
-                          MarlinUndoFinishCallback cb,
-                          gpointer done_callback_data)
+marlin_undo_manager_undo (MarlinUndoManager   *self,
+                          GtkWidget           *parent_view,
+                          GCancellable        *cancellable,
+                          GAsyncReadyCallback  callback,
+                          gpointer             user_data)
 {
+    GTask *task;
     GList *uris = NULL;
     GHashTable *files_to_restore;
     GFile *file;
@@ -501,6 +638,8 @@ marlin_undo_manager_undo (MarlinUndoManager *self,
 
     g_return_if_fail (MARLIN_IS_UNDO_MANAGER (self));
 
+    task = g_task_new (self, cancellable, callback, user_data);
+    g_task_set_source_tag (task, marlin_undo_manager_undo);
     g_mutex_lock (&self->mutex);
 
     MarlinUndoActionData *action = stack_scroll_right (self);
@@ -529,7 +668,9 @@ marlin_undo_manager_undo (MarlinUndoManager *self,
             }
             if (self->confirm_delete) {
                 marlin_file_operations_delete (uris, NULL, FALSE,
-                                               undo_redo_done_delete_callback, action);
+                                               cancellable,
+                                               marlin_undo_manager_on_delete_finished,
+                                               task);
                 g_list_free_full (uris, g_object_unref);
             } else {
                 /* We skip the confirmation message
@@ -544,13 +685,17 @@ marlin_undo_manager_undo (MarlinUndoManager *self,
                 marlin_file_changes_consume_changes (TRUE);
 
                 /* Here we must do what's necessary for the callback */
-                undo_redo_done_transfer_callback (NULL, action);
+                marlin_undo_action_data_done (action);
+                g_task_return_boolean (task, TRUE);
+                g_object_unref (task);
             }
             break;
         case MARLIN_UNDO_RESTOREFROMTRASH:
             uris = construct_gfile_list (action->destinations, action->dest_dir);
             marlin_file_operations_delete (uris, NULL, TRUE,
-                                           undo_redo_done_delete_callback, action);
+                                           cancellable,
+                                           marlin_undo_manager_on_delete_finished,
+                                           task);
             g_list_free_full (uris, g_object_unref);
             break;
         case MARLIN_UNDO_MOVETOTRASH:
@@ -581,13 +726,17 @@ marlin_undo_manager_undo (MarlinUndoManager *self,
             g_hash_table_destroy (files_to_restore);
 
             /* Here we must do what's necessary for the callback */
-            undo_redo_done_transfer_callback (NULL, action);
+            marlin_undo_action_data_done (action);
+            g_task_return_boolean (task, TRUE);
+            g_object_unref (task);
             break;
         case MARLIN_UNDO_MOVE:
             uris = construct_gfile_list (action->destinations, action->dest_dir);
             marlin_file_operations_copy_move_link (uris, NULL, action->src_dir,
                                                    GDK_ACTION_MOVE, NULL,
-                                                   G_CALLBACK (undo_redo_done_transfer_callback), action);
+                                                   cancellable,
+                                                   marlin_undo_manager_on_copy_move_link,
+                                                   task);
 
             g_list_free_full (uris, g_object_unref); /* marlin-file-operation takes deep copy */
             break;
@@ -598,8 +747,8 @@ marlin_undo_manager_undo (MarlinUndoManager *self,
             pf_file_utils_set_file_display_name (file,
                                                  new_name,
                                                  NULL,
-                                                 undo_redo_done_rename_callback,
-                                                 action);
+                                                 marlin_undo_manager_on_renamed_finished,
+                                                 task);
             g_free (new_name);
             g_object_unref (file);
             break;
@@ -1639,36 +1788,6 @@ undo_redo_done_transfer_callback (GHashTable * debuting_uris, gpointer data)
 
     /* Update menus */
     do_menu_update (action->manager);
-}
-
-/** ---------------------------------------------------------------- */
-static void
-undo_redo_done_delete_callback (gboolean user_cancel, gpointer callback_data)
-{
-    undo_redo_done_transfer_callback (NULL, callback_data);
-}
-
-/** ---------------------------------------------------------------- */
-static void
-undo_redo_done_create_callback (GFile * new_file, gpointer callback_data)
-{
-    undo_redo_done_transfer_callback (NULL, callback_data);
-}
-
-/** ---------------------------------------------------------------- */
-static void
-undo_redo_done_rename_callback (GObject      *object,
-                                GAsyncResult *result,
-                                gpointer      user_data)
-{
-    GError *e = NULL;
-    GFile* res_file = pf_file_utils_set_file_display_name_finish (result, &e);
-    if (e != NULL) {
-        g_error_free (e);
-    }
-
-    g_object_unref (res_file);
-    undo_redo_done_transfer_callback (NULL, user_data);
 }
 
 /** ---------------------------------------------------------------- */

--- a/libcore/marlin-undostack-manager.c
+++ b/libcore/marlin-undostack-manager.c
@@ -460,8 +460,8 @@ marlin_undo_manager_redo (MarlinUndoManager *self,
                 GList *uri_to_trash = g_hash_table_get_keys (action->trashed);
                 uris = uri_list_to_gfile_list (uri_to_trash);
                 self->undo_redo_flag = TRUE;
-                marlin_file_operations_trash_or_delete
-                    (uris, NULL, undo_redo_done_delete_callback, action);
+                marlin_file_operations_delete
+                    (uris, NULL, TRUE, undo_redo_done_delete_callback, action);
                 g_list_free (uri_to_trash);
                 g_list_free_full (uris, g_object_unref);
             }
@@ -528,7 +528,7 @@ marlin_undo_manager_undo (MarlinUndoManager *self,
                 uris = g_list_reverse (uris); // Deleting must be done in reverse
             }
             if (self->confirm_delete) {
-                marlin_file_operations_delete (uris, NULL,
+                marlin_file_operations_delete (uris, NULL, FALSE,
                                                undo_redo_done_delete_callback, action);
                 g_list_free_full (uris, g_object_unref);
             } else {
@@ -549,8 +549,8 @@ marlin_undo_manager_undo (MarlinUndoManager *self,
             break;
         case MARLIN_UNDO_RESTOREFROMTRASH:
             uris = construct_gfile_list (action->destinations, action->dest_dir);
-            marlin_file_operations_trash_or_delete (uris, NULL,
-                                                    undo_redo_done_delete_callback, action);
+            marlin_file_operations_delete (uris, NULL, TRUE,
+                                           undo_redo_done_delete_callback, action);
             g_list_free_full (uris, g_object_unref);
             break;
         case MARLIN_UNDO_MOVETOTRASH:

--- a/libcore/marlin-undostack-manager.h
+++ b/libcore/marlin-undostack-manager.h
@@ -61,9 +61,6 @@ struct _MarlinUndoMenuData {
 
 /* End action structures */
 
-typedef void
-(*MarlinUndoFinishCallback)(gpointer data);
-
 #define TYPE_MARLIN_UNDO_MANAGER (marlin_undo_manager_get_type())
 G_DECLARE_FINAL_TYPE (MarlinUndoManager, marlin_undo_manager, MARLIN, UNDO_MANAGER, GObject)
 
@@ -75,14 +72,28 @@ void
 marlin_undo_manager_add_rename_action (MarlinUndoManager* manager,
                                        GFile* file,
                                        const char* original_name);
- 
-void
-marlin_undo_manager_undo (MarlinUndoManager* manager,
-                          GtkWidget *parent_view, MarlinUndoFinishCallback cb, gpointer done_callback_data);
 
 void
-marlin_undo_manager_redo (MarlinUndoManager* manager,
-                          GtkWidget *parent_view, MarlinUndoFinishCallback cb, gpointer done_callback_data);
+marlin_undo_manager_undo (MarlinUndoManager   *manager,
+                          GtkWidget           *parent_view,
+                          GCancellable        *cancellable,
+                          GAsyncReadyCallback  callback,
+                          gpointer             user_data);
+gboolean
+marlin_undo_manager_undo_finish (MarlinUndoManager  *manager,
+                                 GAsyncResult       *result,
+                                 GError            **error);
+
+void
+marlin_undo_manager_redo (MarlinUndoManager   *manager,
+                          GtkWidget           *parent_view,
+                          GCancellable        *cancellable,
+                          GAsyncReadyCallback  callback,
+                          gpointer             user_data);
+gboolean
+marlin_undo_manager_redo_finish (MarlinUndoManager  *manager,
+                                 GAsyncResult       *result,
+                                 GError            **error);
 
 MarlinUndoActionData*
 marlin_undo_manager_data_new (MarlinUndoActionType type,

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -56,8 +56,7 @@ namespace Marlin {
         static void new_folder(Gtk.Widget? parent_view, Gdk.Point? target_point, GLib.File file,Marlin.CreateCallback? create_callback = null);
         static void mount_volume (GLib.Volume volume, Gtk.Window? parent_window = null);
         static async void mount_volume_full (GLib.Volume volume, Gtk.Window? parent_window = null) throws GLib.Error;
-        static void trash_or_delete (GLib.List<GLib.File> locations, Gtk.Window window, DeleteCallback? callback = null);
-        static void @delete (GLib.List<GLib.File> locations, Gtk.Window window, DeleteCallback? callback = null);
+        static void @delete (GLib.List<GLib.File> locations, Gtk.Window window, bool try_trash, DeleteCallback? callback = null);
         static bool has_trash_files (GLib.Mount mount);
         static GLib.List<GLib.File> get_trash_dirs_for_mount (GLib.Mount mount);
         static void empty_trash (Gtk.Widget? widget);

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -53,25 +53,18 @@ namespace FM
 namespace Marlin {
     [CCode (cprefix = "MarlinFileOperations", lower_case_cprefix = "marlin_file_operations_", cheader_filename = "marlin-file-operations.h")]
     namespace FileOperations {
-        static void new_folder(Gtk.Widget? parent_view, Gdk.Point? target_point, GLib.File file,Marlin.CreateCallback? create_callback = null);
+        static async GLib.File new_folder (Gtk.Widget? parent_view, Gdk.Point? target_point, GLib.File file) throws GLib.Error;
         static void mount_volume (GLib.Volume volume, Gtk.Window? parent_window = null);
-        static async void mount_volume_full (GLib.Volume volume, Gtk.Window? parent_window = null) throws GLib.Error;
-        static void @delete (GLib.List<GLib.File> locations, Gtk.Window window, bool try_trash, DeleteCallback? callback = null);
+        static async void mount_volume_full (GLib.Volume volume, Gtk.Window? parent_window = null, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        static async void @delete (GLib.List<GLib.File> locations, Gtk.Window window, bool try_trash, GLib.Cancellable? cancellable = null) throws GLib.Error;
         static bool has_trash_files (GLib.Mount mount);
         static GLib.List<GLib.File> get_trash_dirs_for_mount (GLib.Mount mount);
         static void empty_trash (Gtk.Widget? widget);
         static void empty_trash_for_mount (Gtk.Widget? widget, GLib.Mount mount);
-        static void copy_move_link (GLib.List<GLib.File> files, GLib.Array<Gdk.Point>? relative_item_points, GLib.File target_dir, Gdk.DragAction copy_action, Gtk.Widget? parent_view = null, CopyCallback? done_callback = null);
-        static void new_file (Gtk.Widget parent_view, Gdk.Point? target_point, string parent_dir, string? target_filename, string? initial_contents, int length, Marlin.CreateCallback? create_callback = null);
-        static void new_file_from_template (Gtk.Widget parent_view, Gdk.Point? target_point, GLib.File parent_dir, string? target_filename, GLib.File template, Marlin.CreateCallback? create_callback = null);
+        static async bool copy_move_link (GLib.List<GLib.File> files, GLib.Array<Gdk.Point>? relative_item_points, GLib.File target_dir, Gdk.DragAction copy_action, Gtk.Widget? parent_view = null, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        static async GLib.File new_file (Gtk.Widget parent_view, Gdk.Point? target_point, string parent_dir, string? target_filename, string? initial_contents, int length, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        static async GLib.File new_file_from_template (Gtk.Widget parent_view, Gdk.Point? target_point, GLib.File parent_dir, string? target_filename, GLib.File template, GLib.Cancellable? cancellable = null) throws GLib.Error;
     }
-
-    [CCode (cheader_filename = "marlin-file-operations.h")]
-    public delegate void CreateCallback (GLib.File? new_file);
-    [CCode (cheader_filename = "marlin-file-operations.h")]
-    public delegate void DeleteCallback (bool user_cancel);
-    [CCode (cname="GCallback")]
-    public delegate void CopyCallback ();
 }
 
 [CCode (cprefix = "Marlin", lower_case_cprefix = "marlin_")]
@@ -86,17 +79,14 @@ namespace Marlin
     }
 
     [CCode (cheader_filename = "marlin-undostack-manager.h")]
-    public delegate void UndoFinishCallback ();
-
-    [CCode (cheader_filename = "marlin-undostack-manager.h")]
     public class UndoManager : GLib.Object
     {
         public static unowned UndoManager instance ();
 
         public signal void request_menu_update (UndoMenuData data);
 
-        public void undo (Gtk.Widget widget, UndoFinishCallback? cb);
-        public void redo (Gtk.Widget widget, UndoFinishCallback? cb);
+        public async bool undo (Gtk.Widget widget, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        public async bool redo (Gtk.Widget widget, GLib.Cancellable? cancellable = null) throws GLib.Error;
         public void add_rename_action (GLib.File renamed_file, string original_name);
     }
 }

--- a/plugins/pantheon-files-trash/plugin.vala
+++ b/plugins/pantheon-files-trash/plugin.vala
@@ -94,7 +94,7 @@ public class Marlin.Plugins.Trash : Marlin.Plugins.Base {
                         }
 
                         if (to_delete != null) {
-                            Marlin.FileOperations.@delete (to_delete, window);
+                            Marlin.FileOperations.@delete (to_delete, window, false);
                         }
                     }
                 });

--- a/src/ClipboardManager.vala
+++ b/src/ClipboardManager.vala
@@ -119,24 +119,9 @@ namespace Marlin {
          * Pastes the contents from the clipboard to the directory
          * referenced by @target_file.
         **/
-        public void paste_files (GLib.File target_file,
-                                 Gtk.Widget? widget = null,
-                                 GLib.Callback? new_files_callback = null) {
-
-            /**
-             *  @cb the clipboard.
-             *  @sd selection_data returned from the clipboard.
-            **/
-            clipboard.request_contents (x_special_gnome_copied_files, (cb, sd) => {
-                contents_received (sd, target_file, widget, new_files_callback);
-            });
-
-        }
-
-        private void contents_received (Gtk.SelectionData sd,
-                                        GLib.File target_file,
-                                        Gtk.Widget? widget = null,
-                                        GLib.Callback? new_files_callback = null) {
+        public async void paste_files (GLib.File target_file,
+                                       Gtk.Widget? widget = null) {
+            SelectionData? sd = clipboard.wait_for_contents (x_special_gnome_copied_files);
 
             /* check whether the retrieval worked */
             string? text;
@@ -168,12 +153,12 @@ namespace Marlin {
             var file_list = PF.FileUtils.files_from_uris (text);
 
             if (file_list != null) {
-                FileOperations.copy_move_link (file_list,
-                                               null,
-                                               target_file,
-                                               action,
-                                               widget,
-                                               (Marlin.CopyCallback) new_files_callback);
+                FileOperations.copy_move_link.begin (file_list,
+                                                     null,
+                                                     target_file,
+                                                     action,
+                                                     widget,
+                                                     (Marlin.CopyCallback) new_files_callback);
             }
 
             /* clear the clipboard if it contained "cutted data"

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -899,15 +899,10 @@ namespace FM {
                 locations.reverse ();
 
                 slot.directory.block_monitor ();
-                if (delete_immediately) {
-                    Marlin.FileOperations.@delete (locations,
-                                                   window as Gtk.Window,
-                                                   after_trash_or_delete);
-                } else {
-                    Marlin.FileOperations.trash_or_delete (locations,
-                                                           window as Gtk.Window,
-                                                           after_trash_or_delete);
-                }
+                Marlin.FileOperations.@delete (locations,
+                                               window as Gtk.Window,
+                                               !delete_immediately,
+                                               after_trash_or_delete);
             }
 
             /* If in recent "folder" we need to refresh the view. */


### PR DESCRIPTION
With this, switching FileOperations to Vala will be easier, also removes the use of a deprecated API