### PR TITLE
libcore: Put the FileOperations cheader on every C function instead of the namespace

### DIFF
--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -51,12 +51,17 @@ namespace FM
 
 
 namespace Marlin {
-    [CCode (cprefix = "MarlinFileOperations", lower_case_cprefix = "marlin_file_operations_", cheader_filename = "marlin-file-operations.h")]
+    [CCode (lower_case_cprefix = "marlin_file_operations_")]
     namespace FileOperations {
+        [CCode (cheader_filename = "marlin-file-operations.h")]
         static async GLib.File? new_folder (Gtk.Widget? parent_view, Gdk.Point? target_point, GLib.File file, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        [CCode (cheader_filename = "marlin-file-operations.h")]
         static async bool @delete (GLib.List<GLib.File> locations, Gtk.Window window, bool try_trash, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        [CCode (cheader_filename = "marlin-file-operations.h")]
         static async bool copy_move_link (GLib.List<GLib.File> files, GLib.Array<Gdk.Point>? relative_item_points, GLib.File target_dir, Gdk.DragAction copy_action, Gtk.Widget? parent_view = null, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        [CCode (cheader_filename = "marlin-file-operations.h")]
         static async GLib.File? new_file (Gtk.Widget parent_view, Gdk.Point? target_point, string parent_dir, string? target_filename, string? initial_contents, int length, GLib.Cancellable? cancellable = null) throws GLib.Error;
+        [CCode (cheader_filename = "marlin-file-operations.h")]
         static async GLib.File? new_file_from_template (Gtk.Widget parent_view, Gdk.Point? target_point, GLib.File parent_dir, string? target_filename, GLib.File template, GLib.Cancellable? cancellable = null) throws GLib.Error;
     }
 }


### PR DESCRIPTION
We are actually reusing the namespace with Vala code so we need to be careful with the cheader not colliding.
Related to https://gitlab.gnome.org/GNOME/vala/-/issues/948