### PR TITLE
Show overlaybar in all view modes.

### DIFF
--- a/data/io.elementary.files.appdata.xml.in.in
+++ b/data/io.elementary.files.appdata.xml.in.in
@@ -63,6 +63,7 @@
         <p>Minor updates:</p>
         <ul>
           <li>Fix an issue that prevented file modification times from showing</li>
+          <li>Show file info overlay in List View as well</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -262,7 +262,6 @@ namespace Marlin.View {
             }
 
             overlay_statusbar = new Marlin.View.OverlayBar (view.overlay);
-            overlay_statusbar.showbar = view_mode != Marlin.ViewMode.LIST;
 
             connect_slot_signals (this.view);
             directory_is_loading (loc);

--- a/src/View/Widgets/OverlayBar.vala
+++ b/src/View/Widgets/OverlayBar.vala
@@ -36,7 +36,7 @@ namespace Marlin.View {
         private Marlin.DeepCount? deep_counter = null;
         private uint deep_count_timeout_id = 0;
 
-        public bool showbar = false;
+        public bool showbar = true;
 
         public OverlayBar (Gtk.Overlay overlay) {
             base (overlay); /* this adds the overlaybar to the overlay (ViewContainer) */
@@ -53,10 +53,6 @@ namespace Marlin.View {
         public void selection_changed (GLib.List<unowned GOF.File> files) {
             cancel ();
             visible = false;
-
-            if (!showbar) {
-                return;
-            }
 
             update_timeout_id = GLib.Timeout.add_full (GLib.Priority.LOW, STATUS_UPDATE_DELAY, () => {
                 if (files != null) {
@@ -78,8 +74,7 @@ namespace Marlin.View {
         public void update_hovered (GOF.File? file) {
             hover_cancel (); /* This will stop and hide spinner, and reset the hover timeout */
 
-            if (!showbar ||
-                (file != null && goffile != null && file.location.equal (goffile.location))) {
+            if (file != null && goffile != null && file.location.equal (goffile.location)) {
 
                 return;
             }
@@ -180,7 +175,7 @@ namespace Marlin.View {
                 }
             }
 
-            visible = showbar && (label.length > 0);
+            visible = label != "";
         }
 
         private string update_status () {

--- a/src/View/Widgets/OverlayBar.vala
+++ b/src/View/Widgets/OverlayBar.vala
@@ -36,8 +36,6 @@ namespace Marlin.View {
         private Marlin.DeepCount? deep_counter = null;
         private uint deep_count_timeout_id = 0;
 
-        public bool showbar = true;
-
         public OverlayBar (Gtk.Overlay overlay) {
             base (overlay); /* this adds the overlaybar to the overlay (ViewContainer) */
 


### PR DESCRIPTION
Fixes #1285 

The overlaybar shows extra information compared to list view columns and there seems no clear reason to suppress it.