### PR TITLE
AbstractPropertiesDialog: unsafely cast header_title as entry

### DIFF
--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -1279,7 +1279,7 @@ public class PropertiesWindow : AbstractPropertiesDialog {
             PF.FileUtils.get_rename_region (goffile.info.get_name (), out start_offset, out end_offset,
                                             goffile.is_folder ());
 
-            (header_title as Gtk.Entry).select_region (start_offset, end_offset);
+            ((Gtk.Entry) header_title).select_region (start_offset, end_offset);
         }
 
         /* Only show 'contains' label when only folders selected - otherwise could be ambiguous whether


### PR DESCRIPTION
Fixes a compiler warning about possible `null`. If we've already checked that `header_title` is a Gtk.Entry, we should be able to make an "unsafe" cast