### PR TITLE
Check file exists before checking for parent when getting Async object

### DIFF
--- a/libcore/gof-directory-async.vala
+++ b/libcore/gof-directory-async.vala
@@ -1079,7 +1079,7 @@ public class Async : Object {
 
         /* Avoid adding a new Async that will be a duplicate of an existing one, when called
          * with non-folder location. */
-        if (gfile.is_native () && gfile.has_parent (null)) {
+        if (gfile.query_exists () && gfile.is_native () && gfile.has_parent (null)) {
             var ftype = gfile.query_file_type (0, null);
             if (ftype != FileType.DIRECTORY) {
                 gfile = gfile.get_parent ();


### PR DESCRIPTION
Fixes #1115 

Fixes regression caused by ef93c748789b0bcdd4b20565dff8e52a56993220