### PR TITLE
Remove tab instead of show warning if loading fails when restoring

### DIFF
--- a/data/io.elementary.files.appdata.xml.in.in
+++ b/data/io.elementary.files.appdata.xml.in.in
@@ -58,6 +58,14 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
+    <release version="4.5.1" date="2020-08-11" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Do not restore locations that have become inaccessible</li>
+        </ul>
+      </description>
+    </release>
     <release version="4.5.0" date="2020-08-11" urgency="medium">
       <description>
         <p>Improvements:</p>

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -6,7 +6,7 @@
        ammonkey <am.monkeyd@gmail.com>
 
     Copyright (c) 2010 Mathijs Henquet
-    Copyright (c) 2017 - 2020 elementary LLC <https://elementary.io>
+                  2017–2020 elementary, Inc. <https://elementary.io>
 *
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -6,7 +6,8 @@
        ammonkey <am.monkeyd@gmail.com>
 
     Copyright (c) 2010 Mathijs Henquet
-
+    Copyright (c) 2017 - 2020 elementary LLC <https://elementary.io>
+*
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 3 of the License, or

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -401,10 +401,13 @@ namespace Marlin.View {
             }
         }
 
-        private void add_tab_by_uri (string uri, Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED) {
+        private void add_tab_by_uri (string uri,
+                                     Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED,
+                                     bool is_restoring = false) {
+
             var file = get_file_from_uri (uri);
             if (file != null) {
-                add_tab (file, mode);
+                add_tab (file, mode, false, is_restoring);
             } else {
                 add_tab ();
             }
@@ -412,7 +415,8 @@ namespace Marlin.View {
 
         private void add_tab (File _location = File.new_for_commandline_arg (Environment.get_home_dir ()),
                              Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED,
-                             bool ignore_duplicate = false) {
+                             bool ignore_duplicate = false,
+                             bool is_restoring = false) {
 
             File location;
             // For simplicity we do not use cancellable. If issues arise may need to do this.
@@ -442,6 +446,8 @@ namespace Marlin.View {
 
             mode = real_mode (mode);
             var content = new View.ViewContainer (this);
+            content.is_restoring = is_restoring;
+
             var tab = new Granite.Widgets.Tab ("", null, content) {
                 ellipsize_mode = Pango.EllipsizeMode.MIDDLE
             };
@@ -987,7 +993,7 @@ namespace Marlin.View {
                  * Leave it to GOF.Directory.Async to deal with invalid locations asynchronously.
                  */
 
-                add_tab_by_uri (root_uri, mode);
+                add_tab_by_uri (root_uri, mode, true);
 
                 if (mode == Marlin.ViewMode.MILLER_COLUMNS && tip_uri != root_uri) {
                     expand_miller_view (tip_uri, root_uri);

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1,6 +1,6 @@
 /*
 * Copyright (c) 2010 Mathijs Henquet <mathijs.henquet@gmail.com>
-*               2017-2018 elementary LLC. <https://elementary.io>
+* Copyright (c) 2017 - 2020 elementary LLC <https://elementary.io>
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1,6 +1,6 @@
 /*
 * Copyright (c) 2010 Mathijs Henquet <mathijs.henquet@gmail.com>
-* Copyright (c) 2017 - 2020 elementary LLC <https://elementary.io>
+*               2017–2020 elementary, Inc. <https://elementary.io>
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public


### PR DESCRIPTION
Fixes #1431 

Makes ViewContainer aware whether it is restoring a location on startup. Now if a view fails to load for any reason while restoring, then none of the usual warnings are displayed, instead the ViewContainer asks Window to remove the tab it is in.