### PR TITLE
Fix view frozen after renaming with blank

### DIFF
--- a/data/io.elementary.files.appdata.xml.in.in
+++ b/data/io.elementary.files.appdata.xml.in.in
@@ -62,6 +62,8 @@
       <description>
         <ul>
           <li>Fix device icon sometimes missing</li>
+          <li>Fix occasional view freeze after renaming</li>
+          <li>Improve renaming logic when dealing with leading/trailing whitespace</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -322,7 +322,7 @@ public class PropertiesWindow : AbstractPropertiesDialog {
         /* Only rename if name actually changed */
         original_name = file.info.get_name ();
 
-        if (new_name != "") {
+        if (new_name.strip () != "") { // Do not want a filename consisting of spaces only (even if legal)
             if (new_name != original_name) {
                 proposed_name = new_name;
                 view.set_file_display_name.begin (file.location, new_name, null, (obj, res) => {

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -318,11 +318,13 @@ public class PropertiesWindow : AbstractPropertiesDialog {
         }
     }
 
-    private void rename_file (GOF.File file, string new_name) {
+    private void rename_file (GOF.File file, string _new_name) {
         /* Only rename if name actually changed */
         original_name = file.info.get_name ();
 
-        if (new_name.strip () != "") { // Do not want a filename consisting of spaces only (even if legal)
+        var new_name = _new_name.strip (); // Disallow leading and trailing space
+
+        if (new_name != "") { // Do not want a filename consisting of spaces only (even if legal)
             if (new_name != original_name) {
                 proposed_name = new_name;
                 view.set_file_display_name.begin (file.location, new_name, null, (obj, res) => {
@@ -332,14 +334,15 @@ public class PropertiesWindow : AbstractPropertiesDialog {
                         reset_entry_text (new_location.get_basename ());
                         goffile = GOF.File.@get (new_location);
                         files.first ().data = goffile;
-                    } catch (Error e) {
-                        reset_entry_text (); //resets entry to old name
-                    }
+                    } catch (Error e) {} // Warning dialog already shown
                 });
             }
         } else {
-            reset_entry_text ();
+            warning ("Blank name not allowed");
+            new_name = original_name;
         }
+
+        reset_entry_text (new_name);
     }
 
     public void reset_entry_text (string? new_name = null) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3188,13 +3188,15 @@ namespace FM {
             grab_focus ();
         }
 
-        protected void on_name_edited (string path_string, string new_name) {
+        protected void on_name_edited (string path_string, string? _new_name) {
             /* Must not re-enter */
-            if (!renaming) {
+            if (!renaming || _new_name == null) {
+                on_name_editing_canceled (); // no problem rentering this function
                 return;
             }
 
-            if (new_name.strip () == "" || proposed_name == new_name) {
+            var new_name = _new_name.strip (); // Disallow leading and trailing space
+            if (new_name == "" || proposed_name == new_name) {
                 warning ("Blank name or name unchanged");
                 on_name_editing_canceled ();
                 return;
@@ -3217,8 +3219,7 @@ namespace FM {
                     set_file_display_name.begin (file.location, new_name, null, (obj, res) => {
                         try {
                             set_file_display_name.end (res);
-                        } catch (Error e) {
-                        }
+                        } catch (Error e) {} // Warning dialog already shown
 
                         on_name_editing_canceled ();
                     });

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3194,7 +3194,7 @@ namespace FM {
                 return;
             }
 
-            if  (new_name.strip () == "" || proposed_name == new_name) {
+            if (new_name.strip () == "" || proposed_name == new_name) {
                 warning ("Blank name or name unchanged");
                 on_name_editing_canceled ();
                 return;

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3190,7 +3190,13 @@ namespace FM {
 
         protected void on_name_edited (string path_string, string new_name) {
             /* Must not re-enter */
-            if (!renaming || proposed_name == new_name) {
+            if (!renaming) {
+                return;
+            }
+
+            if  (new_name.strip () == "" || proposed_name == new_name) {
+                warning ("Blank name or name unchanged");
+                on_name_editing_canceled ();
                 return;
             }
 


### PR DESCRIPTION
Fixes #1252 
Fixes #1255 

Note that this also prevents a user naming a file with only spaces even though this seems to be legal with some filesystems.   It also removes any leading or trailing space. Should the user be restricted in this way?  If not then the `.strip ()` functions can be removed.

Some further cleanup of renaming is possible but left for another PR.