### PR TITLE
Add message_plugin hook and associated action in app

### DIFF
--- a/libcore/Plugin.vala
+++ b/libcore/Plugin.vala
@@ -22,6 +22,7 @@ public abstract class Marlin.Plugins.Base {
     public virtual void sidebar_loaded (Gtk.Widget widget) { }
     public virtual void update_sidebar (Gtk.Widget widget) { }
     public virtual void update_file_info (GOF.File file) { }
+    public virtual void message_plugin (string data, List<GOF.File> selected) { }
 
     public Gtk.Widget window;
 

--- a/libcore/PluginManager.vala
+++ b/libcore/PluginManager.vala
@@ -23,6 +23,8 @@ public static Marlin.PluginManager plugins;
 
 public class Marlin.PluginManager : Object {
 
+    public const string MESSAGE_PLUGIN_ACTION = "message-plugin";
+
     delegate Plugins.Base ModuleInitFunc ();
     Gee.HashMap<string,Plugins.Base> plugin_hash;
     Gee.List<string> names;
@@ -241,6 +243,12 @@ public class Marlin.PluginManager : Object {
     public void update_file_info (GOF.File file) {
         foreach (var plugin in plugin_hash.values) {
             plugin.update_file_info (file);
+        }
+    }
+
+    public void message_plugin (string data, List<GOF.File> selected) {
+        foreach (var plugin in plugin_hash.values) {
+            plugin.message_plugin (data, selected);
         }
     }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,6 +21,9 @@
              Julián Unrrein <junrrein@gmail.com>
 ***/
 public class Marlin.Application : Gtk.Application {
+    const ActionEntry[] APP_ENTRIES = {
+        {Marlin.PluginManager.MESSAGE_PLUGIN_ACTION, action_message_plugin, "s"}
+    };
 
     private VolumeMonitor volume_monitor;
     private Marlin.Progress.UIHandler progress_handler;
@@ -38,6 +41,8 @@ public class Marlin.Application : Gtk.Application {
         /* Needed by Glib.Application */
         this.application_id = Marlin.APP_ID; //Ensures an unique instance.
         this.flags |= ApplicationFlags.HANDLES_COMMAND_LINE;
+
+        add_action_entries (APP_ENTRIES, this);
     }
 
     public override void startup () {
@@ -291,5 +296,10 @@ public class Marlin.Application : Gtk.Application {
         win.open_tabs (locations, viewmode);
 
         return win;
+    }
+
+    private void action_message_plugin (SimpleAction action, Variant? param) {
+        var win = (Marlin.View.Window)(get_active_window ());
+        plugins.message_plugin (param.get_string (), win.current_tab.slot.get_selected_files ());
     }
 }


### PR DESCRIPTION
Allow a plugin to set a target for a new "app.action-message-plugin" action together with, if desired, an accelerator.  The action triggers a plugin hook that passes the target string and the currently selected files to the plugins.  An example of the use of this can be found at #1291.

Shortcuts could also be set for core contracts for example.