### PR TITLE
Ensure destruction of progress info and release of application.

### DIFF
--- a/libcore/ProgressInfo.vala
+++ b/libcore/ProgressInfo.vala
@@ -63,7 +63,6 @@ public class PF.Progress.Info : GLib.Object {
     }
 
     ~Info () {
-        warning ("destruct info - release application");
         /* As the hold was placed on construction, we release it here to ensure matching count */
         /* Must ensure all references are released so Info is destroyed */
         Application.get_default ().release ();

--- a/libcore/ProgressInfo.vala
+++ b/libcore/ProgressInfo.vala
@@ -58,7 +58,6 @@ public class PF.Progress.Info : GLib.Object {
          * Using cancellable.connect () results in refcounting problem as it cannot be disconnected in its handler */
         cancellable.cancelled.connect (finish);
         PF.Progress.InfoManager.get_instance ().add_new_info (this);
-        warning ("construct info - hold application");
         Application.get_default ().hold ();
     }
 

--- a/libcore/ProgressInfo.vala
+++ b/libcore/ProgressInfo.vala
@@ -174,7 +174,6 @@ public class PF.Progress.Info : GLib.Object {
          * Similar to what gdk_threads_add_idle does.
          */
         if (source.is_destroyed ()) {
-            critical ("Source destroyed on another thread");
             return GLib.Source.REMOVE;
         }
 

--- a/libcore/ProgressInfoManager.vala
+++ b/libcore/ProgressInfoManager.vala
@@ -16,6 +16,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+/* Maintains a list of active infos and signals when a new one added */
+/* Used by the ProgressUIHandler to update the progress window and launcher */
 public class PF.Progress.InfoManager : GLib.Object {
     public signal void new_progress_info (PF.Progress.Info info);
 
@@ -41,16 +43,14 @@ public class PF.Progress.InfoManager : GLib.Object {
         }
 
         progress_infos.add (info);
-        info.finished.connect_after (on_info_finished);
         new_progress_info (info);
     }
 
-    private void on_info_finished (Info info) {
-        info.finished.disconnect (on_info_finished);
+    public void remove_finished_info (PF.Progress.Info info) {
         progress_infos.remove (info);
     }
 
-    public Gee.LinkedList<PF.Progress.Info> get_all_infos () {
+    public unowned Gee.LinkedList<PF.Progress.Info> get_all_infos () {
         return progress_infos;
     }
 }

--- a/src/ProgressUIHandler.vala
+++ b/src/ProgressUIHandler.vala
@@ -35,7 +35,6 @@ public class Marlin.Progress.UIHandler : Object {
     construct {
         application = (Gtk.Application) GLib.Application.get_default ();
         manager = PF.Progress.InfoManager.get_instance ();
-
         manager.new_progress_info.connect ((info) => {
             info.started.connect (progress_info_started_cb);
         });
@@ -53,14 +52,16 @@ public class Marlin.Progress.UIHandler : Object {
     }
 
     private void progress_info_started_cb (PF.Progress.Info info) {
-        application.hold ();
-
-        if (info == null || !(info is PF.Progress.Info) ||
-            info.is_finished || info.is_cancelled) {
-
-            application.release ();
+        if (info == null) {
+            critical ("Null progressinfo started");
             return;
         }
+
+        info.started.disconnect (progress_info_started_cb);
+        if (info.is_finished || info.is_cancelled) {
+            return;
+        }
+
 
         info.finished.connect (progress_info_finished_cb);
         this.active_infos++;
@@ -143,7 +144,6 @@ public class Marlin.Progress.UIHandler : Object {
     private void progress_info_finished_cb (PF.Progress.Info info) {
         /* Must only be called once for each info */
         info.finished.disconnect (progress_info_finished_cb);
-        application.release ();
 
         if (active_infos > 0) {
             this.active_infos--;

--- a/src/View/Widgets/ProgressInfoWidget.vala
+++ b/src/View/Widgets/ProgressInfoWidget.vala
@@ -22,7 +22,7 @@
 */
 
 public class Marlin.Progress.InfoWidget : Gtk.Grid {
-    public PF.Progress.Info info { get; construct; }
+    public unowned PF.Progress.Info info { get; construct; }
 
     private Gtk.Label details;
     private Gtk.ProgressBar progress_bar;


### PR DESCRIPTION
Fixes #1153 

Each file operation places a hold on the application so it is essential that each hold is matched by a release when the operation ends or is cancelled.

This is done by:
 - Creating the hold in the ProgressInfo constructor
- Releaseing the hold when the ProgressInfo is destroyed.
- Ensuring all references on the info are released when the info is finished with so that it destructs properly.

In master, the info was being kept alive by an internal signal connect that was never disconnected. 