### PR TITLE
Fix scrolling cursor in Column View

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -345,7 +345,7 @@ namespace FM {
         }
 
         private void set_up_directory_view () {
-            set_policy (Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC);
+            set_policy (Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
             set_shadow_type (Gtk.ShadowType.NONE);
 
             popup_menu.connect (on_popup_menu);
@@ -3146,10 +3146,6 @@ namespace FM {
 
                     default:
                         break;
-                }
-
-                if (increment != 0.0) {
-                    slot.horizontal_scroll_event (increment);
                 }
             }
             return handle_scroll_event (event);

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -247,7 +247,6 @@ namespace Marlin.View {
         private void connect_slot_signals (Slot slot) {
             slot.frozen_changed.connect (on_slot_frozen_changed);
             slot.active.connect (on_slot_active);
-            slot.horizontal_scroll_event.connect (on_slot_horizontal_scroll_event);
             slot.miller_slot_request.connect (on_miller_slot_request);
             slot.new_container_request.connect (on_new_container_request);
             slot.size_change.connect (update_total_width);
@@ -261,7 +260,6 @@ namespace Marlin.View {
         private void disconnect_slot_signals (Slot slot) {
             slot.frozen_changed.disconnect (on_slot_frozen_changed);
             slot.active.disconnect (on_slot_active);
-            slot.horizontal_scroll_event.disconnect (on_slot_horizontal_scroll_event);
             slot.miller_slot_request.disconnect (on_miller_slot_request);
             slot.new_container_request.disconnect (on_new_container_request);
             slot.size_change.disconnect (update_total_width);
@@ -285,17 +283,6 @@ namespace Marlin.View {
 
         private void on_new_container_request (GLib.File loc, Marlin.OpenFlag flag) {
             new_container_request (loc, flag);
-        }
-
-        private bool on_slot_horizontal_scroll_event (double delta_x) {
-            /* We can assume this is a horizontal or smooth scroll without control pressed*/
-            double increment = 0.0;
-            increment = delta_x * 10.0;
-
-            if (increment != 0.0) {
-                hadj.set_value (hadj.get_value () + increment);
-            }
-            return true;
         }
 
         private void on_slot_path_changed () {

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -65,7 +65,6 @@ namespace Marlin.View {
             }
         }
 
-        public signal bool horizontal_scroll_event (double delta_x);
         public signal void frozen_changed (bool freeze);
         public signal void folder_deleted (GOF.File file, GOF.Directory.Async parent);
 


### PR DESCRIPTION
Fixes #1214 

* Lose unnecessary signal from Slot
* Change scroll policy of AbstractDirectoryView

There seems to be no reason for slots (Directory Views) to scroll horizontally themselves or to have a custom signal handled by Column View.  Allowing the Scrolled Window native handler to handle horizontal scrolling fixes the issue with the cursor.