### PR TITLE
Fix Dropbox plugin for Hera

### DIFF
--- a/dropbox-command-client.c
+++ b/dropbox-command-client.c
@@ -21,6 +21,7 @@
  *
  */
 
+#include "config.h"
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/dropbox-command-client.h
+++ b/dropbox-command-client.h
@@ -24,7 +24,8 @@
 #ifndef DROPBOX_COMMAND_CLIENT_H
 #define DROPBOX_COMMAND_CLIENT_H
 
-#include <pantheon-files-core/pantheon-files-core.h>
+#include "config.h"
+#include "pantheon-files-core.h"
 
 G_BEGIN_DECLS
 

--- a/plugin.c
+++ b/plugin.c
@@ -15,11 +15,13 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#include <pantheon-files-core/pantheon-files-core.h>
+#include "pantheon-files-core.h"
 #include "g-util.h"
 #include "plugin.h"
+
+#include <glib/gi18n.h>
 
 G_DEFINE_TYPE (PFDropbox, pf_dropbox, MARLIN_PLUGINS_TYPE_BASE);
 

--- a/plugin.c
+++ b/plugin.c
@@ -21,8 +21,6 @@
 #include "g-util.h"
 #include "plugin.h"
 
-#include <glib/gi18n.h>
-
 G_DEFINE_TYPE (PFDropbox, pf_dropbox, MARLIN_PLUGINS_TYPE_BASE);
 
 typedef struct {
@@ -602,7 +600,7 @@ pf_dropbox_context_menu (MarlinPluginsBase *base, GtkWidget *menu, GList *files)
         gtk_menu_shell_append ((GtkMenuShell*) menu, separator);
 
         gtk_menu_shell_append ((GtkMenuShell*) menu, root_item);
-        plugins->menus = g_list_prepend (plugins->menus, _g_object_ref0 (root_item));
+        gee_list_insert (marlin_plugin_manager_get_menuitem_references (plugins), 0, root_item);
 
         pf_dropbox_parse_menu(options, submenu, base, file);
     }


### PR DESCRIPTION
Enable pantheon-dropbox-plugin to compile and fix some warnings.

Before this PR, the plugin was not working.  After installing, the dropbox emblems appeared as expected and the context menu worked as expected (see https://elementaryos.stackexchange.com/questions/25008/dropbox-plug-in-dont-work-5-1-5-hera).