### PR TITLE
AbstractDirectoryView: Fix compiler warning about nullable cast

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1386,7 +1386,7 @@ namespace FM {
 
     /** Handle Preference changes */
         private void on_show_hidden_files_changed (GLib.Object prefs, GLib.ParamSpec pspec) {
-            bool show = (prefs as GOF.Preferences).show_hidden_files;
+            bool show = ((GOF.Preferences) prefs).show_hidden_files;
             cancel ();
             /* As directory may reload, for consistent behaviour always lose selection */
             unselect_all ();
@@ -1406,19 +1406,19 @@ namespace FM {
         }
 
         private void on_show_remote_thumbnails_changed (GLib.Object prefs, GLib.ParamSpec pspec) {
-            show_remote_thumbnails = (prefs as GOF.Preferences).show_remote_thumbnails;
+            show_remote_thumbnails = ((GOF.Preferences) prefs).show_remote_thumbnails;
             action_set_state (background_actions, "show-remote-thumbnails", show_remote_thumbnails);
             slot.reload ();
         }
 
         private void on_hide_local_thumbnails_changed (GLib.Object prefs, GLib.ParamSpec pspec) {
-            hide_local_thumbnails = (prefs as GOF.Preferences).hide_local_thumbnails;
+            hide_local_thumbnails = ((GOF.Preferences) prefs).hide_local_thumbnails;
             action_set_state (background_actions, "hide-local-thumbnails", hide_local_thumbnails);
             slot.reload ();
         }
 
         private void on_sort_directories_first_changed (GLib.Object prefs, GLib.ParamSpec pspec) {
-            var sort_directories_first = (prefs as GOF.Preferences).sort_directories_first;
+            var sort_directories_first = ((GOF.Preferences) prefs).sort_directories_first;
             model.set_should_sort_directories_first (sort_directories_first);
         }
 
@@ -1446,7 +1446,7 @@ namespace FM {
         private bool on_drag_timeout_motion_notify (Gdk.EventMotion event) {
             /* Only active during drag timeout */
             Gdk.DragContext context;
-            var widget = get_real_view ();
+            var widget = get_child ();
             int x = (int)event.x;
             int y = (int)event.y;
 
@@ -1519,7 +1519,7 @@ namespace FM {
         /* Signal emitted on source after a DND move operation */
         private void on_drag_data_delete (Gdk.DragContext context) {
             /* block real_view default handler because handled in on_drag_end */
-            GLib.Signal.stop_emission_by_name (get_real_view (), "drag-data-delete");
+            GLib.Signal.stop_emission_by_name (get_child (), "drag-data-delete");
         }
 
         /* Signal emitted on source after completion of DnD. */
@@ -1562,7 +1562,7 @@ namespace FM {
             string? uri = null;
             drop_occurred = true;
 
-            Gdk.Atom target = Gtk.drag_dest_find_target (get_real_view (), context, list);
+            Gdk.Atom target = Gtk.drag_dest_find_target (get_child (), context, list);
             if (target == Gdk.Atom.intern_static_string ("XdndDirectSave0")) {
                 GOF.File? target_file = get_drop_target_file (x, y);
                 /* get XdndDirectSave file name from DnD source window */
@@ -1582,7 +1582,7 @@ namespace FM {
 
             /* request the drag data from the source (initiates
              * saving in case of XdndDirectSave).*/
-            Gtk.drag_get_data (get_real_view (), context, target, timestamp);
+            Gtk.drag_get_data (get_child (), context, target, timestamp);
 
             return true;
         }
@@ -1633,7 +1633,7 @@ namespace FM {
                             unselect_all ();
                         }
 
-                        success = dnd_handler.handle_file_drag_actions (get_real_view (),
+                        success = dnd_handler.handle_file_drag_actions (get_child (),
                                                                         window,
                                                                         context,
                                                                         drop_target_file,
@@ -1715,7 +1715,7 @@ namespace FM {
         /* Called by destination during drag motion */
         private void get_drag_data (Gdk.DragContext context, int x, int y, uint timestamp) {
             Gtk.TargetList? list = null;
-            Gdk.Atom target = Gtk.drag_dest_find_target (get_real_view (), context, list);
+            Gdk.Atom target = Gtk.drag_dest_find_target (get_child (), context, list);
             current_target_type = target;
 
             /* Check if we can handle it yet */
@@ -1734,7 +1734,7 @@ namespace FM {
             } else if (target != Gdk.Atom.NONE && destination_drop_file_list == null) {
                 /* request the drag data from the source.
                  * See {Source]on_drag_data_get () and [Destination]on_drag_data_received () */
-                Gtk.drag_get_data (get_real_view (), context, target, timestamp);
+                Gtk.drag_get_data (get_child (), context, target, timestamp);
             }
         }
 
@@ -2660,12 +2660,8 @@ namespace FM {
             model.row_deleted.connect (on_row_deleted);
         }
 
-        private Gtk.Widget? get_real_view () {
-            return (this as Gtk.Bin).get_child ();
-        }
-
         private void connect_drag_timeout_motion_and_release_events () {
-            var real_view = get_real_view ();
+            var real_view = get_child ();
             real_view.button_release_event.connect (on_drag_timeout_button_release);
             real_view.motion_notify_event.connect (on_drag_timeout_motion_notify);
         }
@@ -2675,7 +2671,7 @@ namespace FM {
                 return;
             }
 
-            var real_view = get_real_view ();
+            var real_view = get_child ();
             real_view.button_release_event.disconnect (on_drag_timeout_button_release);
             real_view.motion_notify_event.disconnect (on_drag_timeout_motion_notify);
         }
@@ -2684,7 +2680,7 @@ namespace FM {
             drag_scroll_timer_id = GLib.Timeout.add_full (GLib.Priority.LOW,
                                                           50,
                                                           () => {
-                Gtk.Widget? widget = (this as Gtk.Bin).get_child ();
+                Gtk.Widget? widget = get_child ();
                 if (widget != null) {
                     Gdk.Device pointer = context.get_device ();
                     Gdk.Window window = widget.get_window ();
@@ -3528,7 +3524,7 @@ namespace FM {
 
             slot.active (should_scroll);
 
-            Gtk.Widget widget = get_real_view ();
+            Gtk.Widget widget = get_child ();
             int x = (int)event.x;
             int y = (int)event.y;
             update_selected_files_and_menu ();


### PR DESCRIPTION
`get_real_view` seems to only exist to perform this cast, but there's no need to do that since ScrolledWindow is a Gtk.Bin subclass