### PR TITLE
Port and combine code relating to getting target files

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -971,22 +971,23 @@ namespace PF.FileUtils {
         return count;
     }
 
-    ///TRANSLATORS Just translate the word "copy" and leave the placeholders (%s) in their current positions
+    /* We assume all these translations will be valid for filenames in all filesystems */
+    ///TRANSLATORS Translate the word "copy" (noun) and leave the placeholders (%s) in their current positions
     public const string COPY_FORMAT_SINGLE = N_("%s%scopy%s%s");
 
-    ///TRANSLATORS Just translate the word "copy " and leave the placeholders (%s, %i) in their current positions
+    ///TRANSLATORS Translate the word "copy " (noun) and the space. Leave the placeholders (%s, %i) in their current positions
     public const string COPY_FORMAT_MULTIPLE = N_("%s%scopy %i%s%s");
 
-    ///TRANSLATORS Just translate the word "link" (meaning a symbolic link to a file) and leave the placeholders (%s) in their current positions
+    ///TRANSLATORS Translate the word "link" (a symbolic link to a file) and leave the placeholders (%s) in their current positions
     public const string LINK_FORMAT_SINGLE = N_("%s%slink%s%s");
 
-    ///TRANSLATORS Just translate the word "link " (meaning a symbolic link to a file) and leave the placeholders (%s, %i) in their current positions
+    ///TRANSLATORS Translate the word "link " (a symbolic link to a file) and the space. Leave the placeholders (%s, %i) in their current positions
     public const string LINK_FORMAT_MULTPLE = N_("%s%slink %i%s%s");
 
-    ///TRANSLATORS Used to separate the basename of a file from the "copy"/"link" duplicate indications.
+    ///TRANSLATORS Separator between the basename of a file from the "copy"/"link" duplicate indications.
     public const string DUPLICATE_START = N_(" (");
 
-    ///TRANSLATORS Used to separate the "copy"/"link" duplicate indication from the extension or end of a filename.
+    ///TRANSLATORS Separator between the "copy"/"link" duplicate indication from the extension or end of a filename.
     public const string DUPLICATE_END = N_(")");
 
     /* Returns a suitably named file that does not already exist (unless @overwrite is TRUE) */

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -892,18 +892,18 @@ namespace PF.FileUtils {
         return result;
     }
 
-    private File get_target_file (GLib.File src, GLib.File dest_dir,
-                                 string? dest_fs_type,
-                                 bool same_fs) {
-
+    private File get_target_file (GLib.File src, GLib.File dest_dir, string? dest_fs_type, bool same_fs) {
         File target_file;
         string copyname = src.get_basename ();
         if (same_fs) {
             target_file = dest_dir.get_child (copyname);
         } else {
             try {
-                FileInfo info = src.query_info (FileAttribute.STANDARD_COPY_NAME,
-                                                FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null);
+                FileInfo info = src.query_info (
+                    FileAttribute.STANDARD_COPY_NAME,
+                    FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+                    null
+                );
                 if (info != null && info.has_attribute (FileAttribute.STANDARD_COPY_NAME)) {
                     copyname = info.get_attribute_string (FileAttribute.STANDARD_COPY_NAME);
                 }
@@ -1000,16 +1000,22 @@ namespace PF.FileUtils {
         int count = parse_duplicate_count (ref base_path) + 1;
         if (count <= 1) { //Not duplicating a duplicate
             format = link ? _(LINK_FORMAT_SINGLE) : _(COPY_FORMAT_SINGLE);
-            target_file = File.new_for_path (format.printf (base_path, _(DUPLICATE_START), _(DUPLICATE_END), extension));
+            target_file = File.new_for_path (
+                format.printf (base_path, _(DUPLICATE_START), _(DUPLICATE_END), extension)
+            );
         } else {
             format = link ? _(LINK_FORMAT_MULTPLE) : _(COPY_FORMAT_MULTIPLE);
-            target_file = File.new_for_path (format.printf (base_path, _(DUPLICATE_START), count, _(DUPLICATE_END), extension));
+            target_file = File.new_for_path (
+                format.printf (base_path, _(DUPLICATE_START), count, _(DUPLICATE_END), extension)
+            );
         }
 
         format = link ? _(LINK_FORMAT_MULTPLE) : _(COPY_FORMAT_MULTIPLE);
         while (target_file.query_exists ()) {
             count++;
-            target_file = File.new_for_path (format.printf (base_path, _(DUPLICATE_START), count, _(DUPLICATE_END), extension));
+            target_file = File.new_for_path (
+                format.printf (base_path, _(DUPLICATE_START), count, _(DUPLICATE_END), extension)
+            );
         }
 
         return target_file;

--- a/libcore/marlin-file-operations.c
+++ b/libcore/marlin-file-operations.c
@@ -168,177 +168,177 @@ shorten_utf8_string (const char *base, int reduce_by_num_bytes)
     }
 }
 
-/* Note that we have these two separate functions with separate format
- * strings for ease of localization.
- */
+///* Note that we have these two separate functions with separate format
+ //* strings for ease of localization.
+ //*/
 
-static char *
-get_link_name (const char *name, int count, int max_length)
-{
-    const char *format;
-    char *result;
-    int unshortened_length;
-    gboolean use_count;
+//static char *
+//get_link_name (const char *name, int count, int max_length)
+//{
+    //const char *format;
+    //char *result;
+    //int unshortened_length;
+    //gboolean use_count;
 
-    g_assert (name != NULL);
+    //g_assert (name != NULL);
 
-    if (count < 0) {
-        g_warning ("bad count in get_link_name");
-        count = 0;
-    }
+    //if (count < 0) {
+        //g_warning ("bad count in get_link_name");
+        //count = 0;
+    //}
 
-    if (count <= 2) {
-        /* Handle special cases for low numbers.
-         * Perhaps for some locales we will need to add more.
-         */
-        switch (count) {
-        default:
-            g_assert_not_reached ();
-            /* fall through */
-        case 0:
-            /* duplicate original file name */
-            format = "%s";
-            break;
-        case 1:
-            /* appended to new link file */
-            format = _("Link to %s");
-            break;
-        case 2:
-            /* appended to new link file */
-            format = _("Another link to %s");
-            break;
-        }
+    //if (count <= 2) {
+        ///* Handle special cases for low numbers.
+         //* Perhaps for some locales we will need to add more.
+         //*/
+        //switch (count) {
+        //default:
+            //g_assert_not_reached ();
+            ///* fall through */
+        //case 0:
+            ///* duplicate original file name */
+            //format = "%s";
+            //break;
+        //case 1:
+            ///* appended to new link file */
+            //format = _("Link to %s");
+            //break;
+        //case 2:
+            ///* appended to new link file */
+            //format = _("Another link to %s");
+            //break;
+        //}
 
-        use_count = FALSE;
-    } else {
-        /* Handle special cases for the first few numbers of each ten.
-         * For locales where getting this exactly right is difficult,
-         * these can just be made all the same as the general case below.
-         */
-        switch (count % 10) {
-        case 1:
-            /* Localizers: Feel free to leave out the "st" suffix
-             * if there's no way to do that nicely for a
-             * particular language.
-             */
-            format = _("%'dst link to %s");
-            break;
-        case 2:
-            /* appended to new link file */
-            format = _("%'dnd link to %s");
-            break;
-        case 3:
-            /* appended to new link file */
-            format = _("%'drd link to %s");
-            break;
-        default:
-            /* appended to new link file */
-            format = _("%'dth link to %s");
-            break;
-        }
+        //use_count = FALSE;
+    //} else {
+        ///* Handle special cases for the first few numbers of each ten.
+         //* For locales where getting this exactly right is difficult,
+         //* these can just be made all the same as the general case below.
+         //*/
+        //switch (count % 10) {
+        //case 1:
+            ///* Localizers: Feel free to leave out the "st" suffix
+             //* if there's no way to do that nicely for a
+             //* particular language.
+             //*/
+            //format = _("%'dst link to %s");
+            //break;
+        //case 2:
+            ///* appended to new link file */
+            //format = _("%'dnd link to %s");
+            //break;
+        //case 3:
+            ///* appended to new link file */
+            //format = _("%'drd link to %s");
+            //break;
+        //default:
+            ///* appended to new link file */
+            //format = _("%'dth link to %s");
+            //break;
+        //}
 
-        use_count = TRUE;
-    }
+        //use_count = TRUE;
+    //}
 
-    if (use_count)
-        result = g_strdup_printf (format, count, name);
-    else
-        result = g_strdup_printf (format, name);
+    //if (use_count)
+        //result = g_strdup_printf (format, count, name);
+    //else
+        //result = g_strdup_printf (format, name);
 
-    if (max_length > 0 && (unshortened_length = strlen (result)) > max_length) {
-        char *new_name;
+    //if (max_length > 0 && (unshortened_length = strlen (result)) > max_length) {
+        //char *new_name;
 
-        new_name = shorten_utf8_string (name, unshortened_length - max_length);
-        if (new_name) {
-            g_free (result);
+        //new_name = shorten_utf8_string (name, unshortened_length - max_length);
+        //if (new_name) {
+            //g_free (result);
 
-            if (use_count)
-                result = g_strdup_printf (format, count, new_name);
-            else
-                result = g_strdup_printf (format, new_name);
+            //if (use_count)
+                //result = g_strdup_printf (format, count, new_name);
+            //else
+                //result = g_strdup_printf (format, new_name);
 
-            g_assert (strlen (result) <= max_length);
-            g_free (new_name);
-        }
-    }
+            //g_assert (strlen (result) <= max_length);
+            //g_free (new_name);
+        //}
+    //}
 
-    return result;
-}
+    //return result;
+//}
 
-/* Localizers:
- * Feel free to leave out the st, nd, rd and th suffix or
- * make some or all of them match.
- */
+///* Localizers:
+ //* Feel free to leave out the st, nd, rd and th suffix or
+ //* make some or all of them match.
+ //*/
 
-/* localizers: tag used to detect the first copy of a file */
-static const char untranslated_copy_duplicate_tag[] = N_(" (copy)");
-/* localizers: tag used to detect the second copy of a file */
-static const char untranslated_another_copy_duplicate_tag[] = N_(" (another copy)");
+///* localizers: tag used to detect the first copy of a file */
+//static const char untranslated_copy_duplicate_tag[] = N_(" (copy)");
+///* localizers: tag used to detect the second copy of a file */
+//static const char untranslated_another_copy_duplicate_tag[] = N_(" (another copy)");
 
-/* localizers: tag used to detect the x11th copy of a file */
-static const char untranslated_x11th_copy_duplicate_tag[] = N_("th copy)");
-/* localizers: tag used to detect the x12th copy of a file */
-static const char untranslated_x12th_copy_duplicate_tag[] = N_("th copy)");
-/* localizers: tag used to detect the x13th copy of a file */
-static const char untranslated_x13th_copy_duplicate_tag[] = N_("th copy)");
+///* localizers: tag used to detect the x11th copy of a file */
+//static const char untranslated_x11th_copy_duplicate_tag[] = N_("th copy)");
+///* localizers: tag used to detect the x12th copy of a file */
+//static const char untranslated_x12th_copy_duplicate_tag[] = N_("th copy)");
+///* localizers: tag used to detect the x13th copy of a file */
+//static const char untranslated_x13th_copy_duplicate_tag[] = N_("th copy)");
 
-/* localizers: tag used to detect the x1st copy of a file */
-static const char untranslated_st_copy_duplicate_tag[] = N_("st copy)");
-/* localizers: tag used to detect the x2nd copy of a file */
-static const char untranslated_nd_copy_duplicate_tag[] = N_("nd copy)");
-/* localizers: tag used to detect the x3rd copy of a file */
-static const char untranslated_rd_copy_duplicate_tag[] = N_("rd copy)");
+///* localizers: tag used to detect the x1st copy of a file */
+//static const char untranslated_st_copy_duplicate_tag[] = N_("st copy)");
+///* localizers: tag used to detect the x2nd copy of a file */
+//static const char untranslated_nd_copy_duplicate_tag[] = N_("nd copy)");
+///* localizers: tag used to detect the x3rd copy of a file */
+//static const char untranslated_rd_copy_duplicate_tag[] = N_("rd copy)");
 
-/* localizers: tag used to detect the xxth copy of a file */
-static const char untranslated_th_copy_duplicate_tag[] = N_("th copy)");
+///* localizers: tag used to detect the xxth copy of a file */
+//static const char untranslated_th_copy_duplicate_tag[] = N_("th copy)");
 
-#define COPY_DUPLICATE_TAG _(untranslated_copy_duplicate_tag)
-#define ANOTHER_COPY_DUPLICATE_TAG _(untranslated_another_copy_duplicate_tag)
-#define X11TH_COPY_DUPLICATE_TAG _(untranslated_x11th_copy_duplicate_tag)
-#define X12TH_COPY_DUPLICATE_TAG _(untranslated_x12th_copy_duplicate_tag)
-#define X13TH_COPY_DUPLICATE_TAG _(untranslated_x13th_copy_duplicate_tag)
+//#define COPY_DUPLICATE_TAG _(untranslated_copy_duplicate_tag)
+//#define ANOTHER_COPY_DUPLICATE_TAG _(untranslated_another_copy_duplicate_tag)
+//#define X11TH_COPY_DUPLICATE_TAG _(untranslated_x11th_copy_duplicate_tag)
+//#define X12TH_COPY_DUPLICATE_TAG _(untranslated_x12th_copy_duplicate_tag)
+//#define X13TH_COPY_DUPLICATE_TAG _(untranslated_x13th_copy_duplicate_tag)
 
-#define ST_COPY_DUPLICATE_TAG _(untranslated_st_copy_duplicate_tag)
-#define ND_COPY_DUPLICATE_TAG _(untranslated_nd_copy_duplicate_tag)
-#define RD_COPY_DUPLICATE_TAG _(untranslated_rd_copy_duplicate_tag)
-#define TH_COPY_DUPLICATE_TAG _(untranslated_th_copy_duplicate_tag)
+//#define ST_COPY_DUPLICATE_TAG _(untranslated_st_copy_duplicate_tag)
+//#define ND_COPY_DUPLICATE_TAG _(untranslated_nd_copy_duplicate_tag)
+//#define RD_COPY_DUPLICATE_TAG _(untranslated_rd_copy_duplicate_tag)
+//#define TH_COPY_DUPLICATE_TAG _(untranslated_th_copy_duplicate_tag)
 
-/* localizers: appended to first file copy */
-static const char untranslated_first_copy_duplicate_format[] = N_("%s (copy)%s");
-/* localizers: appended to second file copy */
-static const char untranslated_second_copy_duplicate_format[] = N_("%s (another copy)%s");
+///* localizers: appended to first file copy */
+//static const char untranslated_first_copy_duplicate_format[] = N_("%s (copy)%s");
+///* localizers: appended to second file copy */
+//static const char untranslated_second_copy_duplicate_format[] = N_("%s (another copy)%s");
 
-/* localizers: appended to x11th file copy */
-static const char untranslated_x11th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
-/* localizers: appended to x12th file copy */
-static const char untranslated_x12th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
-/* localizers: appended to x13th file copy */
-static const char untranslated_x13th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
+///* localizers: appended to x11th file copy */
+//static const char untranslated_x11th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
+///* localizers: appended to x12th file copy */
+//static const char untranslated_x12th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
+///* localizers: appended to x13th file copy */
+//static const char untranslated_x13th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
 
-/* localizers: if in your language there's no difference between 1st, 2nd, 3rd and nth
- * plurals, you can leave the st, nd, rd suffixes out and just make all the translated
- * strings look like "%s (copy %'d)%s".
- */
+///* localizers: if in your language there's no difference between 1st, 2nd, 3rd and nth
+ //* plurals, you can leave the st, nd, rd suffixes out and just make all the translated
+ //* strings look like "%s (copy %'d)%s".
+ //*/
 
-/* localizers: appended to x1st file copy */
-static const char untranslated_st_copy_duplicate_format[] = N_("%s (%'dst copy)%s");
-/* localizers: appended to x2nd file copy */
-static const char untranslated_nd_copy_duplicate_format[] = N_("%s (%'dnd copy)%s");
-/* localizers: appended to x3rd file copy */
-static const char untranslated_rd_copy_duplicate_format[] = N_("%s (%'drd copy)%s");
-/* localizers: appended to xxth file copy */
-static const char untranslated_th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
+///* localizers: appended to x1st file copy */
+//static const char untranslated_st_copy_duplicate_format[] = N_("%s (%'dst copy)%s");
+///* localizers: appended to x2nd file copy */
+//static const char untranslated_nd_copy_duplicate_format[] = N_("%s (%'dnd copy)%s");
+///* localizers: appended to x3rd file copy */
+//static const char untranslated_rd_copy_duplicate_format[] = N_("%s (%'drd copy)%s");
+///* localizers: appended to xxth file copy */
+//static const char untranslated_th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
 
-#define FIRST_COPY_DUPLICATE_FORMAT _(untranslated_first_copy_duplicate_format)
-#define SECOND_COPY_DUPLICATE_FORMAT _(untranslated_second_copy_duplicate_format)
-#define X11TH_COPY_DUPLICATE_FORMAT _(untranslated_x11th_copy_duplicate_format)
-#define X12TH_COPY_DUPLICATE_FORMAT _(untranslated_x12th_copy_duplicate_format)
-#define X13TH_COPY_DUPLICATE_FORMAT _(untranslated_x13th_copy_duplicate_format)
+//#define FIRST_COPY_DUPLICATE_FORMAT _(untranslated_first_copy_duplicate_format)
+//#define SECOND_COPY_DUPLICATE_FORMAT _(untranslated_second_copy_duplicate_format)
+//#define X11TH_COPY_DUPLICATE_FORMAT _(untranslated_x11th_copy_duplicate_format)
+//#define X12TH_COPY_DUPLICATE_FORMAT _(untranslated_x12th_copy_duplicate_format)
+//#define X13TH_COPY_DUPLICATE_FORMAT _(untranslated_x13th_copy_duplicate_format)
 
-#define ST_COPY_DUPLICATE_FORMAT _(untranslated_st_copy_duplicate_format)
-#define ND_COPY_DUPLICATE_FORMAT _(untranslated_nd_copy_duplicate_format)
-#define RD_COPY_DUPLICATE_FORMAT _(untranslated_rd_copy_duplicate_format)
-#define TH_COPY_DUPLICATE_FORMAT _(untranslated_th_copy_duplicate_format)
+//#define ST_COPY_DUPLICATE_FORMAT _(untranslated_st_copy_duplicate_format)
+//#define ND_COPY_DUPLICATE_FORMAT _(untranslated_nd_copy_duplicate_format)
+//#define RD_COPY_DUPLICATE_FORMAT _(untranslated_rd_copy_duplicate_format)
+//#define TH_COPY_DUPLICATE_FORMAT _(untranslated_th_copy_duplicate_format)
 
 static char *
 extract_string_until (const char *original, const char *until_substring)
@@ -355,223 +355,223 @@ extract_string_until (const char *original, const char *until_substring)
     return result;
 }
 
-/* Dismantle a file name, separating the base name, the file suffix and removing any
- * (xxxcopy), etc. string. Figure out the count that corresponds to the given
- * (xxxcopy) substring.
- */
-static void
-parse_previous_duplicate_name (const char *name,
-                               char **name_base,
-                               const char **suffix,
-                               int *count)
-{
-    const char *tag;
+///* Dismantle a file name, separating the base name, the file suffix and removing any
+ //* (xxxcopy), etc. string. Figure out the count that corresponds to the given
+ //* (xxxcopy) substring.
+ //*/
+//static void
+//parse_previous_duplicate_name (const char *name,
+                               //char **name_base,
+                               //const char **suffix,
+                               //int *count)
+//{
+    //const char *tag;
 
-    g_assert (name[0] != '\0');
+    //g_assert (name[0] != '\0');
 
-    *suffix = strchr (name + 1, '.');
-    if (*suffix == NULL || (*suffix)[1] == '\0') {
-        /* no suffix */
-        *suffix = "";
-    }
+    //*suffix = strchr (name + 1, '.');
+    //if (*suffix == NULL || (*suffix)[1] == '\0') {
+        ///* no suffix */
+        //*suffix = "";
+    //}
 
-    tag = strstr (name, COPY_DUPLICATE_TAG);
-    if (tag != NULL) {
-        if (tag > *suffix) {
-            /* handle case "foo. (copy)" */
-            *suffix = "";
-        }
-        *name_base = extract_string_until (name, tag);
-        *count = 1;
-        return;
-    }
-
-
-    tag = strstr (name, ANOTHER_COPY_DUPLICATE_TAG);
-    if (tag != NULL) {
-        if (tag > *suffix) {
-            /* handle case "foo. (another copy)" */
-            *suffix = "";
-        }
-        *name_base = extract_string_until (name, tag);
-        *count = 2;
-        return;
-    }
+    //tag = strstr (name, COPY_DUPLICATE_TAG);
+    //if (tag != NULL) {
+        //if (tag > *suffix) {
+            ///* handle case "foo. (copy)" */
+            //*suffix = "";
+        //}
+        //*name_base = extract_string_until (name, tag);
+        //*count = 1;
+        //return;
+    //}
 
 
-    /* Check to see if we got one of st, nd, rd, th. */
-    tag = strstr (name, X11TH_COPY_DUPLICATE_TAG);
-
-    if (tag == NULL) {
-        tag = strstr (name, X12TH_COPY_DUPLICATE_TAG);
-    }
-    if (tag == NULL) {
-        tag = strstr (name, X13TH_COPY_DUPLICATE_TAG);
-    }
-
-    if (tag == NULL) {
-        tag = strstr (name, ST_COPY_DUPLICATE_TAG);
-    }
-    if (tag == NULL) {
-        tag = strstr (name, ND_COPY_DUPLICATE_TAG);
-    }
-    if (tag == NULL) {
-        tag = strstr (name, RD_COPY_DUPLICATE_TAG);
-    }
-    if (tag == NULL) {
-        tag = strstr (name, TH_COPY_DUPLICATE_TAG);
-    }
-
-    /* If we got one of st, nd, rd, th, fish out the duplicate number. */
-    if (tag != NULL) {
-        /* localizers: opening parentheses to match the "th copy)" string */
-        tag = strstr (name, _(" ("));
-        if (tag != NULL) {
-            if (tag > *suffix) {
-                /* handle case "foo. (22nd copy)" */
-                *suffix = "";
-            }
-            *name_base = extract_string_until (name, tag);
-            /* localizers: opening parentheses of the "th copy)" string */
-            if (sscanf (tag, _(" (%'d"), count) == 1) {
-                if (*count < 1 || *count > 1000000) {
-                    /* keep the count within a reasonable range */
-                    *count = 0;
-                }
-                return;
-            }
-            *count = 0;
-            return;
-        }
-    }
+    //tag = strstr (name, ANOTHER_COPY_DUPLICATE_TAG);
+    //if (tag != NULL) {
+        //if (tag > *suffix) {
+            ///* handle case "foo. (another copy)" */
+            //*suffix = "";
+        //}
+        //*name_base = extract_string_until (name, tag);
+        //*count = 2;
+        //return;
+    //}
 
 
-    *count = 0;
-    if (**suffix != '\0') {
-        *name_base = extract_string_until (name, *suffix);
-    } else {
-        *name_base = g_strdup (name);
-    }
-}
+    ///* Check to see if we got one of st, nd, rd, th. */
+    //tag = strstr (name, X11TH_COPY_DUPLICATE_TAG);
 
-static char *
-make_next_duplicate_name (const char *base, const char *suffix, int count, int max_length)
-{
-    const char *format;
-    char *result;
-    int unshortened_length;
-    gboolean use_count;
+    //if (tag == NULL) {
+        //tag = strstr (name, X12TH_COPY_DUPLICATE_TAG);
+    //}
+    //if (tag == NULL) {
+        //tag = strstr (name, X13TH_COPY_DUPLICATE_TAG);
+    //}
 
-    if (count < 1) {
-        g_warning ("bad count %d in get_duplicate_name", count);
-        count = 1;
-    }
+    //if (tag == NULL) {
+        //tag = strstr (name, ST_COPY_DUPLICATE_TAG);
+    //}
+    //if (tag == NULL) {
+        //tag = strstr (name, ND_COPY_DUPLICATE_TAG);
+    //}
+    //if (tag == NULL) {
+        //tag = strstr (name, RD_COPY_DUPLICATE_TAG);
+    //}
+    //if (tag == NULL) {
+        //tag = strstr (name, TH_COPY_DUPLICATE_TAG);
+    //}
 
-    if (count <= 2) {
+    ///* If we got one of st, nd, rd, th, fish out the duplicate number. */
+    //if (tag != NULL) {
+        ///* localizers: opening parentheses to match the "th copy)" string */
+        //tag = strstr (name, _(" ("));
+        //if (tag != NULL) {
+            //if (tag > *suffix) {
+                ///* handle case "foo. (22nd copy)" */
+                //*suffix = "";
+            //}
+            //*name_base = extract_string_until (name, tag);
+            ///* localizers: opening parentheses of the "th copy)" string */
+            //if (sscanf (tag, _(" (%'d"), count) == 1) {
+                //if (*count < 1 || *count > 1000000) {
+                    ///* keep the count within a reasonable range */
+                    //*count = 0;
+                //}
+                //return;
+            //}
+            //*count = 0;
+            //return;
+        //}
+    //}
 
-        /* Handle special cases for low numbers.
-         * Perhaps for some locales we will need to add more.
-         */
-        switch (count) {
-        default:
-            g_assert_not_reached ();
-            /* fall through */
-        case 1:
-            format = FIRST_COPY_DUPLICATE_FORMAT;
-            break;
-        case 2:
-            format = SECOND_COPY_DUPLICATE_FORMAT;
-            break;
 
-        }
+    //*count = 0;
+    //if (**suffix != '\0') {
+        //*name_base = extract_string_until (name, *suffix);
+    //} else {
+        //*name_base = g_strdup (name);
+    //}
+//}
 
-        use_count = FALSE;
-    } else {
+//static char *
+//make_next_duplicate_name (const char *base, const char *suffix, int count, int max_length)
+//{
+    //const char *format;
+    //char *result;
+    //int unshortened_length;
+    //gboolean use_count;
 
-        /* Handle special cases for the first few numbers of each ten.
-         * For locales where getting this exactly right is difficult,
-         * these can just be made all the same as the general case below.
-         */
+    //if (count < 1) {
+        //g_warning ("bad count %d in get_duplicate_name", count);
+        //count = 1;
+    //}
 
-        /* Handle special cases for x11th - x20th.
-        */
-        switch (count % 100) {
-        case 11:
-            format = X11TH_COPY_DUPLICATE_FORMAT;
-            break;
-        case 12:
-            format = X12TH_COPY_DUPLICATE_FORMAT;
-            break;
-        case 13:
-            format = X13TH_COPY_DUPLICATE_FORMAT;
-            break;
-        default:
-            format = NULL;
-            break;
-        }
+    //if (count <= 2) {
 
-        if (format == NULL) {
-            switch (count % 10) {
-            case 1:
-                format = ST_COPY_DUPLICATE_FORMAT;
-                break;
-            case 2:
-                format = ND_COPY_DUPLICATE_FORMAT;
-                break;
-            case 3:
-                format = RD_COPY_DUPLICATE_FORMAT;
-                break;
-            default:
-                /* The general case. */
-                format = TH_COPY_DUPLICATE_FORMAT;
-                break;
-            }
-        }
+        ///* Handle special cases for low numbers.
+         //* Perhaps for some locales we will need to add more.
+         //*/
+        //switch (count) {
+        //default:
+            //g_assert_not_reached ();
+            ///* fall through */
+        //case 1:
+            //format = FIRST_COPY_DUPLICATE_FORMAT;
+            //break;
+        //case 2:
+            //format = SECOND_COPY_DUPLICATE_FORMAT;
+            //break;
 
-        use_count = TRUE;
+        //}
 
-    }
+        //use_count = FALSE;
+    //} else {
 
-    if (use_count)
-        result = g_strdup_printf (format, base, count, suffix);
-    else
-        result = g_strdup_printf (format, base, suffix);
+        ///* Handle special cases for the first few numbers of each ten.
+         //* For locales where getting this exactly right is difficult,
+         //* these can just be made all the same as the general case below.
+         //*/
 
-    if (max_length > 0 && (unshortened_length = strlen (result)) > max_length) {
-        char *new_base;
+        ///* Handle special cases for x11th - x20th.
+        //*/
+        //switch (count % 100) {
+        //case 11:
+            //format = X11TH_COPY_DUPLICATE_FORMAT;
+            //break;
+        //case 12:
+            //format = X12TH_COPY_DUPLICATE_FORMAT;
+            //break;
+        //case 13:
+            //format = X13TH_COPY_DUPLICATE_FORMAT;
+            //break;
+        //default:
+            //format = NULL;
+            //break;
+        //}
 
-        new_base = shorten_utf8_string (base, unshortened_length - max_length);
-        if (new_base) {
-            g_free (result);
+        //if (format == NULL) {
+            //switch (count % 10) {
+            //case 1:
+                //format = ST_COPY_DUPLICATE_FORMAT;
+                //break;
+            //case 2:
+                //format = ND_COPY_DUPLICATE_FORMAT;
+                //break;
+            //case 3:
+                //format = RD_COPY_DUPLICATE_FORMAT;
+                //break;
+            //default:
+                ///* The general case. */
+                //format = TH_COPY_DUPLICATE_FORMAT;
+                //break;
+            //}
+        //}
 
-            if (use_count)
-                result = g_strdup_printf (format, new_base, count, suffix);
-            else
-                result = g_strdup_printf (format, new_base, suffix);
+        //use_count = TRUE;
 
-            g_assert (strlen (result) <= max_length);
-            g_free (new_base);
-        }
-    }
+    //}
 
-    return result;
-}
+    //if (use_count)
+        //result = g_strdup_printf (format, base, count, suffix);
+    //else
+        //result = g_strdup_printf (format, base, suffix);
 
-static char *
-get_duplicate_name (const char *name, int count_increment, int max_length)
-{
-    char *result;
-    char *name_base;
-    const char *suffix;
-    int count;
+    //if (max_length > 0 && (unshortened_length = strlen (result)) > max_length) {
+        //char *new_base;
 
-    parse_previous_duplicate_name (name, &name_base, &suffix, &count);
-    result = make_next_duplicate_name (name_base, suffix, count + count_increment, max_length);
+        //new_base = shorten_utf8_string (base, unshortened_length - max_length);
+        //if (new_base) {
+            //g_free (result);
 
-    g_free (name_base);
+            //if (use_count)
+                //result = g_strdup_printf (format, new_base, count, suffix);
+            //else
+                //result = g_strdup_printf (format, new_base, suffix);
 
-    return result;
-}
+            //g_assert (strlen (result) <= max_length);
+            //g_free (new_base);
+        //}
+    //}
+
+    //return result;
+//}
+
+//static char *
+//get_duplicate_name (const char *name, int count_increment, int max_length)
+//{
+    //char *result;
+    //char *name_base;
+    //const char *suffix;
+    //int count;
+
+    //parse_previous_duplicate_name (name, &name_base, &suffix, &count);
+    //result = make_next_duplicate_name (name_base, suffix, count + count_increment, max_length);
+
+    //g_free (name_base);
+
+    //return result;
+//}
 
 static gboolean
 has_invalid_xml_char (char *str)
@@ -5120,13 +5120,12 @@ create_job (GIOSchedulerJob *io_job,
     char *dest_fs_type;
     GError *error;
     gboolean res;
-    gboolean filename_is_utf8;
+    //gboolean filename_is_utf8;
     char *primary, *secondary, *details;
     int response;
     char *data;
     int length;
     GFileOutputStream *out;
-    gboolean handled_invalid_filename;
     int max_length;
 
     job = user_data;
@@ -5134,8 +5133,6 @@ create_job (GIOSchedulerJob *io_job,
     common->io_job = io_job;
 
     pf_progress_info_start (job->common.progress);
-
-    handled_invalid_filename = FALSE;
 
     dest_fs_type = NULL;
     filename = NULL;
@@ -5146,20 +5143,16 @@ create_job (GIOSchedulerJob *io_job,
     verify_destination (common,
                         job->dest_dir,
                         NULL, -1);
+
     if (job_aborted (common)) {
         goto aborted;
     }
 
     filename = g_strdup (job->filename);
-    filename_is_utf8 = FALSE;
-    if (filename) {
-        filename_is_utf8 = g_utf8_validate (filename, -1, NULL);
-    }
     if (filename == NULL) {
         if (job->make_dir) {
             /* localizers: the initial name of a new folder  */
             filename = g_strdup (_("untitled folder"));
-            filename_is_utf8 = TRUE; /* Pass in utf8 */
         } else {
             if (job->src != NULL) {
                 filename = g_file_get_basename (job->src);
@@ -5167,21 +5160,12 @@ create_job (GIOSchedulerJob *io_job,
             if (filename == NULL) {
                 /* localizers: the initial name of a new empty file */
                 filename = g_strdup (_("new file"));
-                filename_is_utf8 = TRUE; /* Pass in utf8 */
             }
         }
     }
 
-    pf_file_utils_make_file_name_valid_for_dest_fs (&filename, dest_fs_type); //FIXME No point - dest_fs_type always null?
-    if (filename_is_utf8) {
-        dest = g_file_get_child_for_display_name (job->dest_dir, filename, NULL);
-    }
-    if (dest == NULL) {
-        dest = g_file_get_child (job->dest_dir, filename);
-    }
-    count = 1;
-
-retry:
+    GFile *src = job->src ? job->src : g_file_new_for_path (filename);
+    dest = pf_file_utils_make_next_link_copy_target_file (src, job->dest_dir, dest_fs_type, FALSE, TRUE, FALSE);
 
     error = NULL;
     if (job->make_dir) {
@@ -5253,83 +5237,9 @@ retry:
        marlin_file_changes_queue_file_added (dest);
     } else {
         g_assert (error != NULL);
-
-        if (IS_IO_ERROR (error, INVALID_FILENAME) &&
-            !handled_invalid_filename) {
-            handled_invalid_filename = TRUE;
-
-            g_assert (dest_fs_type == NULL);
-            dest_fs_type = query_fs_type (job->dest_dir, common->cancellable);
-
-            g_object_unref (dest);
-
-            if (count == 1) {
-                new_filename = g_strdup (filename);
-            } else if (job->make_dir) {
-                filename2 = g_strdup_printf ("%s %d", filename, count);
-
-                new_filename = NULL;
-                if (max_length > 0 && strlen (filename2) > max_length) {
-                    new_filename = shorten_utf8_string (filename2, strlen (filename2) - max_length);
-                }
-
-                if (new_filename == NULL) {
-                    new_filename = g_strdup (filename2);
-                }
-
-                g_free (filename2);
-            } else {
-                new_filename = get_duplicate_name (filename, count, max_length);
-            }
-
-            if (pf_file_utils_make_file_name_valid_for_dest_fs (&new_filename, dest_fs_type)) {
-                g_object_unref (dest);
-
-                if (filename_is_utf8) {
-                    dest = g_file_get_child_for_display_name (job->dest_dir, new_filename, NULL);
-                }
-                if (dest == NULL) {
-                    dest = g_file_get_child (job->dest_dir, new_filename);
-                }
-
-                g_free (new_filename);
-                g_error_free (error);
-                goto retry;
-            }
-            g_free (new_filename);
-        } else if (IS_IO_ERROR (error, EXISTS)) {
-            g_object_unref (dest);
-            dest = NULL;
-            if (job->make_dir) {
-                filename2 = g_strdup_printf ("%s %d", filename, ++count);
-                if (max_length > 0 && strlen (filename2) > max_length) {
-                    new_filename = shorten_utf8_string (filename2, strlen (filename2) - max_length);
-                    if (new_filename != NULL) {
-                        g_free (filename2);
-                        filename2 = new_filename;
-                    }
-                }
-            } else {
-                filename2 = get_duplicate_name (filename, count++, max_length);
-            }
-            pf_file_utils_make_file_name_valid_for_dest_fs (&filename2, dest_fs_type);
-            if (filename_is_utf8) {
-                dest = g_file_get_child_for_display_name (job->dest_dir, filename2, NULL);
-            }
-            if (dest == NULL) {
-                dest = g_file_get_child (job->dest_dir, filename2);
-            }
-            g_free (filename2);
+        if (IS_IO_ERROR (error, CANCELLED)) {
             g_error_free (error);
-            goto retry;
-        }
-
-        else if (IS_IO_ERROR (error, CANCELLED)) {
-            g_error_free (error);
-        }
-
-        /* Other error */
-        else {
+        } else {/* Other error */
             gchar *dest_basename = custom_basename_from_file (dest);
             if (job->make_dir) {
                 /// TRANSLATORS: %s is a placeholder for the basename of a file.  It may change position but must not be translated or removed

--- a/libcore/marlin-file-operations.c
+++ b/libcore/marlin-file-operations.c
@@ -168,178 +168,6 @@ shorten_utf8_string (const char *base, int reduce_by_num_bytes)
     }
 }
 
-///* Note that we have these two separate functions with separate format
- //* strings for ease of localization.
- //*/
-
-//static char *
-//get_link_name (const char *name, int count, int max_length)
-//{
-    //const char *format;
-    //char *result;
-    //int unshortened_length;
-    //gboolean use_count;
-
-    //g_assert (name != NULL);
-
-    //if (count < 0) {
-        //g_warning ("bad count in get_link_name");
-        //count = 0;
-    //}
-
-    //if (count <= 2) {
-        ///* Handle special cases for low numbers.
-         //* Perhaps for some locales we will need to add more.
-         //*/
-        //switch (count) {
-        //default:
-            //g_assert_not_reached ();
-            ///* fall through */
-        //case 0:
-            ///* duplicate original file name */
-            //format = "%s";
-            //break;
-        //case 1:
-            ///* appended to new link file */
-            //format = _("Link to %s");
-            //break;
-        //case 2:
-            ///* appended to new link file */
-            //format = _("Another link to %s");
-            //break;
-        //}
-
-        //use_count = FALSE;
-    //} else {
-        ///* Handle special cases for the first few numbers of each ten.
-         //* For locales where getting this exactly right is difficult,
-         //* these can just be made all the same as the general case below.
-         //*/
-        //switch (count % 10) {
-        //case 1:
-            ///* Localizers: Feel free to leave out the "st" suffix
-             //* if there's no way to do that nicely for a
-             //* particular language.
-             //*/
-            //format = _("%'dst link to %s");
-            //break;
-        //case 2:
-            ///* appended to new link file */
-            //format = _("%'dnd link to %s");
-            //break;
-        //case 3:
-            ///* appended to new link file */
-            //format = _("%'drd link to %s");
-            //break;
-        //default:
-            ///* appended to new link file */
-            //format = _("%'dth link to %s");
-            //break;
-        //}
-
-        //use_count = TRUE;
-    //}
-
-    //if (use_count)
-        //result = g_strdup_printf (format, count, name);
-    //else
-        //result = g_strdup_printf (format, name);
-
-    //if (max_length > 0 && (unshortened_length = strlen (result)) > max_length) {
-        //char *new_name;
-
-        //new_name = shorten_utf8_string (name, unshortened_length - max_length);
-        //if (new_name) {
-            //g_free (result);
-
-            //if (use_count)
-                //result = g_strdup_printf (format, count, new_name);
-            //else
-                //result = g_strdup_printf (format, new_name);
-
-            //g_assert (strlen (result) <= max_length);
-            //g_free (new_name);
-        //}
-    //}
-
-    //return result;
-//}
-
-///* Localizers:
- //* Feel free to leave out the st, nd, rd and th suffix or
- //* make some or all of them match.
- //*/
-
-///* localizers: tag used to detect the first copy of a file */
-//static const char untranslated_copy_duplicate_tag[] = N_(" (copy)");
-///* localizers: tag used to detect the second copy of a file */
-//static const char untranslated_another_copy_duplicate_tag[] = N_(" (another copy)");
-
-///* localizers: tag used to detect the x11th copy of a file */
-//static const char untranslated_x11th_copy_duplicate_tag[] = N_("th copy)");
-///* localizers: tag used to detect the x12th copy of a file */
-//static const char untranslated_x12th_copy_duplicate_tag[] = N_("th copy)");
-///* localizers: tag used to detect the x13th copy of a file */
-//static const char untranslated_x13th_copy_duplicate_tag[] = N_("th copy)");
-
-///* localizers: tag used to detect the x1st copy of a file */
-//static const char untranslated_st_copy_duplicate_tag[] = N_("st copy)");
-///* localizers: tag used to detect the x2nd copy of a file */
-//static const char untranslated_nd_copy_duplicate_tag[] = N_("nd copy)");
-///* localizers: tag used to detect the x3rd copy of a file */
-//static const char untranslated_rd_copy_duplicate_tag[] = N_("rd copy)");
-
-///* localizers: tag used to detect the xxth copy of a file */
-//static const char untranslated_th_copy_duplicate_tag[] = N_("th copy)");
-
-//#define COPY_DUPLICATE_TAG _(untranslated_copy_duplicate_tag)
-//#define ANOTHER_COPY_DUPLICATE_TAG _(untranslated_another_copy_duplicate_tag)
-//#define X11TH_COPY_DUPLICATE_TAG _(untranslated_x11th_copy_duplicate_tag)
-//#define X12TH_COPY_DUPLICATE_TAG _(untranslated_x12th_copy_duplicate_tag)
-//#define X13TH_COPY_DUPLICATE_TAG _(untranslated_x13th_copy_duplicate_tag)
-
-//#define ST_COPY_DUPLICATE_TAG _(untranslated_st_copy_duplicate_tag)
-//#define ND_COPY_DUPLICATE_TAG _(untranslated_nd_copy_duplicate_tag)
-//#define RD_COPY_DUPLICATE_TAG _(untranslated_rd_copy_duplicate_tag)
-//#define TH_COPY_DUPLICATE_TAG _(untranslated_th_copy_duplicate_tag)
-
-///* localizers: appended to first file copy */
-//static const char untranslated_first_copy_duplicate_format[] = N_("%s (copy)%s");
-///* localizers: appended to second file copy */
-//static const char untranslated_second_copy_duplicate_format[] = N_("%s (another copy)%s");
-
-///* localizers: appended to x11th file copy */
-//static const char untranslated_x11th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
-///* localizers: appended to x12th file copy */
-//static const char untranslated_x12th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
-///* localizers: appended to x13th file copy */
-//static const char untranslated_x13th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
-
-///* localizers: if in your language there's no difference between 1st, 2nd, 3rd and nth
- //* plurals, you can leave the st, nd, rd suffixes out and just make all the translated
- //* strings look like "%s (copy %'d)%s".
- //*/
-
-///* localizers: appended to x1st file copy */
-//static const char untranslated_st_copy_duplicate_format[] = N_("%s (%'dst copy)%s");
-///* localizers: appended to x2nd file copy */
-//static const char untranslated_nd_copy_duplicate_format[] = N_("%s (%'dnd copy)%s");
-///* localizers: appended to x3rd file copy */
-//static const char untranslated_rd_copy_duplicate_format[] = N_("%s (%'drd copy)%s");
-///* localizers: appended to xxth file copy */
-//static const char untranslated_th_copy_duplicate_format[] = N_("%s (%'dth copy)%s");
-
-//#define FIRST_COPY_DUPLICATE_FORMAT _(untranslated_first_copy_duplicate_format)
-//#define SECOND_COPY_DUPLICATE_FORMAT _(untranslated_second_copy_duplicate_format)
-//#define X11TH_COPY_DUPLICATE_FORMAT _(untranslated_x11th_copy_duplicate_format)
-//#define X12TH_COPY_DUPLICATE_FORMAT _(untranslated_x12th_copy_duplicate_format)
-//#define X13TH_COPY_DUPLICATE_FORMAT _(untranslated_x13th_copy_duplicate_format)
-
-//#define ST_COPY_DUPLICATE_FORMAT _(untranslated_st_copy_duplicate_format)
-//#define ND_COPY_DUPLICATE_FORMAT _(untranslated_nd_copy_duplicate_format)
-//#define RD_COPY_DUPLICATE_FORMAT _(untranslated_rd_copy_duplicate_format)
-//#define TH_COPY_DUPLICATE_FORMAT _(untranslated_th_copy_duplicate_format)
-
 static char *
 extract_string_until (const char *original, const char *until_substring)
 {
@@ -354,224 +182,6 @@ extract_string_until (const char *original, const char *until_substring)
 
     return result;
 }
-
-///* Dismantle a file name, separating the base name, the file suffix and removing any
- //* (xxxcopy), etc. string. Figure out the count that corresponds to the given
- //* (xxxcopy) substring.
- //*/
-//static void
-//parse_previous_duplicate_name (const char *name,
-                               //char **name_base,
-                               //const char **suffix,
-                               //int *count)
-//{
-    //const char *tag;
-
-    //g_assert (name[0] != '\0');
-
-    //*suffix = strchr (name + 1, '.');
-    //if (*suffix == NULL || (*suffix)[1] == '\0') {
-        ///* no suffix */
-        //*suffix = "";
-    //}
-
-    //tag = strstr (name, COPY_DUPLICATE_TAG);
-    //if (tag != NULL) {
-        //if (tag > *suffix) {
-            ///* handle case "foo. (copy)" */
-            //*suffix = "";
-        //}
-        //*name_base = extract_string_until (name, tag);
-        //*count = 1;
-        //return;
-    //}
-
-
-    //tag = strstr (name, ANOTHER_COPY_DUPLICATE_TAG);
-    //if (tag != NULL) {
-        //if (tag > *suffix) {
-            ///* handle case "foo. (another copy)" */
-            //*suffix = "";
-        //}
-        //*name_base = extract_string_until (name, tag);
-        //*count = 2;
-        //return;
-    //}
-
-
-    ///* Check to see if we got one of st, nd, rd, th. */
-    //tag = strstr (name, X11TH_COPY_DUPLICATE_TAG);
-
-    //if (tag == NULL) {
-        //tag = strstr (name, X12TH_COPY_DUPLICATE_TAG);
-    //}
-    //if (tag == NULL) {
-        //tag = strstr (name, X13TH_COPY_DUPLICATE_TAG);
-    //}
-
-    //if (tag == NULL) {
-        //tag = strstr (name, ST_COPY_DUPLICATE_TAG);
-    //}
-    //if (tag == NULL) {
-        //tag = strstr (name, ND_COPY_DUPLICATE_TAG);
-    //}
-    //if (tag == NULL) {
-        //tag = strstr (name, RD_COPY_DUPLICATE_TAG);
-    //}
-    //if (tag == NULL) {
-        //tag = strstr (name, TH_COPY_DUPLICATE_TAG);
-    //}
-
-    ///* If we got one of st, nd, rd, th, fish out the duplicate number. */
-    //if (tag != NULL) {
-        ///* localizers: opening parentheses to match the "th copy)" string */
-        //tag = strstr (name, _(" ("));
-        //if (tag != NULL) {
-            //if (tag > *suffix) {
-                ///* handle case "foo. (22nd copy)" */
-                //*suffix = "";
-            //}
-            //*name_base = extract_string_until (name, tag);
-            ///* localizers: opening parentheses of the "th copy)" string */
-            //if (sscanf (tag, _(" (%'d"), count) == 1) {
-                //if (*count < 1 || *count > 1000000) {
-                    ///* keep the count within a reasonable range */
-                    //*count = 0;
-                //}
-                //return;
-            //}
-            //*count = 0;
-            //return;
-        //}
-    //}
-
-
-    //*count = 0;
-    //if (**suffix != '\0') {
-        //*name_base = extract_string_until (name, *suffix);
-    //} else {
-        //*name_base = g_strdup (name);
-    //}
-//}
-
-//static char *
-//make_next_duplicate_name (const char *base, const char *suffix, int count, int max_length)
-//{
-    //const char *format;
-    //char *result;
-    //int unshortened_length;
-    //gboolean use_count;
-
-    //if (count < 1) {
-        //g_warning ("bad count %d in get_duplicate_name", count);
-        //count = 1;
-    //}
-
-    //if (count <= 2) {
-
-        ///* Handle special cases for low numbers.
-         //* Perhaps for some locales we will need to add more.
-         //*/
-        //switch (count) {
-        //default:
-            //g_assert_not_reached ();
-            ///* fall through */
-        //case 1:
-            //format = FIRST_COPY_DUPLICATE_FORMAT;
-            //break;
-        //case 2:
-            //format = SECOND_COPY_DUPLICATE_FORMAT;
-            //break;
-
-        //}
-
-        //use_count = FALSE;
-    //} else {
-
-        ///* Handle special cases for the first few numbers of each ten.
-         //* For locales where getting this exactly right is difficult,
-         //* these can just be made all the same as the general case below.
-         //*/
-
-        ///* Handle special cases for x11th - x20th.
-        //*/
-        //switch (count % 100) {
-        //case 11:
-            //format = X11TH_COPY_DUPLICATE_FORMAT;
-            //break;
-        //case 12:
-            //format = X12TH_COPY_DUPLICATE_FORMAT;
-            //break;
-        //case 13:
-            //format = X13TH_COPY_DUPLICATE_FORMAT;
-            //break;
-        //default:
-            //format = NULL;
-            //break;
-        //}
-
-        //if (format == NULL) {
-            //switch (count % 10) {
-            //case 1:
-                //format = ST_COPY_DUPLICATE_FORMAT;
-                //break;
-            //case 2:
-                //format = ND_COPY_DUPLICATE_FORMAT;
-                //break;
-            //case 3:
-                //format = RD_COPY_DUPLICATE_FORMAT;
-                //break;
-            //default:
-                ///* The general case. */
-                //format = TH_COPY_DUPLICATE_FORMAT;
-                //break;
-            //}
-        //}
-
-        //use_count = TRUE;
-
-    //}
-
-    //if (use_count)
-        //result = g_strdup_printf (format, base, count, suffix);
-    //else
-        //result = g_strdup_printf (format, base, suffix);
-
-    //if (max_length > 0 && (unshortened_length = strlen (result)) > max_length) {
-        //char *new_base;
-
-        //new_base = shorten_utf8_string (base, unshortened_length - max_length);
-        //if (new_base) {
-            //g_free (result);
-
-            //if (use_count)
-                //result = g_strdup_printf (format, new_base, count, suffix);
-            //else
-                //result = g_strdup_printf (format, new_base, suffix);
-
-            //g_assert (strlen (result) <= max_length);
-            //g_free (new_base);
-        //}
-    //}
-
-    //return result;
-//}
-
-//static char *
-//get_duplicate_name (const char *name, int count_increment, int max_length)
-//{
-    //char *result;
-    //char *name_base;
-    //const char *suffix;
-    //int count;
-
-    //parse_previous_duplicate_name (name, &name_base, &suffix, &count);
-    //result = make_next_duplicate_name (name_base, suffix, count + count_increment, max_length);
-
-    //g_free (name_base);
-
-    //return result;
-//}
 
 static gboolean
 has_invalid_xml_char (char *str)
@@ -3252,12 +2862,13 @@ copy_move_file (CopyMoveJob *copy_job,
         return;
     }
 
-    /* another file in the same directory might have handled the invalid
-     * filename condition for us
-     */
-    handled_invalid_filename = *dest_fs_type != NULL;
+    ///* another file in the same directory might have handled the invalid
+     //* filename condition for us
+     //*/
+    //handled_invalid_filename = *dest_fs_type != NULL;
 
-    dest = pf_file_utils_make_next_link_copy_target_file (src, dest_dir, *dest_fs_type, FALSE, same_fs, !unique_names);
+    /* We allow filename conflict here as it is handled later on */
+    dest = pf_file_utils_make_next_link_copy_target_file (src, dest_dir, *dest_fs_type, FALSE, same_fs, TRUE);
 
     if (dest == NULL) {
         *skipped_file = TRUE; /* Or aborted, but same-same */
@@ -3373,14 +2984,9 @@ retry:
         report_copy_progress (copy_job, source_info, transfer_info);
 
         if (debuting_files) {
-            /*if (position) {
-                //marlin_file_changes_queue_schedule_position_set (dest, *position, job->screen_num);
-            } else {
-                //marlin_file_changes_queue_schedule_position_remove (dest);
-            }*/
-
             g_hash_table_replace (debuting_files, g_object_ref (dest), GINT_TO_POINTER (TRUE));
         }
+
         if (copy_job->is_move) {
             marlin_file_changes_queue_file_moved (src, dest);
         } else {
@@ -3395,27 +3001,10 @@ retry:
         return;
     }
 
-    if (!handled_invalid_filename &&
-        IS_IO_ERROR (error, INVALID_FILENAME)) {
-        handled_invalid_filename = TRUE;
-
-        g_assert (*dest_fs_type == NULL);
-        *dest_fs_type = query_fs_type (dest_dir, job->cancellable);
-
-        new_dest = pf_file_utils_make_next_link_copy_target_file (src, dest_dir, *dest_fs_type, FALSE, same_fs, !unique_names);
-
-        if (!g_file_equal (dest, new_dest)) {
-            g_object_unref (dest);
-            dest = new_dest;
-
-            g_error_free (error);
-            goto retry;
-        } else {
-            g_object_unref (new_dest);
-        }
-    }
+    /* filename should already be guaranteed valid
 
     /* Conflict */
+    /* Handle conflict based on response to conflict dialog */
     if (!overwrite &&
         IS_IO_ERROR (error, EXISTS)) {
         gboolean is_merge;
@@ -3988,12 +3577,6 @@ retry:
 
         marlin_file_changes_queue_file_moved (src, dest);
 
-        /*if (position) {
-            //marlin_file_changes_queue_schedule_position_set (dest, *position, job->screen_num);
-        } else {
-            marlin_file_changes_queue_schedule_position_remove (dest);
-        }*/
-
         // Start UNDO-REDO
         marlin_undo_action_data_add_origin_target_pair (job->undo_redo_data, src, dest);
         // End UNDO-REDO
@@ -4001,22 +3584,7 @@ retry:
         return;
     }
 
-    if (IS_IO_ERROR (error, INVALID_FILENAME) &&
-        !handled_invalid_filename) { // Should not happen - target file name should be guaranteed valid
-        handled_invalid_filename = TRUE;
-
-        g_assert (*dest_fs_type == NULL);
-        *dest_fs_type = query_fs_type (dest_dir, job->cancellable);
-
-        dest = pf_file_utils_make_next_link_copy_target_file (src, dest_dir, *dest_fs_type, FALSE, same_fs, overwrite);
-        if (!g_file_equal (dest, new_dest)) {
-            g_object_unref (dest);
-            dest = new_dest;
-            goto retry;
-        } else {
-            g_object_unref (new_dest);
-        }
-    }
+    /* Filename should already be guaranteed valid */
 
     /* Conflict */
     else if (!overwrite &&
@@ -4431,15 +3999,15 @@ link_file (CopyMoveJob *job,
     CommonJob *common;
     char *primary, *secondary, *details;
     int response;
-    gboolean handled_invalid_filename;
+    //gboolean handled_invalid_filename;
 
     common = (CommonJob *)job;
 
-    handled_invalid_filename = *dest_fs_type != NULL; //Assume not same_fs if this is TRUE
+    //handled_invalid_filename = *dest_fs_type != NULL; //Assume not same_fs if this is TRUE
 
-    //`same_fs` not passed a parameter to `link_file ()` so use `!handled_invalid_filename` as a proxy
+    //`same_fs` not passed as a parameter to `link_file ()` so use FALSE for safety
     dest = pf_file_utils_make_next_link_copy_target_file (
-        src, dest_dir, *dest_fs_type, !handled_invalid_filename, TRUE, FALSE
+        src, dest_dir, *dest_fs_type, FALSE, TRUE, FALSE
     );
 
 retry:
@@ -4477,33 +4045,10 @@ retry:
     }
     g_free (path);
 
-    if (error != NULL &&
-        IS_IO_ERROR (error, INVALID_FILENAME) &&
-        !handled_invalid_filename) {
-        handled_invalid_filename = TRUE;
-
-        g_assert (*dest_fs_type == NULL);
-        *dest_fs_type = query_fs_type (dest_dir, common->cancellable);
-
-        new_dest = pf_file_utils_make_next_link_copy_target_file (
-            src, dest_dir, *dest_fs_type, !handled_invalid_filename, TRUE, FALSE
-        );
-
-        if (!g_file_equal (dest, new_dest)) {
-            g_object_unref (dest);
-            dest = new_dest;
-            g_error_free (error);
-
-            goto retry;
-        } else {
-            g_object_unref (new_dest);
-        }
-    } else if (error != NULL && IS_IO_ERROR (error, CANCELLED)) {
+    /* Filename should already be guaranteed valid */
+    if (error != NULL && IS_IO_ERROR (error, CANCELLED)) {
         g_error_free (error);
-    }
-
-    /* Other error */
-    else {
+    } else {/* Other error */
         gchar *src_basename;
         if (common->skip_all_error) {
             goto out;

--- a/libcore/marlin-file-operations.c
+++ b/libcore/marlin-file-operations.c
@@ -3455,7 +3455,6 @@ copy_move_file (CopyMoveJob *copy_job,
     gboolean would_recurse, is_merge;
     CommonJob *job;
     gboolean res;
-    int unique_name_nr;
     gboolean handled_invalid_filename;
 
     job = (CommonJob *)copy_job;
@@ -3465,19 +3464,12 @@ copy_move_file (CopyMoveJob *copy_job,
         return;
     }
 
-    unique_name_nr = 1;
-
     /* another file in the same directory might have handled the invalid
      * filename condition for us
      */
     handled_invalid_filename = *dest_fs_type != NULL;
 
-    //amtest
-    if (unique_names) {
-        dest = get_unique_target_file (src, dest_dir, same_fs, *dest_fs_type, unique_name_nr++);
-    } else {
-        dest = get_target_file (src, dest_dir, *dest_fs_type, same_fs);
-    }
+    dest = pf_file_utils_make_next_link_copy_target_file (src, dest_dir, *dest_fs_type, FALSE, same_fs, !unique_names);
 
     if (dest == NULL) {
         *skipped_file = TRUE; /* Or aborted, but same-same */
@@ -3622,11 +3614,7 @@ retry:
         g_assert (*dest_fs_type == NULL);
         *dest_fs_type = query_fs_type (dest_dir, job->cancellable);
 
-        if (unique_names) {
-            new_dest = get_unique_target_file (src, dest_dir, same_fs, *dest_fs_type, unique_name_nr);
-        } else {
-            new_dest = get_target_file (src, dest_dir, *dest_fs_type, same_fs);
-        }
+        new_dest = pf_file_utils_make_next_link_copy_target_file (src, dest_dir, *dest_fs_type, FALSE, same_fs, !unique_names);
 
         if (!g_file_equal (dest, new_dest)) {
             g_object_unref (dest);
@@ -3649,7 +3637,8 @@ retry:
 
         if (unique_names) {
             g_object_unref (dest);
-            dest = get_unique_target_file (src, dest_dir, same_fs, *dest_fs_type, unique_name_nr++);
+            dest = pf_file_utils_make_next_link_copy_target_file (src, dest_dir, *dest_fs_type, FALSE, same_fs, FALSE);
+
             goto retry;
         }
 

--- a/libcore/tests/UtilTests/UtilTests.vala
+++ b/libcore/tests/UtilTests/UtilTests.vala
@@ -108,26 +108,30 @@ void add_file_utils_tests () {
 
     Test.add_func ("/FileUtils/make_filename_valid_null", () => {
         string filename = "Valid:;*?\\<> name";
+        string original = filename.dup ();
         string? dest_fs = null;
-        bool changed = PF.FileUtils.make_file_name_valid_for_dest_fs (ref filename, dest_fs);
-        assert (changed == false);
-        assert (filename == "Valid:;*?\\<> name");
+        bool valid = PF.FileUtils.make_file_name_valid_for_dest_fs (ref filename, dest_fs);
+        assert (valid == true);
+        assert (filename == original);
     });
 
     /* Make filename valid for destination fs */
     Test.add_func ("/FileUtils/make_filename_valid_ext", () => {
         string filename = "Valid:;*?\\<> name";
+        string original = filename.dup ();
         string dest_fs = "ext3/ext4";
-        bool changed = PF.FileUtils.make_file_name_valid_for_dest_fs (ref filename, dest_fs);
-        assert (changed == false);
-        assert (filename == "Valid:;*?\\<> name");
+        bool valid = PF.FileUtils.make_file_name_valid_for_dest_fs (ref filename, dest_fs);
+        assert (valid == true);
+        assert (filename == original);
     });
 
     Test.add_func ("/FileUtils/make_filename_valid_msdos", () => {
         string filename = "Invalid:;*?\\<> name"; // 8 invalid characters
+        string original = filename.dup ();
         string dest_fs = "msdos";
-        bool changed = PF.FileUtils.make_file_name_valid_for_dest_fs (ref filename, dest_fs);
-        assert (changed == true);
+        bool valid = PF.FileUtils.make_file_name_valid_for_dest_fs (ref filename, dest_fs);
+        assert (valid == true);
+        assert (filename != original);
         assert (filename == "Invalid________name");
     });
 


### PR DESCRIPTION
This combines and simplifies the code relating to getting target files when copying, linking and creating files and ports it to Vala.

Because of the intricacy of the original code, it is hard to ensure all corner cases are dealt with but it seems to work well enough in normal situations and when moving files to filesystems where the names are invalid.

As discussed, the naming of duplicates has been simplified and rationalised so that both copy and link duplicates have the same form  - "(copy xx)" or "(link xx)".

I am aware the way the duplicate format strings are constructed might be questionable but this was required to ensure that they could be parsed in any locale to be identified and to extract the digit part reliably.  Alternative suggestions welcome.

Some attempt was made to improve the efficiency of file operations by only determining the maximum name length for the destination file system once per operation instead of for each file.  The assumption is made that the source and destination filesystems do not change during an operation.

Also the opportunity was taken to remove all reference to "debuting files" which have not been used for years and add an overhead.