### PR TITLE
Fix click on breadcrumb regression

### DIFF
--- a/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
+++ b/libwidgets/Chrome/BasicBreadcrumbsEntry.vala
@@ -286,7 +286,7 @@ namespace Marlin.View.Chrome {
 
             set_tooltip_markup ("");
             var el = get_element_from_coordinates ((int)event.x, (int)event.y);
-            if (el != null && placeholder == null) {
+            if (el != null && !hide_breadcrumbs) {
                 set_tooltip_markup (_("Go to %s").printf (el.text_for_display));
                 set_entry_cursor (new Gdk.Cursor.from_name (Gdk.Display.get_default (), "default"));
             } else {

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -537,7 +537,7 @@ namespace Marlin.View.Chrome {
 
         protected override bool on_button_press_event (Gdk.EventButton event) {
             /* Only handle if not on icon and breadcrumbs are visible */
-            if (icon_event (event) || has_focus || placeholder != null) {
+            if (icon_event (event) || has_focus || hide_breadcrumbs) {
                 return base.on_button_press_event (event);
             } else {
                 var el = mark_pressed_element (event);

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -295,6 +295,7 @@ namespace Marlin.View.Chrome {
                 show_placeholder ();
                 show_search_icon ();
             } else {
+                hide_placeholder ();
                 hide_search_icon ();
             }
         }


### PR DESCRIPTION
Fixes #1355 
Fixes #1358

* Placeholder now cleared after breadcrumbs shown
* Use hide_breadcrumbs to determine whether breadcrumbs shown

In master this was working until the home directory was displayed, maybe explaining how the regression was missed.  

`hide_breadcrumbs` is a better and more logical indicator of whether the breadcrumbs are displayed.