### PR TITLE
Delint src

### DIFF
--- a/src/ClipboardManager.vala
+++ b/src/ClipboardManager.vala
@@ -34,7 +34,7 @@ namespace Marlin {
 
         private static GLib.Quark marlin_clipboard_manager_quark;
         private static Gdk.Atom x_special_gnome_copied_files;
-        private const Gtk.TargetEntry[] clipboard_targets = {
+        private const Gtk.TargetEntry[] CLIPBOARD_TARGETS = {
             {"x-special/gnome-copied-files", 0, ClipboardTarget.GNOME_COPIED_FILES},
             {"UTF8_STRING", 0, ClipboardTarget.UTF8_STRING}
         };
@@ -225,7 +225,7 @@ namespace Marlin {
             }
 
             /* acquire the Clipboard ownership */
-            clipboard.set_with_owner (clipboard_targets, get_callback, clear_callback, this);
+            clipboard.set_with_owner (CLIPBOARD_TARGETS, get_callback, clear_callback, this);
 
             /* Need to fake a "owner-change" event here if the Xserver doesn't support clipboard notification */
             if (!clipboard.get_display ().supports_selection_notification ()) {

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -188,7 +188,10 @@ namespace Marlin {
             }
 
             cr.scale (1.0 / icon_scale, 1.0 / icon_scale);
-            style_context.render_background (cr, draw_rect.x * icon_scale, draw_rect.y * icon_scale, draw_rect.width * icon_scale, draw_rect.height * icon_scale);
+            style_context.render_background (cr,
+                                             draw_rect.x * icon_scale, draw_rect.y * icon_scale,
+                                             draw_rect.width * icon_scale, draw_rect.height * icon_scale);
+
             style_context.render_icon (cr, pb, draw_rect.x * icon_scale, draw_rect.y * icon_scale);
 
             style_context.restore ();

--- a/src/ProgressUIHandler.vala
+++ b/src/ProgressUIHandler.vala
@@ -171,7 +171,7 @@ public class Marlin.Progress.UIHandler : Object {
                     if (!application.get_active_window ().has_toplevel_focus) {
                         show_operation_complete_notification (title, active_infos < 1);
                     }
-                    
+
                     return GLib.Source.REMOVE;
                 });
             }

--- a/src/View/Browser.vala
+++ b/src/View/Browser.vala
@@ -98,7 +98,7 @@ namespace Marlin.View {
             if (n <= 1) {
                 return uri;
             } else {
-                return go_forward (n-1);
+                return go_forward (n - 1);
             }
         }
 

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -451,7 +451,7 @@ namespace FM {
                 before_first = previous_linear_selection_direction > 0;
                 after_last = previous_linear_selection_direction < 0;
             } else { /* fallback to most recent selection or if that is invalid, the first selected in the view */
-                end_path =  most_recently_selected != null ? most_recently_selected : first_selected;
+                end_path = most_recently_selected != null ? most_recently_selected : first_selected;
             }
 
             unselect_all (); /* This clears previous linear selection details */

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -307,7 +307,7 @@ namespace Marlin.View {
         }
 
         private void on_slot_folder_deleted (Slot slot, GOF.File file, GOF.Directory.Async dir) {
-            Slot? next_slot = slot_list.nth_data (slot.slot_number +1);
+            Slot? next_slot = slot_list.nth_data (slot.slot_number + 1);
             if (next_slot != null && next_slot.directory == dir) {
                 truncate_list_after_slot (slot);
             }
@@ -499,7 +499,7 @@ namespace Marlin.View {
                 new_value = previous_width;
             }
 
-            int offset = slot.slot_number < slot_list.length () -1 ? 90 : 0;
+            int offset = slot.slot_number < slot_list.length () - 1 ? 90 : 0;
             int val = page_size - (width + slot.width + offset);
 
             if (val < 0) { /*scroll left until right hand edge of active slot is in view*/

--- a/src/View/PopupMenuBuilder.vala
+++ b/src/View/PopupMenuBuilder.vala
@@ -30,7 +30,10 @@ public class PopupMenuBuilder : Object {
         return popupmenu;
     }
 
-    public Gtk.Menu build_from_model (MenuModel model, string? action_group_namespace = null, ActionGroup? action_group = null) {
+    public Gtk.Menu build_from_model (MenuModel model,
+                                      string? action_group_namespace = null,
+                                      ActionGroup? action_group = null) {
+
         var menu = new Gtk.Menu.from_model (model);
         menu.insert_action_group (action_group_namespace, action_group);
 

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -36,7 +36,7 @@ namespace Marlin.View.Chrome {
         public bool search_mode = false; // Used to suppress activate events while searching
 
         /** Drag and drop support **/
-        protected const Gdk.DragAction file_drag_actions = (Gdk.DragAction.COPY |
+        protected const Gdk.DragAction FILE_DRAG_ACTIONS = (Gdk.DragAction.COPY |
                                                             Gdk.DragAction.MOVE |
                                                             Gdk.DragAction.LINK);
 
@@ -64,7 +64,10 @@ namespace Marlin.View.Chrome {
         private void set_up_drag_drop () {
             /* Drag and drop */
             Gtk.TargetEntry target_uri_list = {"text/uri-list", 0, Marlin.TargetType.TEXT_URI_LIST};
-            Gtk.drag_dest_set (this, Gtk.DestDefaults.MOTION, {target_uri_list}, Gdk.DragAction.ASK|file_drag_actions);
+            Gtk.drag_dest_set (this, Gtk.DestDefaults.MOTION,
+                               {target_uri_list},
+                               Gdk.DragAction.ASK | FILE_DRAG_ACTIONS);
+
             drag_leave.connect (on_drag_leave);
             drag_motion.connect (on_drag_motion);
             drag_data_received.connect (on_drag_data_received);
@@ -361,7 +364,7 @@ namespace Marlin.View.Chrome {
                                                                      context,
                                                                      out current_suggested_action);
 
-                    if ((current_actions & file_drag_actions) != 0) {
+                    if ((current_actions & FILE_DRAG_ACTIONS) != 0) {
                         success = dnd_handler.handle_file_drag_actions (this,
                                                                         this.get_toplevel () as Gtk.ApplicationWindow,
                                                                         context,

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -24,7 +24,7 @@
 namespace Marlin.View {
 
     public class Window : Gtk.ApplicationWindow {
-        const GLib.ActionEntry [] win_entries = {
+        const GLib.ActionEntry [] WIN_ENTRIES = {
             {"new-window", action_new_window},
             {"quit", action_quit},
             {"refresh", action_reload},
@@ -43,7 +43,7 @@ namespace Marlin.View {
             {"hide-local-thumbnails", null, null, "false", change_state_hide_local_thumbnails}
         };
 
-        const string [] mode_strings = {
+        const string [] MODE_STRINGS = {
             "ICON",
             "LIST",
             "MILLER"
@@ -91,7 +91,7 @@ namespace Marlin.View {
         }
 
         construct {
-            add_action_entries (win_entries, this);
+            add_action_entries (WIN_ENTRIES, this);
 
             undo_actions_set_insensitive ();
 
@@ -1046,7 +1046,7 @@ namespace Marlin.View {
             var mode = current_tab.view_mode;
             view_switcher.selected = mode;
             view_switcher.sensitive = current_tab.can_show_folder;
-            get_action ("view-mode").set_state (mode_strings [(int)mode]);
+            get_action ("view-mode").set_state (MODE_STRINGS [(int)mode]);
             Preferences.settings.set_enum ("default-viewmode", mode);
         }
 

--- a/src/ZeitgeistManager.vala
+++ b/src/ZeitgeistManager.vala
@@ -57,4 +57,3 @@ namespace Marlin {
         }
     }
 }
-


### PR DESCRIPTION
Fix lint errors and line-length below src directory.

Now only warnings produced on running `io.elementary.vala-lint -d [path-to-src-directory]`