### PR TITLE
Stop hyphenation in TextRenderer

### DIFF
--- a/src/TextRenderer.vala
+++ b/src/TextRenderer.vala
@@ -262,6 +262,12 @@ namespace Marlin {
                 connect_widget_signals ();
                 context = widget.get_pango_context ();
                 layout = new Pango.Layout (context);
+
+                /* We do not want hyphens inserted when text wraps */
+                var attr = new Pango.AttrList ();
+                attr.insert (Pango.attr_insert_hyphens_new (false));
+                layout.set_attributes (attr);
+
                 layout.set_auto_dir (false);
                 layout.set_single_paragraph_mode (true);
                 metrics = context.get_metrics (layout.get_font_description (), context.get_language ());


### PR DESCRIPTION
Partially fixes #1348 

The file names are no longer hyphenated in Icon View but when renaming, the TextView widget used continues to insert hyphens.  There was no obvious way to fix this in Gtk3 but Gtk4 adds an extra TextTag attribute that can turn off insertion of hyphens.

Can anyone suggest a way of stopping auto-hyphenation during renaming in IconView? 