### PR TITLE
Cleanup ViewMode string handling

### DIFF
--- a/libcore/Enums.vala
+++ b/libcore/Enums.vala
@@ -60,8 +60,6 @@ namespace Marlin {
         }
     }
 
-
-
     public enum ViewMode {
         /* First three modes must match the corresponding mode switch indices */
         ICON = 0,
@@ -69,7 +67,39 @@ namespace Marlin {
         MILLER_COLUMNS = 2,
         CURRENT,
         PREFERRED,
-        INVALID
+        INVALID;
+
+        public string to_string () {
+            switch (this) {
+                case ICON:
+                    return "ICON";
+                case LIST:
+                    return "LIST";
+                case MILLER_COLUMNS:
+                    return "MILLER";
+                case PREFERRED:
+                    return "PREFERRED";
+                default:
+                    return "INVALID";
+            }
+        }
+
+        public static ViewMode from_string (string mode_string) {
+            switch (mode_string) {
+                case "ICON":
+                    return ViewMode.ICON;
+                case "LIST":
+                    return ViewMode.LIST;
+                case "MILLER":
+                    return ViewMode.MILLER_COLUMNS;
+                case "CURRENT":
+                    return ViewMode.CURRENT;
+                case "PREFERRED":
+                    return ViewMode.PREFERRED;
+                default:
+                    return ViewMode.INVALID;
+            }
+        }
     }
 
     public enum OpenFlag {

--- a/libcore/Enums.vala
+++ b/libcore/Enums.vala
@@ -69,7 +69,7 @@ namespace Marlin {
         PREFERRED,
         INVALID;
 
-        public string to_string () {
+        public unowned string to_string () {
             switch (this) {
                 case ICON:
                     return "ICON";

--- a/libwidgets/Chrome/ViewSwitcher.vala
+++ b/libwidgets/Chrome/ViewSwitcher.vala
@@ -27,7 +27,7 @@ namespace Marlin.View.Chrome {
         private bool freeze_update = false;
         public GLib.SimpleAction view_mode_action { get; construct; }
         private uint mode_change_timeout_id = 0;
-        private int last_selected;
+        private ViewMode last_selected;
 
         construct {
             /* Item 0 */
@@ -46,27 +46,15 @@ namespace Marlin.View.Chrome {
             append (miller);
 
             mode_changed.connect (() => {
-                last_selected = selected;
+                last_selected = (ViewMode)selected;
+
                 if (mode_change_timeout_id > 0) {
                     return;
                 }
 
                 mode_change_timeout_id = Timeout.add (SWITCH_DELAY_MSEC, () => {
-                    switch (last_selected) {
-                        case 0:
-                            view_mode_action.activate (new GLib.Variant.string ("ICON"));
-                            break;
-                        case 1:
-                            view_mode_action.activate (new GLib.Variant.string ("LIST"));
-                            break;
-                        case 2:
-                            view_mode_action.activate (new GLib.Variant.string ("MILLER"));
-                            break;
-
-                        default:
-                            break;
-                    }
-
+                    var action = new GLib.Variant.string (last_selected.to_string ());
+                    view_mode_action.activate (action);
                     mode_change_timeout_id = 0;
                     return Source.REMOVE;
                 });

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -43,12 +43,6 @@ namespace Marlin.View {
             {"hide-local-thumbnails", null, null, "false", change_state_hide_local_thumbnails}
         };
 
-        const string [] mode_strings = {
-            "ICON",
-            "LIST",
-            "MILLER"
-        };
-
         public uint window_number { get; construct; }
 
         public bool is_first_window {
@@ -639,24 +633,7 @@ namespace Marlin.View {
         }
 
         private void action_view_mode (GLib.SimpleAction action, GLib.Variant? param) {
-            string mode_string = param.get_string ();
-            Marlin.ViewMode mode = Marlin.ViewMode.MILLER_COLUMNS;
-            switch (mode_string) {
-                case "ICON":
-                    mode = Marlin.ViewMode.ICON;
-                    break;
-
-                case "LIST":
-                    mode = Marlin.ViewMode.LIST;
-                    break;
-
-                case "MILLER":
-                    mode = Marlin.ViewMode.MILLER_COLUMNS;
-                    break;
-
-                default:
-                    return;
-            }
+            var mode = real_mode (ViewMode.from_string (param.get_string ()));
 
             current_tab.change_view_mode (mode);
             /* ViewContainer takes care of changing appearance */
@@ -844,6 +821,7 @@ namespace Marlin.View {
                 default:
                     break;
             }
+
             return (Marlin.ViewMode)(Preferences.settings.get_enum ("default-viewmode"));
         }
 
@@ -1046,7 +1024,7 @@ namespace Marlin.View {
             var mode = current_tab.view_mode;
             view_switcher.selected = mode;
             view_switcher.sensitive = current_tab.can_show_folder;
-            get_action ("view-mode").set_state (mode_strings [(int)mode]);
+            get_action ("view-mode").set_state (mode.to_string ());
             Preferences.settings.set_enum ("default-viewmode", mode);
         }
 


### PR DESCRIPTION
Use ViewMode enum functions instead of hard-coded strings in Window and ViewSwitcher.