### PR TITLE
Show color-tag regardless of thumbnail setting

### DIFF
--- a/data/io.elementary.files.appdata.xml.in.in
+++ b/data/io.elementary.files.appdata.xml.in.in
@@ -64,6 +64,7 @@
         <ul>
           <li>Fix an issue that prevented file modification times from showing</li>
           <li>Show file info overlay in List View as well</li>
+          <li>Fix color tags disappearing when thumbnails hidden</li>
           <li>Updated translations</li>
         </ul>
       </description>


### PR DESCRIPTION
Fixes #1306 

Both color-tags and thumbnails are fetched only when a file item is visible or about to be visible. Turning off thumbnails was inadvertantly turning off color-tag info fetching.  This PR fixes the problem by testing for the thumbnail settings _after_ visible file info has been fetched and plugins updated.