### PR TITLE
Fix Clang10 build

### DIFF
--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -183,7 +183,9 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
     }
 
     private async void rreal_update_file_info (GOF.File file) {
-        return_if_fail (file != null);
+        if (file == null) {
+            return;
+        }
 
         try {
             if (!file.exists) {
@@ -231,11 +233,9 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
     }
 
     private async void rreal_update_file_info_for_recent (GOF.File file, string? target_uri) {
-        if (target_uri == null) { /* e.g. for recent:/// */
+        if (target_uri == null || file == null) { /* e.g. for recent:/// */
             return;
         }
-
-        return_if_fail (file != null);
 
         try {
             var rc = yield daemon.get_uri_infos (target_uri);
@@ -256,7 +256,6 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
     }
 
     public override void update_file_info (GOF.File file) {
-
         return_if_fail (file != null);
 
         if (file.info != null && !f_ignore_dir (file.directory) &&


### PR DESCRIPTION
See #1341 

The Vala compiler does not correctly handle the `return_if_fail ()` in async functions as it gets expanded within a boolean function.  With Clang10 this causes the build to fail.  Not sure what the effect would be if this were actually triggered at run time.   

Only the ctags plugin uses this macro within an async function so it is just replaced with a simple `if` clause (which compiles to correct C code).