### PR TITLE
Fix drag out of archive

### DIFF
--- a/libcore/DndHandler.vala
+++ b/libcore/DndHandler.vala
@@ -200,6 +200,7 @@ namespace Marlin {
                     case 'E':
                         /* No fallback for XdndDirectSave stage (3), result "E" ("Error") yet.
                          * Note this result may be obtained even if the file was successfully saved */
+                        success = true;
                         break;
                     case 'S':
                         /* XdndDirectSave "Success" */

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -149,7 +149,7 @@ namespace FM {
                     /*  ... store clicked folder and start double-click timeout */
                     awaiting_double_click = true;
                     is_frozen = true;
-                    double_click_timeout_id = GLib.Timeout.add (drag_delay, () => {
+                    double_click_timeout_id = GLib.Timeout.add (300, () => {
                         not_double_click (event, path);
                         return GLib.Source.REMOVE;
                     });


### PR DESCRIPTION
Fixes #1082 

Also some simplification, better variable names, comments.

Significant changes are:

* Return success even if XDnDDirectSave returns "E"
* Separate clearing of source and drag data
* Process "drag-leave" and "drag-drop" in correct order

Other changes should only be code cleaning - lose unneeded variables, rename some variables for clarity, added comments, reorder some lines for efficiency.
