### PR TITLE
Initialize properties inline with `new` statement

### DIFF
--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -121,35 +121,44 @@ public class PF.ConnectServerDialog : Gtk.Dialog {
 
         info_label = new Gtk.Label (null);
 
-        info_bar = new Gtk.InfoBar ();
-        info_bar.message_type = Gtk.MessageType.INFO;
+        info_bar = new Gtk.InfoBar () {
+            message_type = Gtk.MessageType.INFO
+        };
+
         info_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FRAME);
         info_bar.get_content_area ().add (info_label);
         dismiss_info ();
 
         var server_header_label = new Granite.HeaderLabel (_("Server Details"));
 
-        server_entry = new DetailEntry (_("Server name or IP address"));
-        server_entry.hexpand = true;
+        server_entry = new DetailEntry (_("Server name or IP address")) {
+            hexpand = true
+        };
 
         var server_label = new DetailLabel (_("Server:"), server_entry);
 
-        port_spinbutton = new Gtk.SpinButton.with_range (0, ushort.MAX, 1);
-        port_spinbutton.digits = 0;
-        port_spinbutton.numeric = true;
-        port_spinbutton.update_policy = Gtk.SpinButtonUpdatePolicy.IF_VALID;
+        port_spinbutton = new Gtk.SpinButton.with_range (0, ushort.MAX, 1) {
+            digits = 0,
+            numeric = true,
+            update_policy = Gtk.SpinButtonUpdatePolicy.IF_VALID
+        };
 
-        var port_label = new DetailLabel (_("Port:"), port_spinbutton);
-        port_label.xalign = 1;
+        var port_label = new DetailLabel (_("Port:"), port_spinbutton) {
+            xalign = 1
+        };
 
-        var port_grid = new Gtk.Grid ();
-        port_grid.column_spacing = 6;
-        port_grid.margin_start = 6;
+        var port_grid = new Gtk.Grid () {
+            column_spacing = 6,
+            margin_start = 6
+        };
+
         port_grid.add (port_label);
         port_grid.add (port_spinbutton);
 
-        port_revealer = new Gtk.Revealer ();
-        port_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+        port_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT
+        };
+
         port_revealer.add (port_grid);
 
         var server_port_grid = new Gtk.Grid ();
@@ -157,12 +166,13 @@ public class PF.ConnectServerDialog : Gtk.Dialog {
         server_port_grid.add (port_revealer);
 
         var type_store = new Gtk.ListStore (2, typeof (MethodInfo), typeof (string));
+
         type_combobox = new Gtk.ComboBox.with_model (type_store);
         var renderer = new Gtk.CellRendererText ();
         type_combobox.pack_start (renderer, true);
         type_combobox.add_attribute (renderer, "text", 1);
-        var type_label = new DetailLabel (_("Type:"), type_combobox);
 
+        var type_label = new DetailLabel (_("Type:"), type_combobox);
 
         share_entry = new DetailEntry (_("Name of share on server"));
         var share_label = new DetailLabel (_("Share:"), share_entry);
@@ -178,9 +188,11 @@ public class PF.ConnectServerDialog : Gtk.Dialog {
         user_entry = new DetailEntry (_("Name of user on server"), Environment.get_user_name ());
         var user_label = new DetailLabel (_("User name:"), user_entry);
 
-        password_entry = new DetailEntry ();
-        password_entry.input_purpose = Gtk.InputPurpose.PASSWORD;
-        password_entry.visibility = false;
+        password_entry = new DetailEntry () {
+            input_purpose = Gtk.InputPurpose.PASSWORD,
+            visibility = false
+        };
+
         var password_label = new DetailLabel (_("Password:"), password_entry);
 
         remember_checkbutton = new Gtk.CheckButton.with_label (_("Remember this password"));
@@ -190,30 +202,38 @@ public class PF.ConnectServerDialog : Gtk.Dialog {
         cancel_button.show ();
         cancel_button.clicked.connect (on_cancel_clicked);
 
-        connect_button = new Gtk.Button.with_label (_("Connect"));
+        connect_button = new Gtk.Button.with_label (_("Connect")) {
+            can_default = true,
+            no_show_all = true
+        };
+
         connect_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-        connect_button.can_default = true;
-        connect_button.no_show_all = true;
         connect_button.show ();
         connect_button.clicked.connect (on_connect_clicked);
 
-        continue_button = new Gtk.Button.with_label (_("Continue"));
+        continue_button = new Gtk.Button.with_label (_("Continue")) {
+            can_default = true,
+            no_show_all = true
+        };
+
         continue_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-        continue_button.can_default = true;
-        continue_button.no_show_all = true;
         continue_button.clicked.connect (on_continue_clicked);
 
-        var button_box = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
-        button_box.layout_style = Gtk.ButtonBoxStyle.END;
-        button_box.margin_top = 24;
-        button_box.spacing = 6;
+        var button_box = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL) {
+            layout_style = Gtk.ButtonBoxStyle.END,
+            margin_top = 24,
+            spacing = 6
+        };
+
         button_box.add (cancel_button);
         button_box.add (connect_button);
         button_box.add (continue_button);
 
-        var grid = new Gtk.Grid ();
-        grid.row_spacing = 6;
-        grid.column_spacing = 6;
+        var grid = new Gtk.Grid () {
+            row_spacing = 6,
+            column_spacing = 6
+        };
+
         grid.attach (info_bar, 0, 0, 2, 1);
 
         grid.attach (server_header_label, 0, 1, 2, 1);
@@ -244,16 +264,20 @@ public class PF.ConnectServerDialog : Gtk.Dialog {
 
         var connecting_label = new Gtk.Label (_("Connecting…"));
 
-        var connecting_grid = new Gtk.Grid ();
-        connecting_grid.orientation = Gtk.Orientation.VERTICAL;
-        connecting_grid.row_spacing = 6;
-        connecting_grid.halign = Gtk.Align.CENTER;
-        connecting_grid.valign = Gtk.Align.CENTER;
+        var connecting_grid = new Gtk.Grid () {
+            orientation = Gtk.Orientation.VERTICAL,
+            row_spacing = 6,
+            halign = Gtk.Align.CENTER,
+            valign = Gtk.Align.CENTER
+        };
+
         connecting_grid.add (connecting_label);
         connecting_grid.add (connecting_spinner);
 
-        stack = new Gtk.Stack ();
-        stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
+        stack = new Gtk.Stack () {
+            transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT
+        };
+
         stack.add_named (grid, "content");
         stack.add_named (connecting_grid, "connecting");
 

--- a/libcore/FileChanges.vala
+++ b/libcore/FileChanges.vala
@@ -56,31 +56,39 @@ namespace Marlin.FileChanges {
     }
 
     public static void queue_file_added (GLib.File location) {
-        var new_item = new Change ();
-        new_item.kind = Kind.ADDED;
-        new_item.from = location;
+        var new_item = new Change () {
+            kind = Kind.ADDED,
+            from = location
+        };
+
         queue_add_common ((owned) new_item);
     }
 
     public static void queue_file_changed (GLib.File location) {
-        var new_item = new Change ();
-        new_item.kind = Kind.CHANGED;
-        new_item.from = location;
+        var new_item = new Change () {
+            kind = Kind.CHANGED,
+            from = location
+        };
+
         queue_add_common ((owned) new_item);
     }
 
     public static void queue_file_removed (GLib.File location) {
-        var new_item = new Change ();
-        new_item.kind = Kind.REMOVED;
-        new_item.from = location;
+        var new_item = new Change () {
+            kind = Kind.REMOVED,
+            from = location
+        };
+
         queue_add_common ((owned) new_item);
     }
 
     public static void queue_file_moved (GLib.File from, GLib.File to) {
-        var new_item = new Change ();
-        new_item.kind = Kind.MOVED;
-        new_item.from = from;
-        new_item.to = to;
+        var new_item = new Change () {
+            kind = Kind.MOVED,
+            from = from,
+            to = to
+        };
+
         queue_add_common ((owned) new_item);
     }
 

--- a/libcore/FileConflictDialog.vala
+++ b/libcore/FileConflictDialog.vala
@@ -93,89 +93,118 @@ public class Marlin.FileConflictDialog : Gtk.Dialog {
 
     construct {
         set_border_width (6);
-        var image = new Gtk.Image.from_icon_name ("dialog-warning", Gtk.IconSize.DIALOG);
-        image.valign = Gtk.Align.START;
 
-        primary_label = new Gtk.Label (null);
+        var image = new Gtk.Image.from_icon_name ("dialog-warning", Gtk.IconSize.DIALOG) {
+            valign = Gtk.Align.START
+        };
+
+        primary_label = new Gtk.Label (null) {
+            selectable = true,
+            max_width_chars = 50,
+            wrap = true,
+            xalign = 0
+        };
+
         primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
-        primary_label.selectable = true;
-        primary_label.max_width_chars = 50;
-        primary_label.wrap = true;
-        primary_label.xalign = 0;
 
-        secondary_label = new Gtk.Label (null);
-        secondary_label.use_markup = true;
-        secondary_label.selectable = true;
-        secondary_label.max_width_chars = 50;
-        secondary_label.wrap = true;
-        secondary_label.xalign = 0;
+        secondary_label = new Gtk.Label (null) {
+            use_markup = true,
+            selectable = true,
+            max_width_chars = 50,
+            wrap = true,
+            xalign = 0
+        };
 
-        destination_image = new Gtk.Image ();
-        destination_image.pixel_size = 64;
+        destination_image = new Gtk.Image () {
+            pixel_size = 64
+        };
 
-        var destination_label = new Gtk.Label ("<b>%s</b>".printf (_("Original file")));
-        destination_label.margin_top = destination_label.margin_bottom = 6;
-        destination_label.use_markup = true;
-        destination_label.xalign = 0;
+        var destination_label = new Gtk.Label ("<b>%s</b>".printf (_("Original file"))) {
+            margin_top = 0,
+            margin_bottom = 6,
+            use_markup = true,
+            xalign = 0
+        };
 
-        var destination_size_title_label = new Gtk.Label (_("Size:"));
-        destination_size_title_label.valign = Gtk.Align.END;
-        destination_size_title_label.xalign = 1;
+        var destination_size_title_label = new Gtk.Label (_("Size:")) {
+            valign = Gtk.Align.END,
+            xalign = 1
+        };
 
-        destination_size_label = new Gtk.Label (null);
-        destination_size_label.valign = Gtk.Align.END;
-        destination_size_label.xalign = 0;
+        destination_size_label = new Gtk.Label (null) {
+            valign = Gtk.Align.END,
+            xalign = 0
+        };
 
-        var destination_type_title_label = new Gtk.Label (_("Type:"));
-        destination_type_title_label.xalign = 1;
-        destination_type_label = new Gtk.Label (null);
-        destination_type_label.xalign = 0;
+        var destination_type_title_label = new Gtk.Label (_("Type:")) {
+            xalign = 1
+        };
 
-        var destination_time_title_label = new Gtk.Label (_("Last modified:"));
-        destination_time_title_label.valign = Gtk.Align.START;
-        destination_time_title_label.xalign = 1;
-        destination_time_label = new Gtk.Label (null);
-        destination_time_label.valign = Gtk.Align.START;
-        destination_time_label.xalign = 0;
+        destination_type_label = new Gtk.Label (null) {
+            xalign = 0
+        };
 
-        source_image = new Gtk.Image ();
-        source_image.pixel_size = 64;
+        var destination_time_title_label = new Gtk.Label (_("Last modified:")) {
+            valign = Gtk.Align.START,
+            xalign = 1
+        };
 
-        var source_label = new Gtk.Label ("<b>%s</b>".printf (_("Replace with")));
-        source_label.margin_bottom = 6;
-        source_label.use_markup = true;
-        source_label.xalign = 0;
+        destination_time_label = new Gtk.Label (null) {
+            valign = Gtk.Align.START,
+            xalign = 0
+        };
 
-        var source_size_title_label = new Gtk.Label (_("Size:"));
-        source_size_title_label.valign = Gtk.Align.END;
-        source_size_title_label.xalign = 1;
+        source_image = new Gtk.Image () {
+            pixel_size = 64
+        };
 
-        source_size_label = new Gtk.Label (null);
-        source_size_label.valign = Gtk.Align.END;
-        source_size_label.xalign = 0;
+        var source_label = new Gtk.Label ("<b>%s</b>".printf (_("Replace with"))) {
+            margin_bottom = 6,
+            use_markup = true,
+            xalign = 0
+        };
 
-        var source_type_title_label = new Gtk.Label (_("Type:"));
-        source_type_title_label.xalign = 1;
-        source_type_label = new Gtk.Label (null);
-        source_type_label.xalign = 0;
+        var source_size_title_label = new Gtk.Label (_("Size:")) {
+            valign = Gtk.Align.END,
+            xalign = 1
+        };
 
-        var source_time_title_label = new Gtk.Label (_("Last modified:"));
-        source_time_title_label.valign = Gtk.Align.START;
-        source_time_title_label.xalign = 1;
-        source_time_label = new Gtk.Label (null);
-        source_time_label.valign = Gtk.Align.START;
-        source_time_label.xalign = 0;
+        source_size_label = new Gtk.Label (null) {
+            valign = Gtk.Align.END,
+            xalign = 0
+        };
 
-        rename_entry = new Gtk.Entry ();
-        rename_entry.hexpand = true;
+        var source_type_title_label = new Gtk.Label (_("Type:")) {
+            xalign = 1
+        };
+
+        source_type_label = new Gtk.Label (null) {
+            xalign = 0
+        };
+
+        var source_time_title_label = new Gtk.Label (_("Last modified:")) {
+            valign = Gtk.Align.START,
+            xalign = 1
+        };
+
+        source_time_label = new Gtk.Label (null) {
+            valign = Gtk.Align.START,
+            xalign = 0
+        };
+
+        rename_entry = new Gtk.Entry () {
+            hexpand = true
+        };
 
         var reset_button = new Gtk.Button.with_label (_("Reset"));
 
-        var expander_grid = new Gtk.Grid ();
-        expander_grid.margin_top = 6;
-        expander_grid.margin_bottom = 6;
-        expander_grid.column_spacing = 6;
-        expander_grid.orientation = Gtk.Orientation.HORIZONTAL;
+        var expander_grid = new Gtk.Grid () {
+            margin_top = 6,
+            margin_bottom = 6,
+            column_spacing = 6,
+            orientation = Gtk.Orientation.HORIZONTAL
+        };
+
         expander_grid.add (rename_entry);
         expander_grid.add (reset_button);
 
@@ -195,10 +224,12 @@ public class Marlin.FileConflictDialog : Gtk.Dialog {
         replace_button = (Gtk.Button) add_button (_("Replace"), ResponseType.REPLACE);
         replace_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
-        var comparison_grid = new Gtk.Grid ();
-        comparison_grid.column_spacing = 6;
-        comparison_grid.row_spacing = 0;
-        comparison_grid.margin_top = 18;
+        var comparison_grid = new Gtk.Grid () {
+            column_spacing = 6,
+            row_spacing = 0,
+            margin_top = 18
+        };
+
         comparison_grid.attach (destination_label, 0, 0, 3, 1);
         comparison_grid.attach (destination_image, 0, 1, 1, 3);
         comparison_grid.attach (destination_size_title_label, 1, 1, 1, 1);
@@ -217,11 +248,13 @@ public class Marlin.FileConflictDialog : Gtk.Dialog {
         comparison_grid.attach (source_time_title_label, 1, 7, 1, 1);
         comparison_grid.attach (source_time_label, 2, 7, 1, 1);
 
-        var grid = new Gtk.Grid ();
-        grid.margin = 0;
-        grid.margin_bottom = 24;
-        grid.column_spacing = 12;
-        grid.row_spacing = 6;
+        var grid = new Gtk.Grid () {
+            margin = 0,
+            margin_bottom = 24,
+            column_spacing = 12,
+            row_spacing = 6
+        };
+
         grid.attach (image, 0, 0, 1, 2);
         grid.attach (primary_label, 1, 0, 1, 1);
         grid.attach (secondary_label, 1, 1, 1, 1);

--- a/libcore/SoundManager.vala
+++ b/libcore/SoundManager.vala
@@ -30,6 +30,7 @@ namespace PF {
             if (instance == null) {
                 instance = new SoundManager ();
             }
+
             return instance;
         }
 

--- a/libcore/Thumbnailer.vala
+++ b/libcore/Thumbnailer.vala
@@ -157,6 +157,7 @@ namespace Marlin {
                 instance = new Thumbnailer ();
                 instance.init ();
             }
+
             return instance;
         }
 

--- a/libcore/UndoManager.vala
+++ b/libcore/UndoManager.vala
@@ -493,9 +493,10 @@ namespace Marlin {
                 return;
             }
             /* The stored uris are escaped */
-            var data = new Marlin.UndoActionData (Marlin.UndoActionType.RENAME, 1);
-            data.old_uri = renamed_file.get_parent ().get_child (original_name).get_uri ();
-            data.new_uri = renamed_file.get_uri ();
+            var data = new Marlin.UndoActionData (Marlin.UndoActionType.RENAME, 1) {
+                old_uri = renamed_file.get_parent ().get_child (original_name).get_uri (),
+                new_uri = renamed_file.get_uri ()
+            };
 
             add_action ((owned) data);
         }

--- a/libwidgets/Chrome/BreadcrumbIconList.vala
+++ b/libwidgets/Chrome/BreadcrumbIconList.vala
@@ -144,15 +144,17 @@ namespace Marlin.View.Chrome {
         private void add_protocol_directory (string protocol, string icon) {
             var separator = "://" + (protocol == "mtp" ? "[" : "");
             var info = new BreadcrumbIconInfo.protocol_directory (protocol + separator,
-                                                                  icon,
-                                                                  protocol_to_name (protocol));
+                                                                    icon,
+                                                                    protocol_to_name (protocol));
             icon_info_list.add (info);
         }
 
         private void add_special_directory (string? dir, string icon_name, bool break_loop = false) {
             if (dir != null) {
-                var icon = new BreadcrumbIconInfo.special_directory (dir, icon_name);
-                icon.break_loop = break_loop;
+                var icon = new BreadcrumbIconInfo.special_directory (dir, icon_name) {
+                    break_loop = break_loop
+                };
+
                 icon_info_list.add (icon);
             }
         }

--- a/libwidgets/Chrome/ViewSwitcher.vala
+++ b/libwidgets/Chrome/ViewSwitcher.vala
@@ -30,18 +30,24 @@ namespace Marlin.View.Chrome {
 
         construct {
             /* Item 0 */
-            var icon = new Gtk.Image.from_icon_name ("view-grid-symbolic", Gtk.IconSize.BUTTON);
-            icon.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>1"}, _("View as Grid"));
+            var icon = new Gtk.Image.from_icon_name ("view-grid-symbolic", Gtk.IconSize.BUTTON) {
+                tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>1"}, _("View as Grid"))
+            };
+
             append (icon);
 
             /* Item 1 */
-            var list = new Gtk.Image.from_icon_name ("view-list-symbolic", Gtk.IconSize.BUTTON);
-            list.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>2"}, _("View as List"));
+            var list = new Gtk.Image.from_icon_name ("view-list-symbolic", Gtk.IconSize.BUTTON) {
+                tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>2"}, _("View as List"))
+            };
+
             append (list);
 
             /* Item 2 */
-            var miller = new Gtk.Image.from_icon_name ("view-column-symbolic", Gtk.IconSize.BUTTON);
-            miller.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>3"}, _("View in Columns"));
+            var miller = new Gtk.Image.from_icon_name ("view-column-symbolic", Gtk.IconSize.BUTTON) {
+                tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>3"}, _("View in Columns"))
+            };
+
             append (miller);
 
             mode_changed.connect (() => {

--- a/libwidgets/View/SearchResults.vala
+++ b/libwidgets/View/SearchResults.vala
@@ -146,8 +146,10 @@ namespace Marlin.View.Chrome {
 #if HAVE_ZEITGEIST
             var template = new Zeitgeist.Event ();
 
-            var template_subject = new Zeitgeist.Subject ();
-            template_subject.manifestation = Zeitgeist.NFO.FILE_DATA_OBJECT;
+            var template_subject = new Zeitgeist.Subject () {
+                manifestation = Zeitgeist.NFO.FILE_DATA_OBJECT
+            };
+
             template.add_subject (template_subject);
 
             templates = new GenericArray<Zeitgeist.Event> ();
@@ -155,16 +157,20 @@ namespace Marlin.View.Chrome {
 
             zg_index = new Zeitgeist.Index ();
 #endif
-            var frame = new Gtk.Frame (null);
-            frame.shadow_type = Gtk.ShadowType.ETCHED_IN;
+            var frame = new Gtk.Frame (null) {
+                shadow_type = Gtk.ShadowType.ETCHED_IN
+            };
 
-            scroll = new Gtk.ScrolledWindow (null, null);
-            scroll.hscrollbar_policy = Gtk.PolicyType.NEVER;
+            scroll = new Gtk.ScrolledWindow (null, null) {
+                hscrollbar_policy = Gtk.PolicyType.NEVER
+            };
 
-            view = new Gtk.TreeView ();
-            view.headers_visible = false;
-            view.level_indentation = 12;
-            view.show_expanders = false;
+            view = new Gtk.TreeView () {
+                headers_visible = false,
+                level_indentation = 12,
+                show_expanders = false
+            };
+
             view.get_selection ().set_mode (Gtk.SelectionMode.BROWSE);
 
             /* Do not select category headers */
@@ -174,21 +180,26 @@ namespace Marlin.View.Chrome {
 
             get_style_context ().add_class ("completion-popup");
 
-            var column = new Gtk.TreeViewColumn ();
-            column.sizing = Gtk.TreeViewColumnSizing.FIXED;
+            var column = new Gtk.TreeViewColumn () {
+                sizing = Gtk.TreeViewColumnSizing.FIXED
+            };
 
             var cell = new Gtk.CellRendererPixbuf ();
             column.pack_start (cell, false);
             column.set_attributes (cell, "gicon", 1, "visible", 4);
 
-            var cell_name = new Gtk.CellRendererText ();
-            cell_name.ellipsize = Pango.EllipsizeMode.MIDDLE;
+            var cell_name = new Gtk.CellRendererText () {
+                ellipsize = Pango.EllipsizeMode.MIDDLE
+            };
+
             column.pack_start (cell_name, true);
             column.set_attributes (cell_name, "markup", 0);
 
-            var cell_path = new Gtk.CellRendererText ();
-            cell_path.xpad = 6;
-            cell_path.ellipsize = Pango.EllipsizeMode.MIDDLE;
+            var cell_path = new Gtk.CellRendererText () {
+                xpad = 6,
+                ellipsize = Pango.EllipsizeMode.MIDDLE
+            };
+
             column.pack_start (cell_path, false);
             column.set_attributes (cell_path, "markup", 2);
 

--- a/plugins/pantheon-files-cloud/plugin.vala
+++ b/plugins/pantheon-files-cloud/plugin.vala
@@ -106,16 +106,18 @@ public class Marlin.Plugins.Cloud.Plugin : Marlin.Plugins.Base {
     static Marlin.SidebarPluginItem adapt_plugin_item (CloudProviders.Provider provider,
                                                        CloudProviders.Account account) {
 
-        var item = new Marlin.SidebarPluginItem ();
-        item.name = account.name;
-        item.tooltip = account.path;
-        item.uri = account.path;
-        item.icon = account.icon;
-        item.show_spinner = account.get_status () == CloudProviders.AccountStatus.SYNCING;
-        item.action_group = account.action_group;
-        item.action_group_namespace = "cloudprovider";
-        item.menu_model = account.menu_model;
-        item.action_icon = get_icon (account.get_status ());
+        var item = new Marlin.SidebarPluginItem () {
+            name = account.name,
+            tooltip = account.path,
+            uri = account.path,
+            icon = account.icon,
+            show_spinner = account.get_status () == CloudProviders.AccountStatus.SYNCING,
+            action_group = account.action_group,
+            action_group_namespace = "cloudprovider",
+            menu_model = account.menu_model,
+            action_icon = get_icon (account.get_status ())
+        };
+
         return item;
     }
 

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -359,10 +359,12 @@ public class Marlin.Plugins.CTags : Marlin.Plugins.Base {
             color_buttons.add (new ColorButton ("brown"));
             color_buttons.add (new ColorButton ("slate"));
 
-            var colorbox = new Gtk.Grid ();
-            colorbox.column_spacing = COLORBOX_SPACING;
-            colorbox.margin_start = 3;
-            colorbox.halign = Gtk.Align.START;
+            var colorbox = new Gtk.Grid () {
+                column_spacing = COLORBOX_SPACING,
+                margin_start = 3,
+                halign = Gtk.Align.START
+            };
+
             colorbox.add (color_button_remove);
 
             for (int i = 0; i < color_buttons.size; i++) {

--- a/plugins/pantheon-files-trash/plugin.vala
+++ b/plugins/pantheon-files-trash/plugin.vala
@@ -60,12 +60,15 @@ public class Marlin.Plugins.Trash : Marlin.Plugins.Base {
                 actionbar = new Gtk.ActionBar ();
                 actionbar.get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);
 
-                restore_button = new Gtk.Button.with_label (_(RESTORE_ALL));
-                restore_button.valign = Gtk.Align.CENTER;
+                restore_button = new Gtk.Button.with_label (_(RESTORE_ALL)) {
+                    valign = Gtk.Align.CENTER
+                };
 
-                delete_button = new Gtk.Button.with_label (_(DELETE_ALL));
-                delete_button.margin = 6;
-                delete_button.margin_start = 0;
+                delete_button = new Gtk.Button.with_label (_(DELETE_ALL)) {
+                    margin = 6,
+                    margin_start = 0
+                };
+
                 delete_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
                 var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);

--- a/src/Dialogs/AbstractPropertiesDialog.vala
+++ b/src/Dialogs/AbstractPropertiesDialog.vala
@@ -48,25 +48,30 @@ protected abstract class Marlin.View.AbstractPropertiesDialog : Gtk.Dialog {
 
         var info_header = new Granite.HeaderLabel (_("Info"));
 
-        info_grid = new Gtk.Grid ();
-        info_grid.column_spacing = 6;
-        info_grid.row_spacing = 6;
+        info_grid = new Gtk.Grid () {
+            column_spacing = 6,
+            row_spacing = 6
+        };
+
         info_grid.attach (info_header, 0, 0, 2, 1);
 
         stack = new Gtk.Stack ();
         stack.add_titled (info_grid, PanelType.INFO.to_string (), _("General"));
 
-        stack_switcher = new Gtk.StackSwitcher ();
-        stack_switcher.homogeneous = true;
-        stack_switcher.margin_top = 12;
-        stack_switcher.no_show_all = true;
-        stack_switcher.stack = stack;
+        stack_switcher = new Gtk.StackSwitcher () {
+            homogeneous = true,
+            margin_top = 12,
+            no_show_all = true,
+            stack = stack
+        };
 
-        layout = new Gtk.Grid ();
-        layout.margin = 12;
-        layout.margin_top = 0;
-        layout.column_spacing = 12;
-        layout.row_spacing = 6;
+        layout = new Gtk.Grid () {
+            margin = 12,
+            margin_top = 0,
+            column_spacing = 12,
+            row_spacing = 6
+        };
+
         layout.attach (stack_switcher, 0, 1, 2, 1);
         layout.attach (stack, 0, 2, 2, 1);
 
@@ -93,10 +98,11 @@ protected abstract class Marlin.View.AbstractPropertiesDialog : Gtk.Dialog {
     protected void overlay_emblems (Gtk.Image file_icon, List<string>? emblems_list) {
         if (emblems_list != null) {
             int pos = 0;
-            var emblem_grid = new Gtk.Grid ();
-            emblem_grid.orientation = Gtk.Orientation.VERTICAL;
-            emblem_grid.halign = Gtk.Align.END;
-            emblem_grid.valign = Gtk.Align.END;
+            var emblem_grid = new Gtk.Grid () {
+                orientation = Gtk.Orientation.VERTICAL,
+                halign = Gtk.Align.END,
+                valign = Gtk.Align.END
+            };
 
             foreach (string emblem_name in emblems_list) {
                 var emblem = new Gtk.Image.from_icon_name (emblem_name, Gtk.IconSize.BUTTON);
@@ -108,11 +114,15 @@ protected abstract class Marlin.View.AbstractPropertiesDialog : Gtk.Dialog {
                 }
             }
 
-            var file_img = new Gtk.Overlay ();
-            file_img.set_size_request (48, 48);
-            file_img.valign = Gtk.Align.CENTER;
+            var file_img = new Gtk.Overlay () {
+                valign = Gtk.Align.CENTER,
+                width_request = 48,
+                height_request = 48
+            };
+
             file_img.add_overlay (file_icon);
             file_img.add_overlay (emblem_grid);
+
             layout.attach (file_img, 0, 0, 1, 1);
         } else {
             layout.attach (file_icon, 0, 0, 1, 1);

--- a/src/Dialogs/ChooseAppDialog.vala
+++ b/src/Dialogs/ChooseAppDialog.vala
@@ -32,15 +32,18 @@ class PF.ChooseAppDialog : Object {
 
     construct {
         dialog = new Gtk.AppChooserDialog (parent,
-                                           Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                                           file_to_open);
-        dialog.deletable = false;
+                                             Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                                             file_to_open) {
+            deletable = false
+        };
 
         var app_chooser = dialog.get_widget () as Gtk.AppChooserWidget;
         app_chooser.show_recommended = true;
 
-        check_default = new Gtk.CheckButton.with_label (_("Set as default"));
-        check_default.active = true;
+        check_default = new Gtk.CheckButton.with_label (_("Set as default")) {
+            active = true
+        };
+
         check_default.show ();
 
         var action_area = dialog.get_action_area () as Gtk.ButtonBox;

--- a/src/Dialogs/VolumePropertiesWindow.vala
+++ b/src/Dialogs/VolumePropertiesWindow.vala
@@ -71,8 +71,10 @@ public class VolumePropertiesWindow : AbstractPropertiesDialog {
             overlay_emblems (file_icon, emblems_list);
         }
 
-        header_title = new Gtk.Label (mount_name);
-        header_title.halign = Gtk.Align.START;
+        header_title = new Gtk.Label (mount_name) {
+            halign = Gtk.Align.START
+        };
+
         create_header_title ();
 
         var location_label = new KeyLabel (_("Location:"));

--- a/src/ProgressUIHandler.vala
+++ b/src/ProgressUIHandler.vala
@@ -123,11 +123,12 @@ public class Marlin.Progress.UIHandler : Object {
     private void ensure_window () {
         if (progress_window == null) {
             /* This provides an undeletable, unminimisable window in which to show the info widgets */
-            progress_window = new Gtk.Dialog ();
-            progress_window.resizable = false;
-            progress_window.deletable = false;
-            progress_window.title = _("File Operations");
-            progress_window.icon_name = "system-file-manager";
+            progress_window = new Gtk.Dialog () {
+                resizable = false,
+                deletable = false,
+                title = _("File Operations"),
+                icon_name = "system-file-manager"
+            };
 
             window_vbox = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
 

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -31,10 +31,11 @@ namespace FM {
         }
 
         protected virtual void create_and_set_up_name_column () {
-            name_column = new Gtk.TreeViewColumn ();
-            name_column.set_sort_column_id (FM.ListModel.ColumnID.FILENAME);
-            name_column.set_expand (true);
-            name_column.set_resizable (true);
+            name_column = new Gtk.TreeViewColumn () {
+                sort_column_id = FM.ListModel.ColumnID.FILENAME,
+                expand = true,
+                resizable = true
+            };
 
             name_renderer = new Marlin.TextRenderer (Marlin.ViewMode.LIST);
             set_up_name_renderer ();
@@ -84,12 +85,13 @@ namespace FM {
         }
 
         protected override Gtk.Widget? create_view () {
-            tree = new FM.TreeView ();
-            tree.set_model (model);
-            tree.set_headers_visible (false);
-            tree.get_selection ().set_mode (Gtk.SelectionMode.MULTIPLE);
-            tree.set_rubber_banding (true);
+            tree = new FM.TreeView () {
+                model = model,
+                headers_visible = false,
+                rubber_banding = true
+            };
 
+            tree.get_selection ().set_mode (Gtk.SelectionMode.MULTIPLE);
             create_and_set_up_name_column ();
             set_up_view ();
 

--- a/src/View/DirectoryNotFound.vala
+++ b/src/View/DirectoryNotFound.vala
@@ -47,6 +47,7 @@ namespace Marlin.View {
                             new ThemedIcon ("dialog-error"),
                             Gtk.ButtonsType.CLOSE
                         );
+
                         dialog.run ();
                         dialog.destroy ();
                     }

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -56,12 +56,14 @@ namespace FM {
                 } else {
                     var renderer = new Gtk.CellRendererText ();
                     var col = new Gtk.TreeViewColumn.with_attributes (column_titles [k - fnc],
-                                                                      renderer,
-                                                                      "text", k);
-                    col.set_sort_column_id (k);
-                    col.set_resizable (false);
-                    col.set_expand (false);
-                    col.min_width = 24;
+                                                                        renderer,
+                                                                        "text", k) {
+                        sort_column_id = k,
+                        resizable = false,
+                        expand = false,
+                        min_width = 24
+                    };
+
                     if (k == FM.ListModel.ColumnID.SIZE || k == FM.ListModel.ColumnID.MODIFIED) {
                         renderer.@set ("xalign", 1.0f);
                     } else {

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -56,12 +56,17 @@ namespace Marlin.View {
 
             colpane = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 
-            scrolled_window = new Gtk.ScrolledWindow (null, null);
-            scrolled_window.set_policy (Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.NEVER);
+            scrolled_window = new Gtk.ScrolledWindow (null, null) {
+                hscrollbar_policy = Gtk.PolicyType.AUTOMATIC,
+                vscrollbar_policy = Gtk.PolicyType.NEVER
+            };
+
             hadj = scrolled_window.get_hadjustment ();
 
-            var viewport = new Gtk.Viewport (null, null);
-            viewport.set_shadow_type (Gtk.ShadowType.NONE);
+            var viewport = new Gtk.Viewport (null, null) {
+                shadow_type = Gtk.ShadowType.NONE
+            };
+
             viewport.add (this.colpane);
 
             scrolled_window.add (viewport);
@@ -87,7 +92,7 @@ namespace Marlin.View {
         public void add_location (GLib.File loc, Marlin.View.Slot? host = null,
                                   bool scroll = true, bool animate = true) {
 
-            Marlin.View.Slot new_slot = new Marlin.View.Slot (loc, ctab, Marlin.ViewMode.MILLER_COLUMNS);
+            var new_slot = new Marlin.View.Slot (loc, ctab, Marlin.ViewMode.MILLER_COLUMNS);
             /* Notify view container of path change - will set tab to working and change pathbar */
             path_changed ();
             new_slot.slot_number = (host != null) ? host.slot_number + 1 : 0;
@@ -102,8 +107,10 @@ namespace Marlin.View {
         }
 
         private void nest_slot_in_host_slot (Marlin.View.Slot slot, Marlin.View.Slot? host) {
-            var hpane1 = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
-            hpane1.hexpand = true;
+            var hpane1 = new Gtk.Paned (Gtk.Orientation.HORIZONTAL) {
+                hexpand = true
+            };
+
             slot.hpane = hpane1;
 
             var box1 = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);

--- a/src/View/Sidebar.vala
+++ b/src/View/Sidebar.vala
@@ -149,44 +149,53 @@ public class Marlin.Sidebar : Marlin.AbstractSidebar {
     }
 
     private void construct_tree_view () {
-        tree_view = new Gtk.TreeView ();
-        tree_view.set_size_request (Preferences.settings.get_int ("minimum-sidebar-width"), -1);
-        tree_view.set_headers_visible (false);
-        tree_view.show_expanders = false;
+        tree_view = new Gtk.TreeView () {
+            width_request = Preferences.settings.get_int ("minimum-sidebar-width"),
+            headers_visible = false,
+            show_expanders = false
+        };
 
-        var col = new Gtk.TreeViewColumn ();
-        col.max_width = -1;
-        col.expand = true;
-        col.spacing = 3;
+        var col = new Gtk.TreeViewColumn () {
+            max_width = -1,
+            expand = true,
+            spacing = 3
+        };
 
-        var crt = new Gtk.CellRendererText (); /* Extra indent for start margin */
-        crt.xpad = ROOT_INDENTATION_XPAD;
-        crt.ypad = BOOKMARK_YPAD;
+        var crt = new Gtk.CellRendererText () { /* Extra indent for start margin */
+            xpad = ROOT_INDENTATION_XPAD,
+            ypad = BOOKMARK_YPAD
+        };
+
         col.pack_start (crt, false);
 
-        crt = new Gtk.CellRendererText (); /* Extra indent for sub-category rows (bookmarks)*/
-        crt.xpad = ICON_XPAD;
-        crt.ypad = BOOKMARK_YPAD;
+        crt = new Gtk.CellRendererText () { /* Extra indent for sub-category rows (bookmarks)*/
+            xpad = ICON_XPAD,
+            ypad = BOOKMARK_YPAD
+        };
+
         col.pack_start (crt, false);
         col.set_attributes (crt, "visible", Column.NOT_CATEGORY);
 
-        var crpb = new Gtk.CellRendererPixbuf (); /* Icon for bookmark or device */
-        crpb.stock_size = Gtk.IconSize.MENU;
-        crpb.ypad = BOOKMARK_YPAD;
+        var crpb = new Gtk.CellRendererPixbuf () { /* Icon for bookmark or device */
+            stock_size = Gtk.IconSize.MENU,
+            ypad = BOOKMARK_YPAD
+        };
+
         col.pack_start (crpb, false);
         col.set_attributes (crpb,
                             "gicon", Column.ICON,
                             "visible", Column.NOT_CATEGORY);
 
-        var crd = new Marlin.CellRendererDisk (); /* Renders category & bookmark text and diskspace graphic */
-        name_renderer = crd as Gtk.CellRendererText;
-        name_renderer.ellipsize = Pango.EllipsizeMode.END;
-        name_renderer.ellipsize_set = true;
+        name_renderer = new Marlin.CellRendererDisk () { /* Renders category & bookmark text and diskspace graphic */
+            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize_set = true
+        };
+
         name_renderer.edited.connect (edited);
         name_renderer.editing_canceled.connect (editing_canceled);
 
-        col.pack_start (crd, true);
-        col.set_attributes (crd,
+        col.pack_start (name_renderer, true);
+        col.set_attributes (name_renderer,
                             "text", Column.NAME,
                             "free_space", Column.FREE_SPACE,
                             "disk_size", Column.DISK_SIZE,
@@ -195,33 +204,37 @@ public class Marlin.Sidebar : Marlin.AbstractSidebar {
         /* renderer function sets font weight and ypadding depending on whether bookmark or category */
         col.set_cell_data_func (name_renderer, category_renderer_func);
 
-        var crsp = new Gtk.CellRendererSpinner (); /* Spinner shown while ejecting */
-        crsp.ypad = BOOKMARK_YPAD;
+        var crsp = new Gtk.CellRendererSpinner () { /* Spinner shown while ejecting */
+            ypad = BOOKMARK_YPAD
+        };
+
         col.pack_end (crsp, false);
         col.set_attributes (crsp,
                             "visible", Column.SHOW_SPINNER,
                             "active", Column.SHOW_SPINNER,
                             "pulse", Column.SPINNER_PULSE);
 
-        crpb = new Gtk.CellRendererPixbuf (); /* Icon for eject button  (hidden while ejecting or unmounted) and another signs */
+        crpb = new Gtk.CellRendererPixbuf () { /* Icon for eject button  (hidden while ejecting or unmounted) and another signs */
+            stock_size = Gtk.IconSize.MENU,
+            xpad = ICON_XPAD,
+            ypad = BOOKMARK_YPAD
+        };
+
         this.eject_spinner_cell_renderer = crpb;
-        crpb.stock_size = Gtk.IconSize.MENU;
-        crpb.xpad = ICON_XPAD;
-        crpb.ypad = BOOKMARK_YPAD;
 
         col.pack_start (crpb, false);
         col.set_attributes (crpb,
                             "gicon", Column.ACTION_ICON);
 
-        var cre = new Granite.Widgets.CellRendererExpander (); /* Expander button for categories */
-        expander_renderer = cre;
-        cre.is_category_expander = true;
-        cre.is_expander = true;
-        cre.xpad = ICON_XPAD;
-        cre.ypad = BOOKMARK_YPAD;
+        expander_renderer = new Granite.Widgets.CellRendererExpander () { /* Expander button for categories */
+            is_category_expander = true,
+            is_expander = true,
+            xpad = ICON_XPAD,
+            ypad = BOOKMARK_YPAD
+        };
 
-        col.pack_end (cre, false);
-        col.set_attributes (cre, "visible", Column.IS_CATEGORY);
+        col.pack_end (expander_renderer, false);
+        col.set_attributes (expander_renderer, "visible", Column.IS_CATEGORY);
 
         tree_view.append_column (col);
         tree_view.tooltip_column = Column.TOOLTIP;
@@ -1646,9 +1659,9 @@ public class Marlin.Sidebar : Marlin.AbstractSidebar {
             }
         } else {
             var menu = new PopupMenuBuilder ().add_open (open_shortcut_cb)
-                                              .add_separator ()
-                                              .add_open_tab (open_shortcut_in_new_tab_cb)
-                                              .add_open_window (open_shortcut_in_new_window_cb);
+                                                .add_separator ()
+                                                .add_open_tab (open_shortcut_in_new_tab_cb)
+                                                .add_open_window (open_shortcut_in_new_window_cb);
 
             if (is_bookmark) {
                 menu.add_separator ().add_remove (remove_shortcut_cb)
@@ -1782,21 +1795,21 @@ public class Marlin.Sidebar : Marlin.AbstractSidebar {
     }
 
     private void expander_init_pref_state (Gtk.TreeView tree_view) {
-        var path = new Gtk.TreePath.from_indices (0,-1);
+        var path = new Gtk.TreePath.from_indices (0, -1);
         if (Preferences.settings.get_boolean ("sidebar-cat-personal-expander")) {
             tree_view.expand_row (path, false);
         } else {
             tree_view.collapse_row (path);
         }
 
-        path = new Gtk.TreePath.from_indices (1,-1);
+        path = new Gtk.TreePath.from_indices (1, -1);
         if (Preferences.settings.get_boolean ("sidebar-cat-devices-expander")) {
             tree_view.expand_row (path, false);
         } else {
             tree_view.collapse_row (path);
         }
 
-        path = new Gtk.TreePath.from_indices (2,-1);
+        path = new Gtk.TreePath.from_indices (2, -1);
         if (Preferences.settings.get_boolean ("sidebar-cat-network-expander")) {
             tree_view.expand_row (path, false);
         } else {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -523,6 +523,7 @@ namespace Marlin.View {
                         aslot.set_all_selected (false);
                         selected_locations = null;
                     }
+
                     var list = new List<File> ();
                     list.prepend (loc);
                     aslot.select_glib_files (list, loc);

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -469,9 +469,11 @@ namespace Marlin.View.Chrome {
             foreach (AppInfo app_info in app_info_list) {
                 if (app_info != null && app_info.get_executable () != Environment.get_application_name ()) {
                     at_least_one = true;
-                     var item_grid = new Gtk.Grid ();
-                    var img = new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.MENU);
-                    img.pixel_size = 16;
+                    var item_grid = new Gtk.Grid ();
+                    var img = new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.MENU) {
+                        pixel_size = 16
+                    };
+
                     item_grid.add (img);
                     item_grid.add (new Gtk.Label (app_info.get_name ()));
                      var menu_item = new Gtk.MenuItem ();
@@ -480,6 +482,7 @@ namespace Marlin.View.Chrome {
                     menu_item.activate.connect (() => {
                         open_with_request (loc, app_info);
                     });
+
                     submenu_open_with.append (menu_item);
                 }
             }

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -62,12 +62,14 @@ public class Marlin.View.Chrome.HeaderBar : Gtk.HeaderBar {
         button_back = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name (
             "go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR
         );
+
         button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
         button_back.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         button_forward = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name (
             "go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR
         );
+
         button_forward.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Right"}, _("Next"));
         button_forward.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
@@ -136,6 +138,7 @@ public class Marlin.View.Chrome.HeaderBar : Gtk.HeaderBar {
             item.activate.connect (() => {
                 back (cn);
             });
+
             back_menu.insert (item, -1);
         }
 
@@ -153,6 +156,7 @@ public class Marlin.View.Chrome.HeaderBar : Gtk.HeaderBar {
             item.activate.connect (() => {
                 forward (cn);
             });
+
             forward_menu.insert (item, -1);
         }
 

--- a/src/View/Widgets/ProgressInfoWidget.vala
+++ b/src/View/Widgets/ProgressInfoWidget.vala
@@ -34,25 +34,28 @@ public class Marlin.Progress.InfoWidget : Gtk.Grid {
     }
 
     construct {
-        var status = new Gtk.Label (info.status);
-        status.max_width_chars = 50;
-        status.selectable = true;
-        status.width_chars = 50;
-        status.wrap = true;
-        status.xalign = 0;
+        var status = new Gtk.Label (info.status) {
+            max_width_chars = 50,
+            selectable = true,
+            width_chars = 50,
+            wrap = true,
+            xalign = 0
+        };
 
-        progress_bar = new Gtk.ProgressBar ();
-        progress_bar.hexpand = true;
-        progress_bar.pulse_step = 0.05;
-        progress_bar.show_text = false;
-        progress_bar.valign = Gtk.Align.CENTER;
+        progress_bar = new Gtk.ProgressBar () {
+            hexpand = true,
+            pulse_step = 0.05,
+            show_text = false,
+            valign = Gtk.Align.CENTER
+        };
 
-        details = new Gtk.Label ("details");
-        details.use_markup = true;
-        details.selectable = true;
-        details.max_width_chars = 50;
-        details.wrap = true;
-        details.xalign = 0;
+        details = new Gtk.Label ("details") {
+            use_markup = true,
+            selectable = true,
+            max_width_chars = 50,
+            wrap = true,
+            xalign = 0
+        };
 
         var button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.BUTTON);
         button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -127,21 +127,24 @@ namespace Marlin.View {
         }
 
         private void build_window () {
-            view_switcher = new Chrome.ViewSwitcher (lookup_action ("view-mode") as SimpleAction);
-            view_switcher.selected = Preferences.settings.get_enum ("default-viewmode");
+            view_switcher = new Chrome.ViewSwitcher ((SimpleAction)lookup_action ("view-mode")) {
+                selected = Preferences.settings.get_enum ("default-viewmode")
+            };
 
-            top_menu = new Chrome.HeaderBar (view_switcher);
-            top_menu.show_close_button = true;
-            top_menu.custom_title = new Gtk.Label (null);
+            top_menu = new Chrome.HeaderBar (view_switcher) {
+                show_close_button = true,
+                custom_title = new Gtk.Label (null)
+            };
 
             set_titlebar (top_menu);
 
-            tabs = new Granite.Widgets.DynamicNotebook ();
-            tabs.show_tabs = true;
-            tabs.allow_restoring = true;
-            tabs.allow_duplication = true;
-            tabs.allow_new_window = true;
-            tabs.group_name = Config.APP_NAME;
+            tabs = new Granite.Widgets.DynamicNotebook () {
+                show_tabs = true,
+                allow_restoring = true,
+                allow_duplication = true,
+                allow_new_window = true,
+                group_name = Config.APP_NAME
+            };
 
             this.configure_event.connect_after ((e) => {
                 tabs.set_size_request (e.width / 2, -1);
@@ -152,8 +155,10 @@ namespace Marlin.View {
 
             sidebar = new Marlin.Sidebar (this);
 
-            lside_pane = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
-            lside_pane.position = Preferences.settings.get_int ("sidebar-width");
+            lside_pane = new Gtk.Paned (Gtk.Orientation.HORIZONTAL) {
+                position = Preferences.settings.get_int ("sidebar-width")
+            };
+
             lside_pane.show ();
             lside_pane.pack1 (sidebar, false, false);
             lside_pane.pack2 (tabs, true, true);
@@ -446,8 +451,9 @@ namespace Marlin.View {
 
             mode = real_mode (mode);
             var content = new View.ViewContainer (this);
-            var tab = new Granite.Widgets.Tab ("", null, content);
-            tab.ellipsize_mode = Pango.EllipsizeMode.MIDDLE;
+            var tab = new Granite.Widgets.Tab ("", null, content) {
+                ellipsize_mode = Pango.EllipsizeMode.MIDDLE
+            };
 
             change_tab ((int)tabs.insert_tab (tab, -1));
             tabs.current = tab;


### PR DESCRIPTION
Following discussions on Slack and noting https://github.com/elementary/notifications/pull/80, where some properties of an object are initialized in separate statements following its creation with `new`, the properties are instead initialized as part of the `new` statement.

For consistency, this is done even if only one property is involved.

A few other minor code-style changes, mostly whitespace, were made when noticed.

None of the changes should have any functional effect.