### PR TITLE
Initial port of FileOperations to GTask

### DIFF
--- a/libcore/marlin-file-operations.h
+++ b/libcore/marlin-file-operations.h
@@ -28,12 +28,6 @@
 #include <gtk/gtk.h>
 #include <gio/gio.h>
 
-typedef void (* MarlinCreateCallback)    (GFile      *new_file,
-                                          gpointer    callback_data);
-typedef void (* MarlinDeleteCallback)    (gboolean    user_cancel,
-                                          gpointer    callback_data);
-
-
 /* Sidebar uses Marlin.FileOperations to mount volumes but handles unmounting itself */
 void marlin_file_operations_mount_volume  (GVolume   *volume,
                                            GtkWindow *parent_window);
@@ -46,50 +40,69 @@ void marlin_file_operations_mount_volume_full (GVolume                        *v
 gboolean marlin_file_operations_mount_volume_full_finish (GAsyncResult  *result,
                                                           GError       **error);
 
-void marlin_file_operations_delete          (GList                  *files,
-                                             GtkWindow              *parent_window,
-                                             gboolean               try_trash,
-                                             MarlinDeleteCallback   done_callback,
-                                             gpointer               done_callback_data);
+void marlin_file_operations_delete (GList               *files,
+                                    GtkWindow           *parent_window,
+                                    gboolean             try_trash,
+                                    GCancellable        *cancellable,
+                                    GAsyncReadyCallback  callback,
+                                    gpointer             user_data);
 
+gboolean marlin_file_operations_delete_finish (GAsyncResult  *result,
+                                               GError       **error);
 
 gboolean marlin_file_operations_has_trash_files (GMount *mount);
 
 GList *marlin_file_operations_get_trash_dirs_for_mount (GMount *mount);
 
-void marlin_file_operations_empty_trash (GtkWidget                 *parent_view);
+void marlin_file_operations_empty_trash (GtkWidget *parent_view);
 
-void marlin_file_operations_copy_move_link   (GList                  *files,
-                                              GArray                 *relative_item_points,
-                                              GFile                  *target_dir,
-                                              GdkDragAction          copy_action,
-                                              GtkWidget              *parent_view,
-                                              GCallback              done_callback,
-                                              gpointer               done_callback_data);
+void marlin_file_operations_copy_move_link (GList               *files,
+                                            GArray              *relative_item_points,
+                                            GFile               *target_dir,
+                                            GdkDragAction        copy_action,
+                                            GtkWidget           *parent_view,
+                                            GCancellable        *cancellable,
+                                            GAsyncReadyCallback  callback,
+                                            gpointer             user_data);
+
+gboolean marlin_file_operations_copy_move_link_finish (GAsyncResult  *result,
+                                                       GError       **error);
 
 
-void marlin_file_operations_new_file    (GtkWidget                 *parent_view,
-                                         GdkPoint                  *target_point,
-                                         const char                *parent_dir,
-                                         const char                *target_filename,
-                                         const char                *initial_contents,
-                                         int                        length,
-                                         MarlinCreateCallback     done_callback,
-                                         gpointer                   data);
+void marlin_file_operations_new_file (GtkWidget           *parent_view,
+                                      GdkPoint            *target_point,
+                                      const gchar         *parent_dir,
+                                      const gchar         *target_filename,
+                                      const gchar         *initial_contents,
+                                      gint                 length,
+                                      GCancellable        *cancellable,
+                                      GAsyncReadyCallback  callback,
+                                      gpointer             user_data);
+
+GFile *marlin_file_operations_new_file_finish (GAsyncResult  *result,
+                                               GError       **error);
 
 /* TODO: Merge with marlin_file_operations_new_file */
-void marlin_file_operations_new_folder  (GtkWidget                 *parent_view,
-                                         GdkPoint                  *target_point,
-                                         GFile                     *parent_dir,
-                                         MarlinCreateCallback     done_callback,
-                                         gpointer                   done_callback_data);
+void marlin_file_operations_new_folder (GtkWidget           *parent_view,
+                                        GdkPoint            *target_point,
+                                        GFile               *parent_dir,
+                                        GCancellable        *cancellable,
+                                        GAsyncReadyCallback  callback,
+                                        gpointer             user_data);
 
-void marlin_file_operations_new_file_from_template (GtkWidget               *parent_view,
-                                                    GdkPoint                *target_point,
-                                                    GFile                   *parent_dir,
-                                                    const char              *target_filename,
-                                                    GFile                   *template,
-                                                    MarlinCreateCallback     done_callback,
-                                                    gpointer                 data);
+GFile *marlin_file_operations_new_folder_finish (GAsyncResult  *result,
+                                                 GError       **error);
+
+void marlin_file_operations_new_file_from_template (GtkWidget           *parent_view,
+                                                    GdkPoint            *target_point,
+                                                    GFile               *parent_dir,
+                                                    const gchar         *target_filename,
+                                                    GFile               *template,
+                                                    GCancellable        *cancellable,
+                                                    GAsyncReadyCallback  callback,
+                                                    gpointer             user_data);
+
+GFile *marlin_file_operations_new_file_from_template_finish (GAsyncResult  *result,
+                                                             GError       **error);
 
 #endif /* MARLIN_FILE_OPERATIONS_H */

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -53,25 +53,18 @@ namespace FM
 namespace Marlin {
     [CCode (cprefix = "MarlinFileOperations", lower_case_cprefix = "marlin_file_operations_", cheader_filename = "marlin-file-operations.h")]
     namespace FileOperations {
-        static void new_folder(Gtk.Widget? parent_view, Gdk.Point? target_point, GLib.File file,Marlin.CreateCallback? create_callback = null);
+        static async GLib.File new_folder (Gtk.Widget? parent_view, Gdk.Point? target_point, GLib.File file) throws GLib.Error;
         static void mount_volume (GLib.Volume volume, Gtk.Window? parent_window = null);
-        static async void mount_volume_full (GLib.Volume volume, Gtk.Window? parent_window = null) throws GLib.Error;
-        static void @delete (GLib.List<GLib.File> locations, Gtk.Window window, bool try_trash, DeleteCallback? callback = null);
+        static async void mount_volume_full (GLib.Volume volume, Gtk.Window? parent_window = null, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        static async void @delete (GLib.List<GLib.File> locations, Gtk.Window window, bool try_trash, GLib.Cancellable? cancellable = null) throws GLib.Error;
         static bool has_trash_files (GLib.Mount mount);
         static GLib.List<GLib.File> get_trash_dirs_for_mount (GLib.Mount mount);
         static void empty_trash (Gtk.Widget? widget);
         static void empty_trash_for_mount (Gtk.Widget? widget, GLib.Mount mount);
-        static void copy_move_link (GLib.List<GLib.File> files, GLib.Array<Gdk.Point>? relative_item_points, GLib.File target_dir, Gdk.DragAction copy_action, Gtk.Widget? parent_view = null, CopyCallback? done_callback = null);
-        static void new_file (Gtk.Widget parent_view, Gdk.Point? target_point, string parent_dir, string? target_filename, string? initial_contents, int length, Marlin.CreateCallback? create_callback = null);
-        static void new_file_from_template (Gtk.Widget parent_view, Gdk.Point? target_point, GLib.File parent_dir, string? target_filename, GLib.File template, Marlin.CreateCallback? create_callback = null);
+        static async bool copy_move_link (GLib.List<GLib.File> files, GLib.Array<Gdk.Point>? relative_item_points, GLib.File target_dir, Gdk.DragAction copy_action, Gtk.Widget? parent_view = null, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        static async GLib.File new_file (Gtk.Widget parent_view, Gdk.Point? target_point, string parent_dir, string? target_filename, string? initial_contents, int length, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        static async GLib.File new_file_from_template (Gtk.Widget parent_view, Gdk.Point? target_point, GLib.File parent_dir, string? target_filename, GLib.File template, GLib.Cancellable? cancellable = null) throws GLib.Error;
     }
-
-    [CCode (cheader_filename = "marlin-file-operations.h")]
-    public delegate void CreateCallback (GLib.File? new_file);
-    [CCode (cheader_filename = "marlin-file-operations.h")]
-    public delegate void DeleteCallback (bool user_cancel);
-    [CCode (cname="GCallback")]
-    public delegate void CopyCallback ();
 }
 
 [CCode (cprefix = "Marlin", lower_case_cprefix = "marlin_")]
@@ -93,7 +86,7 @@ namespace Marlin
         public signal void request_menu_update (UndoMenuData data);
 
         public async bool undo (Gtk.Widget widget, GLib.Cancellable? cancellable = null) throws GLib.Error;
-        public async void redo (Gtk.Widget widget, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        public async bool redo (Gtk.Widget widget, GLib.Cancellable? cancellable = null) throws GLib.Error;
         public void add_rename_action (GLib.File renamed_file, string original_name);
     }
 }

--- a/src/ClipboardManager.vala
+++ b/src/ClipboardManager.vala
@@ -119,24 +119,9 @@ namespace Marlin {
          * Pastes the contents from the clipboard to the directory
          * referenced by @target_file.
         **/
-        public void paste_files (GLib.File target_file,
-                                 Gtk.Widget? widget = null,
-                                 GLib.Callback? new_files_callback = null) {
-
-            /**
-             *  @cb the clipboard.
-             *  @sd selection_data returned from the clipboard.
-            **/
-            clipboard.request_contents (x_special_gnome_copied_files, (cb, sd) => {
-                contents_received (sd, target_file, widget, new_files_callback);
-            });
-
-        }
-
-        private void contents_received (Gtk.SelectionData sd,
-                                        GLib.File target_file,
-                                        Gtk.Widget? widget = null,
-                                        GLib.Callback? new_files_callback = null) {
+        public async void paste_files (GLib.File target_file,
+                                       Gtk.Widget? widget = null) {
+            SelectionData? sd = clipboard.wait_for_contents (x_special_gnome_copied_files);
 
             /* check whether the retrieval worked */
             string? text;
@@ -168,12 +153,12 @@ namespace Marlin {
             var file_list = PF.FileUtils.files_from_uris (text);
 
             if (file_list != null) {
-                FileOperations.copy_move_link (file_list,
-                                               null,
-                                               target_file,
-                                               action,
-                                               widget,
-                                               (Marlin.CopyCallback) new_files_callback);
+                FileOperations.copy_move_link.begin (file_list,
+                                                     null,
+                                                     target_file,
+                                                     action,
+                                                     widget,
+                                                     (Marlin.CopyCallback) new_files_callback);
             }
 
             /* clear the clipboard if it contained "cutted data"


### PR DESCRIPTION
With this, switching FileOperations to Vala will be easier, also removes the use of a deprecated API