### PR TITLE
FileOperations: ensure that all functions are async

### DIFF
--- a/libcore/DndHandler.vala
+++ b/libcore/DndHandler.vala
@@ -31,12 +31,14 @@ namespace Marlin {
                                  Gdk.DragAction action) {
 
             if (drop_target.is_folder ()) {
-                Marlin.FileOperations.copy_move_link (drop_file_list,
-                                                      null,
-                                                      drop_target.get_target_location (),
-                                                      action,
-                                                      widget,
-                                                      null);
+                Marlin.FileOperations.copy_move_link.begin (
+                    drop_file_list,
+                    null,
+                    drop_target.get_target_location (),
+                    action,
+                    widget,
+                    null
+                );
                 return true;
             } else if (drop_target.is_executable ()) {
                 try {

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -90,12 +90,12 @@ namespace PF.FileUtils {
         }
 
         original_dirs_hash.foreach ((original_dir, dir_files) => {
-                Marlin.FileOperations.copy_move_link (dir_files,
-                                                      null,
-                                                      original_dir,
-                                                      Gdk.DragAction.MOVE,
-                                                      widget,
-                                                      null);
+                Marlin.FileOperations.copy_move_link.begin (dir_files,
+                                                            null,
+                                                            original_dir,
+                                                            Gdk.DragAction.MOVE,
+                                                            widget,
+                                                            null);
         });
     }
 

--- a/libcore/marlin-file-operations.c
+++ b/libcore/marlin-file-operations.c
@@ -75,8 +75,7 @@ typedef struct {
     GdkPoint *icon_positions;
     int n_icon_positions;
     GHashTable *debuting_files;
-    MarlinCopyCallback  done_callback;
-    gpointer done_callback_data;
+    GTask *task;
 } CopyMoveJob;
 
 typedef struct {
@@ -84,8 +83,7 @@ typedef struct {
     GList *files;
     gboolean try_trash;
     gboolean user_cancel;
-    MarlinDeleteCallback done_callback;
-    gpointer done_callback_data;
+    GTask *task;
 } DeleteJob;
 
 typedef struct {
@@ -1769,14 +1767,11 @@ skip:
 static gboolean
 delete_job_done (gpointer user_data)
 {
-    DeleteJob *job;
-    job = user_data;
+    DeleteJob *job = user_data;
 
     g_list_free_full (job->files, g_object_unref);
-
-    if (job->done_callback) {
-        job->done_callback (job->user_cancel, job->done_callback_data);
-    }
+    g_task_return_boolean (job->task, TRUE);
+    g_clear_object (&job->task);
 
     finalize_common ((CommonJob *)job);
 
@@ -1875,11 +1870,12 @@ delete_job (GIOSchedulerJob *io_job,
 }
 
 void
-marlin_file_operations_delete (GList                    *files,
-                               GtkWindow                *parent_window,
-                               gboolean                 try_trash,
-                               MarlinDeleteCallback     done_callback,
-                               gpointer                 done_callback_data)
+marlin_file_operations_delete (GList               *files,
+                               GtkWindow           *parent_window,
+                               gboolean             try_trash,
+                               GCancellable        *cancellable,
+                               GAsyncReadyCallback  callback,
+                               gpointer             user_data)
 {
     g_return_if_fail (files != NULL);
 
@@ -1891,8 +1887,7 @@ marlin_file_operations_delete (GList                    *files,
     job->files = g_list_copy_deep (files, (GCopyFunc) g_object_ref, NULL);
     job->try_trash = try_trash;
     job->user_cancel = FALSE;
-    job->done_callback = done_callback;
-    job->done_callback_data = done_callback_data;
+    job->task = g_task_new (NULL, cancellable, callback, user_data);
 
     if (try_trash) {
         inhibit_power_manager ((CommonJob *)job, _("Trashing Files"));
@@ -1913,6 +1908,14 @@ marlin_file_operations_delete (GList                    *files,
                              NULL);
 }
 
+gboolean
+marlin_file_operations_delete_finish (GAsyncResult  *result,
+                                      GError       **error)
+{
+    g_return_val_if_fail (g_task_is_valid (result, NULL), NULL);
+
+    return g_task_propagate_boolean (G_TASK (result), error);
+}
 
 typedef struct {
     gboolean eject;
@@ -4357,19 +4360,14 @@ copy_job_done (gpointer user_data)
     CopyMoveJob *job;
 
     job = user_data;
-    if (job->done_callback) {
-        job->done_callback (job->done_callback_data);
-    }
+    g_task_return_boolean (job->task, TRUE);
+    g_clear_object (&job->task);
 
     g_list_free_full (job->files, g_object_unref);
-    if (job->destination) {
-        g_object_unref (job->destination);
-    }
-    /*if (job->desktop_location) {
-        g_object_unref (job->desktop_location);
-    }*/
-    g_hash_table_unref (job->debuting_files);
-    g_free (job->icon_positions);
+    job->files = NULL;
+    g_clear_object (&job->destination);
+    g_clear_pointer (&job->debuting_files, g_hash_table_unref);
+    g_clear_pointer (&job->icon_positions, g_free);
 
     finalize_common ((CommonJob *)job);
 
@@ -4442,19 +4440,18 @@ aborted:
 }
 
 static void
-marlin_file_operations_copy (GList *files,
-                             GArray *relative_item_points,
-                             GFile *target_dir,
-                             GtkWindow *parent_window,
-                             MarlinCopyCallback  done_callback,
-                             gpointer done_callback_data)
+marlin_file_operations_copy (GList               *files,
+                             GArray              *relative_item_points,
+                             GFile               *target_dir,
+                             GtkWindow           *parent_window,
+                             GCancellable        *cancellable,
+                             GAsyncReadyCallback  callback,
+                             gpointer             user_data)
 {
 
     CopyMoveJob *job;
     job = op_job_new (CopyMoveJob, parent_window);
-    //job->desktop_location = marlin_get_desktop_location ();
-    job->done_callback = done_callback;
-    job->done_callback_data = done_callback_data;
+    job->task = g_task_new (NULL, cancellable, callback, user_data);
     job->files = g_list_copy_deep (files, (GCopyFunc) g_object_ref, NULL);
     job->destination = g_object_ref (target_dir);
     if (relative_item_points != NULL &&
@@ -4483,6 +4480,15 @@ marlin_file_operations_copy (GList *files,
                              NULL, /* destroy notify */
                              0,
                              job->common.cancellable);
+}
+
+static gboolean
+marlin_file_operations_copy_finish (GAsyncResult  *result,
+                                    GError       **error)
+{
+    g_return_val_if_fail (g_task_is_valid (result, NULL), NULL);
+
+    return g_task_propagate_boolean (G_TASK (result), error);
 }
 
 static void
@@ -4892,14 +4898,14 @@ move_job_done (gpointer user_data)
     CopyMoveJob *job;
 
     job = user_data;
-    if (job->done_callback) {
-        job->done_callback (job->done_callback_data);
-    }
+    g_task_return_boolean (job->task, TRUE);
+    g_clear_object (&job->task);
 
     g_list_free_full (job->files, g_object_unref);
-    g_object_unref (job->destination);
-    g_hash_table_unref (job->debuting_files);
-    g_free (job->icon_positions);
+    job->files = NULL;
+    g_clear_object (&job->destination);
+    g_clear_pointer (&job->debuting_files, g_hash_table_unref);
+    g_clear_pointer (&job->icon_positions, g_free);
 
     finalize_common ((CommonJob *)job);
 
@@ -4989,19 +4995,19 @@ aborted:
 }
 
 static void
-marlin_file_operations_move (GList *files,
-                             GArray *relative_item_points,
-                             GFile *target_dir,
-                             GtkWindow *parent_window,
-                             MarlinCopyCallback  done_callback,
-                             gpointer done_callback_data)
+marlin_file_operations_move (GList               *files,
+                             GArray              *relative_item_points,
+                             GFile               *target_dir,
+                             GtkWindow           *parent_window,
+                             GCancellable        *cancellable,
+                             GAsyncReadyCallback  callback,
+                             gpointer             user_data)
 {
 
     CopyMoveJob *job;
     job = op_job_new (CopyMoveJob, parent_window);
     job->is_move = TRUE;
-    job->done_callback = done_callback;
-    job->done_callback_data = done_callback_data;
+    job->task = g_task_new (NULL, cancellable, callback, user_data);
     job->files = g_list_copy_deep (files, (GCopyFunc) g_object_ref, NULL);
     job->destination = g_object_ref (target_dir);
     if (relative_item_points != NULL &&
@@ -5033,6 +5039,15 @@ marlin_file_operations_move (GList *files,
                              NULL, /* destroy notify */
                              0,
                              job->common.cancellable);
+}
+
+static gboolean
+marlin_file_operations_move_finish (GAsyncResult  *result,
+                                    GError       **error)
+{
+    g_return_val_if_fail (g_task_is_valid (result, NULL), NULL);
+
+    return g_task_propagate_boolean (G_TASK (result), error);
 }
 
 static void
@@ -5242,14 +5257,14 @@ link_job_done (gpointer user_data)
     CopyMoveJob *job;
 
     job = user_data;
-    if (job->done_callback) {
-        job->done_callback (job->done_callback_data);
-    }
+    g_task_return_boolean (job->task, TRUE);
+    g_clear_object (&job->task);
 
     g_list_free_full (job->files, g_object_unref);
-    g_object_unref (job->destination);
-    g_hash_table_unref (job->debuting_files);
-    g_free (job->icon_positions);
+    job->files = NULL;
+    g_clear_object (&job->destination);
+    g_clear_pointer (&job->debuting_files, g_hash_table_unref);
+    g_clear_pointer (&job->icon_positions, g_free);
 
     finalize_common ((CommonJob *)job);
 
@@ -5323,18 +5338,18 @@ aborted:
 }
 
 static void
-marlin_file_operations_link (GList *files,
-                             GArray *relative_item_points,
-                             GFile *target_dir,
-                             GtkWindow *parent_window,
-                             MarlinCopyCallback  done_callback,
-                             gpointer done_callback_data)
+marlin_file_operations_link (GList               *files,
+                             GArray              *relative_item_points,
+                             GFile               *target_dir,
+                             GtkWindow           *parent_window,
+                             GCancellable        *cancellable,
+                             GAsyncReadyCallback  callback,
+                             gpointer             user_data)
 {
     CopyMoveJob *job;
 
     job = op_job_new (CopyMoveJob, parent_window);
-    job->done_callback = done_callback;
-    job->done_callback_data = done_callback_data;
+    job->task = g_task_new (NULL, cancellable, callback, user_data);
     job->files = g_list_copy_deep (files, (GCopyFunc) g_object_ref, NULL);
     job->destination = g_object_ref (target_dir);
     if (relative_item_points != NULL &&
@@ -5363,19 +5378,27 @@ marlin_file_operations_link (GList *files,
                              job->common.cancellable);
 }
 
+static gboolean
+marlin_file_operations_link_finish (GAsyncResult  *result,
+                                    GError       **error)
+{
+    g_return_val_if_fail (g_task_is_valid (result, NULL), NULL);
+
+    return g_task_propagate_boolean (G_TASK (result), error);
+}
 
 static void
-marlin_file_operations_duplicate (GList *files,
-                                  GArray *relative_item_points,
-                                  GtkWindow *parent_window,
-                                  MarlinCopyCallback  done_callback,
-                                  gpointer done_callback_data)
+marlin_file_operations_duplicate (GList               *files,
+                                  GArray              *relative_item_points,
+                                  GtkWindow           *parent_window,
+                                  GCancellable        *cancellable,
+                                  GAsyncReadyCallback  callback,
+                                  gpointer             user_data)
 {
     CopyMoveJob *job;
 
     job = op_job_new (CopyMoveJob, parent_window);
-    job->done_callback = done_callback;
-    job->done_callback_data = done_callback_data;
+    job->task = g_task_new (NULL, cancellable, callback, user_data);
     job->files = g_list_copy_deep (files, (GCopyFunc) g_object_ref, NULL);
     job->destination = NULL;
     if (relative_item_points != NULL &&
@@ -5402,6 +5425,15 @@ marlin_file_operations_duplicate (GList *files,
                              NULL, /* destroy notify */
                              0,
                              job->common.cancellable);
+}
+
+static gboolean
+marlin_file_operations_duplicate_finish (GAsyncResult  *result,
+                                         GError       **error)
+{
+    g_return_val_if_fail (g_task_is_valid (result, NULL), NULL);
+
+    return g_task_propagate_boolean (G_TASK (result), error);
 }
 
 #if 0  /* TODO: Implement recursive permissions in PropertiesWindow.vala - may use this code */
@@ -5568,18 +5600,113 @@ marlin_file_set_permissions_recursive (const char *directory,
 }
 #endif
 
-/** The done_callback function has a variable signature. When the file is being moved to
- * trash, it must be a MarlinDeleteCallback, otherwise it must be a MarlinCopyCallback.
- */
+
 void
-marlin_file_operations_copy_move_link   (GList                  *files,
-                                         GArray                 *relative_item_points,
-                                         GFile                  *target_dir,
-                                         GdkDragAction          copy_action,
-                                         GtkWidget              *parent_view,
-                                         GCallback              done_callback,
-                                         gpointer               done_callback_data)
+copy_move_link_delete_finish (GObject *source_object,
+                              GAsyncResult *res,
+                              gpointer user_data)
 {
+    GTask *task = user_data;
+    GError *error = NULL;
+    gboolean result;
+
+    result = marlin_file_operations_delete_finish (res, &error);
+    if (error != NULL) {
+        g_task_return_error (task, g_steal_pointer (&error));
+    } else {
+        g_task_return_boolean (task, result);
+    }
+
+    g_clear_object (&task);
+}
+
+static void
+copy_move_link_duplicate_finish (GObject *source_object,
+                                 GAsyncResult *res,
+                                 gpointer user_data)
+{
+    GTask *task = user_data;
+    GError *error = NULL;
+    gboolean result;
+
+    result = marlin_file_operations_duplicate_finish (res, &error);
+    if (error != NULL) {
+        g_task_return_error (task, g_steal_pointer (&error));
+    } else {
+        g_task_return_boolean (task, result);
+    }
+
+    g_clear_object (&task);
+}
+
+static void
+copy_move_link_copy_finish (GObject *source_object,
+                            GAsyncResult *res,
+                            gpointer user_data)
+{
+    GTask *task = user_data;
+    GError *error = NULL;
+    gboolean result;
+
+    result = marlin_file_operations_copy_finish (res, &error);
+    if (error != NULL) {
+        g_task_return_error (task, g_steal_pointer (&error));
+    } else {
+        g_task_return_boolean (task, result);
+    }
+
+    g_clear_object (&task);
+}
+
+static void
+copy_move_link_move_finish (GObject *source_object,
+                            GAsyncResult *res,
+                            gpointer user_data)
+{
+    GTask *task = user_data;
+    GError *error = NULL;
+    gboolean result;
+
+    result = marlin_file_operations_move_finish (res, &error);
+    if (error != NULL) {
+        g_task_return_error (task, g_steal_pointer (&error));
+    } else {
+        g_task_return_boolean (task, result);
+    }
+
+    g_clear_object (&task);
+}
+
+static void
+copy_move_link_link_finish (GObject *source_object,
+                            GAsyncResult *res,
+                            gpointer user_data)
+{
+    GTask *task = user_data;
+    GError *error = NULL;
+    gboolean result;
+
+    result = marlin_file_operations_link_finish (res, &error);
+    if (error != NULL) {
+        g_task_return_error (task, g_steal_pointer (&error));
+    } else {
+        g_task_return_boolean (task, result);
+    }
+
+    g_clear_object (&task);
+}
+
+void
+marlin_file_operations_copy_move_link (GList               *files,
+                                       GArray              *relative_item_points,
+                                       GFile               *target_dir,
+                                       GdkDragAction        copy_action,
+                                       GtkWidget           *parent_view,
+                                       GCancellable        *cancellable,
+                                       GAsyncReadyCallback  callback,
+                                       gpointer             user_data)
+{
+    GTask *task;
     GList *p;
     GFile *src_dir;
     GtkWindow *parent_window;
@@ -5588,10 +5715,6 @@ marlin_file_operations_copy_move_link   (GList                  *files,
 
     target_is_mapping = FALSE;
     have_nonmapping_source = FALSE;
-
-    if (done_callback_data == NULL) {
-        done_callback_data = (void*)parent_view;
-    }
 
     if (g_file_has_uri_scheme (target_dir, "burn")) {
         target_is_mapping = TRUE;
@@ -5616,6 +5739,7 @@ marlin_file_operations_copy_move_link   (GList                  *files,
         parent_window = (GtkWindow *)gtk_widget_get_ancestor (parent_view, GTK_TYPE_WINDOW);
     }
 
+    task = g_task_new (NULL, cancellable, callback, user_data);
     if (copy_action == GDK_ACTION_COPY) {
         if (g_file_has_uri_scheme (target_dir, "trash")) {
             char *primary = g_strdup (_("Cannot copy into trash."));
@@ -5624,10 +5748,12 @@ marlin_file_operations_copy_move_link   (GList                  *files,
                                           secondary,
                                           parent_window);
 
-            if (done_callback != NULL) {
-                ((MarlinDeleteCallback)done_callback) (TRUE, done_callback_data);
-            }
-
+            g_task_return_new_error (task,
+                                     G_IO_ERROR,
+                                     G_IO_ERROR_FAILED,
+                                     _("It is not permitted to copy files into the trash"),
+                                     NULL);
+            g_clear_object (&task);
             return;
         }
 
@@ -5640,15 +5766,17 @@ marlin_file_operations_copy_move_link   (GList                  *files,
              marlin_file_operations_duplicate (files,
                                                relative_item_points,
                                                parent_window,
-                                               (MarlinCopyCallback)done_callback,
-                                               done_callback_data);
+                                               cancellable,
+                                               copy_move_link_duplicate_finish,
+                                               g_steal_pointer (&task));
         } else {
             marlin_file_operations_copy (files,
                                          relative_item_points,
                                          target_dir,
                                          parent_window,
-                                         (MarlinCopyCallback)done_callback,
-                                         done_callback_data);
+                                         cancellable,
+                                         copy_move_link_copy_finish,
+                                         g_steal_pointer (&task));
         }
         if (src_dir) {
             g_object_unref (src_dir);
@@ -5661,25 +5789,38 @@ marlin_file_operations_copy_move_link   (GList                  *files,
             marlin_file_operations_delete (files,
                                            parent_window,
                                            TRUE,
-                                           (MarlinDeleteCallback)done_callback,
-                                           done_callback_data);
+                                           cancellable,
+                                           copy_move_link_delete_finish,
+                                           g_steal_pointer (&task));
         } else {
             /* done_callback is (or should be) a CopyCallBack or null in this case */
             marlin_file_operations_move (files,
                                          relative_item_points,
                                          target_dir,
                                          parent_window,
-                                         (MarlinCopyCallback)done_callback,
-                                         done_callback_data);
+                                         cancellable,
+                                         copy_move_link_move_finish,
+                                         g_steal_pointer (&task));
         }
     } else {
         marlin_file_operations_link (files,
                                      relative_item_points,
                                      target_dir,
                                      parent_window,
-                                    (MarlinCopyCallback)done_callback,
-                                     done_callback_data);
+                                     cancellable,
+                                     copy_move_link_link_finish,
+                                     g_steal_pointer (&task));
     }
+}
+
+
+gboolean
+marlin_file_operations_copy_move_link_finish (GAsyncResult  *result,
+                                              GError       **error)
+{
+    g_return_val_if_fail (g_task_is_valid (result, NULL), NULL);
+
+    return g_task_propagate_boolean (G_TASK (result), error);
 }
 
 static gboolean

--- a/libcore/marlin-file-operations.h
+++ b/libcore/marlin-file-operations.h
@@ -28,10 +28,6 @@
 #include <gtk/gtk.h>
 #include <gio/gio.h>
 
-typedef void (* MarlinDeleteCallback)    (gboolean    user_cancel,
-                                          gpointer    callback_data);
-
-
 /* Sidebar uses Marlin.FileOperations to mount volumes but handles unmounting itself */
 void marlin_file_operations_mount_volume  (GVolume   *volume,
                                            GtkWindow *parent_window);
@@ -44,11 +40,14 @@ void marlin_file_operations_mount_volume_full (GVolume                        *v
 gboolean marlin_file_operations_mount_volume_full_finish (GAsyncResult  *result,
                                                           GError       **error);
 
-void marlin_file_operations_delete          (GList                  *files,
-                                             GtkWindow              *parent_window,
-                                             gboolean               try_trash,
-                                             MarlinDeleteCallback   done_callback,
-                                             gpointer               done_callback_data);
+void marlin_file_operations_delete (GList               *files,
+                                    GtkWindow           *parent_window,
+                                    gboolean             try_trash,
+                                    GCancellable        *cancellable,
+                                    GAsyncReadyCallback  callback,
+                                    gpointer             user_data);
+gboolean marlin_file_operations_delete_finish (GAsyncResult  *result,
+                                               GError       **error);
 
 
 gboolean marlin_file_operations_has_trash_files (GMount *mount);
@@ -57,14 +56,16 @@ GList *marlin_file_operations_get_trash_dirs_for_mount (GMount *mount);
 
 void marlin_file_operations_empty_trash (GtkWidget                 *parent_view);
 
-void marlin_file_operations_copy_move_link   (GList                  *files,
-                                              GArray                 *relative_item_points,
-                                              GFile                  *target_dir,
-                                              GdkDragAction          copy_action,
-                                              GtkWidget              *parent_view,
-                                              GCallback              done_callback,
-                                              gpointer               done_callback_data);
-
+void marlin_file_operations_copy_move_link (GList               *files,
+                                            GArray              *relative_item_points,
+                                            GFile               *target_dir,
+                                            GdkDragAction        copy_action,
+                                            GtkWidget           *parent_view,
+                                            GCancellable        *cancellable,
+                                            GAsyncReadyCallback  callback,
+                                            gpointer             user_data);
+gboolean marlin_file_operations_copy_move_link_finish (GAsyncResult  *result,
+                                                       GError       **error);
 
 void marlin_file_operations_new_file (GtkWidget           *parent_view,
                                       GdkPoint            *target_point,

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -56,20 +56,15 @@ namespace Marlin {
         static async GLib.File? new_folder (Gtk.Widget? parent_view, Gdk.Point? target_point, GLib.File file, GLib.Cancellable? cancellable = null) throws GLib.Error;
         static void mount_volume (GLib.Volume volume, Gtk.Window? parent_window = null);
         static async void mount_volume_full (GLib.Volume volume, Gtk.Window? parent_window = null) throws GLib.Error;
-        static void @delete (GLib.List<GLib.File> locations, Gtk.Window window, bool try_trash, DeleteCallback? callback = null);
+        static async bool @delete (GLib.List<GLib.File> locations, Gtk.Window window, bool try_trash, GLib.Cancellable? cancellable = null) throws GLib.Error;
         static bool has_trash_files (GLib.Mount mount);
         static GLib.List<GLib.File> get_trash_dirs_for_mount (GLib.Mount mount);
         static void empty_trash (Gtk.Widget? widget);
         static void empty_trash_for_mount (Gtk.Widget? widget, GLib.Mount mount);
-        static void copy_move_link (GLib.List<GLib.File> files, GLib.Array<Gdk.Point>? relative_item_points, GLib.File target_dir, Gdk.DragAction copy_action, Gtk.Widget? parent_view = null, CopyCallback? done_callback = null);
+        static async bool copy_move_link (GLib.List<GLib.File> files, GLib.Array<Gdk.Point>? relative_item_points, GLib.File target_dir, Gdk.DragAction copy_action, Gtk.Widget? parent_view = null, GLib.Cancellable? cancellable = null) throws GLib.Error;
         static async GLib.File? new_file (Gtk.Widget parent_view, Gdk.Point? target_point, string parent_dir, string? target_filename, string? initial_contents, int length, GLib.Cancellable? cancellable = null) throws GLib.Error;
         static async GLib.File? new_file_from_template (Gtk.Widget parent_view, Gdk.Point? target_point, GLib.File parent_dir, string? target_filename, GLib.File template, GLib.Cancellable? cancellable = null) throws GLib.Error;
     }
-
-    [CCode (cheader_filename = "marlin-file-operations.h")]
-    public delegate void DeleteCallback (bool user_cancel);
-    [CCode (cname="GCallback")]
-    public delegate void CopyCallback ();
 }
 
 [CCode (cprefix = "Marlin", lower_case_cprefix = "marlin_")]

--- a/plugins/pantheon-files-trash/plugin.vala
+++ b/plugins/pantheon-files-trash/plugin.vala
@@ -94,7 +94,7 @@ public class Marlin.Plugins.Trash : Marlin.Plugins.Base {
                         }
 
                         if (to_delete != null) {
-                            Marlin.FileOperations.@delete (to_delete, window, false);
+                            Marlin.FileOperations.@delete.begin (to_delete, window, false);
                         }
                     }
                 });


### PR DESCRIPTION
This allows to use the native Vala syntax for async and provides a decent base to get rid of GIOScheduler