### PR TITLE
Remove unused ui hook from plugin interface

### DIFF
--- a/libcore/Plugin.vala
+++ b/libcore/Plugin.vala
@@ -19,7 +19,6 @@
 public abstract class Marlin.Plugins.Base {
     public virtual void directory_loaded (Gtk.ApplicationWindow window, GOF.AbstractSlot view, GOF.File directory) { }
     public virtual void context_menu (Gtk.Widget? widget, List<GOF.File> files) { }
-    public virtual void ui (Gtk.UIManager? widget) { }
     public virtual void sidebar_loaded (Gtk.Widget widget) { }
     public virtual void update_sidebar (Gtk.Widget widget) { }
     public virtual void update_file_info (GOF.File file) { }

--- a/libcore/PluginManager.vala
+++ b/libcore/PluginManager.vala
@@ -214,12 +214,6 @@ public class Marlin.PluginManager : Object {
         menus = null;
     }
 
-    public void ui (Gtk.UIManager data) {
-        foreach (var plugin in plugin_hash.values) {
-            plugin.ui (data);
-        }
-    }
-
     public void directory_loaded (Gtk.ApplicationWindow window, GOF.AbstractSlot view, GOF.File directory) {
         foreach (var plugin in plugin_hash.values) {
             plugin.directory_loaded (window, view, directory);

--- a/plugins/contractor/plugin.vala
+++ b/plugins/contractor/plugin.vala
@@ -42,7 +42,6 @@ public class Marlin.Plugins.ContractMenuItem : Gtk.MenuItem {
 }
 
 public class Marlin.Plugins.Contractor : Marlin.Plugins.Base {
-    private Gtk.UIManager ui_manager;
     private Gtk.Menu menu;
     private GOF.File current_directory = null;
 
@@ -102,11 +101,6 @@ public class Marlin.Plugins.Contractor : Marlin.Plugins.Base {
         } catch (Error e) {
             warning (e.message);
         }
-    }
-
-    public override void ui (Gtk.UIManager? widget) {
-        ui_manager = widget;
-        menu = (Gtk.Menu) ui_manager.get_widget ("/selection");
     }
 
     public override void directory_loaded (Gtk.ApplicationWindow window, GOF.AbstractSlot view, GOF.File directory) {


### PR DESCRIPTION
Files no longer uses a UIManager and no longer uses this hook so I believe it may safely be removed.