### PR TITLE
View should resize when Paned resized (not Sidebar or Window)

### DIFF
--- a/data/io.elementary.files.appdata.xml.in.in
+++ b/data/io.elementary.files.appdata.xml.in.in
@@ -64,6 +64,7 @@
         <ul>
           <li>Fix an issue that prevented file modification times from showing</li>
           <li>Show file info overlay in List View as well</li>
+          <li>Prevent window resizing when filename column width exceeds available space</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -127,7 +127,7 @@ namespace Marlin.View {
         }
 
         private void on_dir_view_size_allocate (Gtk.Allocation alloc) {
-                width = alloc.width;
+            width = alloc.width;
         }
 
         private void on_dir_view_item_hovered (GOF.File? file) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -168,7 +168,7 @@ namespace Marlin.View {
             lside_pane.position = Preferences.settings.get_int ("sidebar-width");
             lside_pane.show ();
             lside_pane.pack1 (sidebar, false, false);
-            lside_pane.pack2 (tabs, true, false);
+            lside_pane.pack2 (tabs, true, true);
             add (lside_pane);
 
             /** Apply preferences */


### PR DESCRIPTION
Fixes #1292 

The properties of the HPaned righthand child are changed to give same behaviour as e.g. Nautilus.  That is, increasing the wifth of the filename column beyond available space does not now cause the window to resize - rather the other columns are pushed outside the visible area.

This also means that the window remains tileable and resizeable.