### PR TITLE
Add libgit2-glib-1.0-dev to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You'll need the following dependencies:
 * libdbus-glib-1-dev
 * libgail-3-dev
 * libgee-0.8-dev
+* libgit2-glib-1.0-dev
 * libglib2.0-dev
 * libgranite-dev >= 5.3.0
 * libgtk-3-dev


### PR DESCRIPTION
By trying to build the project in a fresh elementary/docker:unstable container, I discovered, that for running `meson build` successfully, the dependency libgit2-glib-1.0-dev needs to be installed.
Without that dependency installed, you get the following error from `meson build`:

```shell
Run-time dependency libgit2-glib-1.0 found: NO (tried pkgconfig)

plugins/git/meson.build:3:0: ERROR: Dependency "libgit2-glib-1.0" not found, tried pkgconfig
```

As the error tells, the git plugin needs the dependency.