### PR TITLE
Ensure target_uri not null in `get_number_of_uri_parts`

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -1107,7 +1107,7 @@ public class GOF.File : GLib.Object {
             target_uri = info.get_attribute_string (GLib.FileAttribute.STANDARD_TARGET_URI);
         }
 
-        if (target_uri != null) {
+        if (target_uri == null) {
             target_uri = uri;
         }
 


### PR DESCRIPTION
Fixes critical warnings due to typo in `GOF.File.get_number_of_uri_parts ()`