### PR TITLE
Use ViewMode as action target

### DIFF
--- a/libwidgets/Chrome/ViewSwitcher.vala
+++ b/libwidgets/Chrome/ViewSwitcher.vala
@@ -27,7 +27,7 @@ namespace Marlin.View.Chrome {
         private bool freeze_update = false;
         public GLib.SimpleAction view_mode_action { get; construct; }
         private uint mode_change_timeout_id = 0;
-        private int last_selected;
+        private ViewMode last_selected;
 
         construct {
             /* Item 0 */
@@ -46,27 +46,13 @@ namespace Marlin.View.Chrome {
             append (miller);
 
             mode_changed.connect (() => {
-                last_selected = selected;
+                last_selected = (ViewMode)selected;
                 if (mode_change_timeout_id > 0) {
                     return;
                 }
 
                 mode_change_timeout_id = Timeout.add (SWITCH_DELAY_MSEC, () => {
-                    switch (last_selected) {
-                        case 0:
-                            view_mode_action.activate (new GLib.Variant.string ("ICON"));
-                            break;
-                        case 1:
-                            view_mode_action.activate (new GLib.Variant.string ("LIST"));
-                            break;
-                        case 2:
-                            view_mode_action.activate (new GLib.Variant.string ("MILLER"));
-                            break;
-
-                        default:
-                            break;
-                    }
-
+                    view_mode_action.activate (new GLib.Variant.uint32 (last_selected));
                     mode_change_timeout_id = 0;
                     return Source.REMOVE;
                 });

--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,7 @@ gio_dep = dependency('gio-2.0', version: '>='+min_glib_version)
 gio_unix_dep = dependency('gio-unix-2.0', version: '>='+min_glib_version)
 gmodule_dep = dependency('gmodule-2.0', version: '>='+min_glib_version)
 gee_dep = dependency('gee-0.8')
-gtk_dep = dependency('gtk+-3.0', version: '>=3.22')
+gtk_dep = dependency('gtk+-3.0', version: '>=3.22.25')
 granite_dep = dependency('granite', version: '>=5.2.5')
 
 common_deps = [

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -37,16 +37,10 @@ namespace Marlin.View {
             {"go-to", action_go_to, "s"},
             {"zoom", action_zoom, "s"},
             {"info", action_info, "s"},
-            {"view-mode", action_view_mode, "s", "'MILLER'"},
+            {"view-mode", action_view_mode, "u", "0" },
             {"show-hidden", null, null, "false", change_state_show_hidden},
             {"show-remote-thumbnails", null, null, "false", change_state_show_remote_thumbnails},
             {"hide-local-thumbnails", null, null, "false", change_state_hide_local_thumbnails}
-        };
-
-        const string [] mode_strings = {
-            "ICON",
-            "LIST",
-            "MILLER"
         };
 
         public uint window_number { get; construct; }
@@ -639,25 +633,7 @@ namespace Marlin.View {
         }
 
         private void action_view_mode (GLib.SimpleAction action, GLib.Variant? param) {
-            string mode_string = param.get_string ();
-            Marlin.ViewMode mode = Marlin.ViewMode.MILLER_COLUMNS;
-            switch (mode_string) {
-                case "ICON":
-                    mode = Marlin.ViewMode.ICON;
-                    break;
-
-                case "LIST":
-                    mode = Marlin.ViewMode.LIST;
-                    break;
-
-                case "MILLER":
-                    mode = Marlin.ViewMode.MILLER_COLUMNS;
-                    break;
-
-                default:
-                    return;
-            }
-
+            Marlin.ViewMode mode = real_mode ((ViewMode)(param.get_uint32 ()));
             current_tab.change_view_mode (mode);
             /* ViewContainer takes care of changing appearance */
         }
@@ -844,6 +820,7 @@ namespace Marlin.View {
                 default:
                     break;
             }
+
             return (Marlin.ViewMode)(Preferences.settings.get_enum ("default-viewmode"));
         }
 
@@ -1046,7 +1023,7 @@ namespace Marlin.View {
             var mode = current_tab.view_mode;
             view_switcher.selected = mode;
             view_switcher.sensitive = current_tab.can_show_folder;
-            get_action ("view-mode").set_state (mode_strings [(int)mode]);
+            get_action ("view-mode").change_state (new Variant.uint32 (mode));
             Preferences.settings.set_enum ("default-viewmode", mode);
         }
 
@@ -1136,9 +1113,9 @@ namespace Marlin.View {
             application.set_accels_for_action ("win.tab::CLOSE", {"<Ctrl>W"});
             application.set_accels_for_action ("win.tab::NEXT", {"<Ctrl>Page_Down", "<Ctrl>Tab"});
             application.set_accels_for_action ("win.tab::PREVIOUS", {"<Ctrl>Page_Up", "<Shift><Ctrl>Tab"});
-            application.set_accels_for_action ("win.view-mode::ICON", {"<Ctrl>1"});
-            application.set_accels_for_action ("win.view-mode::LIST", {"<Ctrl>2"});
-            application.set_accels_for_action ("win.view-mode::MILLER", {"<Ctrl>3"});
+            application.set_accels_for_action ("win.view-mode(0)", {"<Ctrl>1"});
+            application.set_accels_for_action ("win.view-mode(1)", {"<Ctrl>2"});
+            application.set_accels_for_action ("win.view-mode(2)", {"<Ctrl>3"});
             application.set_accels_for_action ("win.zoom::ZOOM_IN", {"<Ctrl>plus", "<Ctrl>equal"});
             application.set_accels_for_action ("win.zoom::ZOOM_OUT", {"<Ctrl>minus"});
             application.set_accels_for_action ("win.zoom::ZOOM_NORMAL", {"<Ctrl>0"});


### PR DESCRIPTION
Save some code by using Variant.uint32 as the parameter type of the "view-mode" action - as permitted in versions of gtk3 >= 3.22.25.  The minimum gtk3 version is bumped accordingly.