### PR TITLE
Use proper icon size for back and forward

### DIFF
--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -60,14 +60,14 @@ public class Marlin.View.Chrome.HeaderBar : Gtk.HeaderBar {
 
     construct {
         button_back = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name (
-            "go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR
+            "go-previous-symbolic", Gtk.IconSize.BUTTON
         );
 
         button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
         button_back.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         button_forward = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name (
-            "go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR
+            "go-next-symbolic", Gtk.IconSize.BUTTON
         );
 
         button_forward.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Right"}, _("Next"));


### PR DESCRIPTION
This fixes the buttons' icon size so it's a button, no icon size hacks :stuck_out_tongue:
this was made apparent after the `go-*` icon PRs I made:
https://github.com/elementary/icons/pull/919 and https://github.com/elementary/icons/pull/920

| Old | New |
|:---:|:---:|
|![Screenshot from 2020-07-15 19 39 58](https://user-images.githubusercontent.com/4886639/87607335-7fa2db80-c6d3-11ea-8a97-5871cda04523.png)|![Screenshot from 2020-07-15 19 40 31](https://user-images.githubusercontent.com/4886639/87607353-86315300-c6d3-11ea-9ac7-474c1f1c88fe.png)|