### PR TITLE
Fix home folder placeholder click

### DIFF
--- a/data/io.elementary.files.appdata.xml.in.in
+++ b/data/io.elementary.files.appdata.xml.in.in
@@ -62,6 +62,7 @@
       <description>
         <p>Minor updates:</p>
         <ul>
+          <li>Fix uneditable area in pathbar which is showing home folder placeholder</li>
           <li>Fix an issue that prevented file modification times from showing</li>
           <li>Show file info overlay in List View as well</li>
           <li>Updated translations</li>

--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -228,15 +228,18 @@ namespace Marlin.View.Chrome {
          protected virtual bool on_button_release_event (Gdk.EventButton event) {
             if (icon_event (event)) {
                 return false;
-            } else {
+            } else if (placeholder == "") {
+                /* Only activate breadcrumbs when they are showing and not hidden by placeholder */
                 reset_elements_states ();
                 var el = get_element_from_coordinates ((int) event.x, (int) event.y);
                 if (el != null) {
                     activate_path (get_path_from_element (el));
-                } else {
-                    grab_focus ();
+                    return true;
                 }
             }
+
+            grab_focus ();
+
             return true;
         }
 
@@ -279,9 +282,11 @@ namespace Marlin.View.Chrome {
             if (secondary_icon_pixbuf != null) {
                 tip = get_icon_tooltip_markup (Gtk.EntryIconPosition.SECONDARY);
             }
+
+
             set_tooltip_markup ("");
             var el = get_element_from_coordinates ((int)event.x, (int)event.y);
-            if (el != null) {
+            if (el != null && placeholder == null) {
                 set_tooltip_markup (_("Go to %s").printf (el.text_for_display));
                 set_entry_cursor (new Gdk.Cursor.from_name (Gdk.Display.get_default (), "default"));
             } else {

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -108,9 +108,11 @@ namespace Marlin.View.Chrome {
                 Source.remove (button_press_timeout_id);
                 button_press_timeout_id = 0;
             }
+
             if (drop_file_list != null) {
                 return true;
             }
+
             if (event.button == 1) {
                 return base.on_button_release_event (event);
             } else { /* other buttons act on press */
@@ -534,7 +536,8 @@ namespace Marlin.View.Chrome {
         }
 
         protected override bool on_button_press_event (Gdk.EventButton event) {
-            if (icon_event (event) || has_focus) {
+            /* Only handle if not on icon and breadcrumbs are visible */
+            if (icon_event (event) || has_focus || placeholder != null) {
                 return base.on_button_press_event (event);
             } else {
                 var el = mark_pressed_element (event);
@@ -554,6 +557,7 @@ namespace Marlin.View.Chrome {
                     }
                 }
             }
+
             return true;
         }
 


### PR DESCRIPTION
Fixes #1328 

This prevents the home folder placeholder reacting to button presses as if a breadcrumb were drawn there.  Instead it now behaves like a normal unfocused entry.