### PR TITLE
Window: Fix view-mode action

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1164,9 +1164,15 @@ namespace Marlin.View {
             application.set_accels_for_action ("win.tab::CLOSE", {"<Ctrl>W"});
             application.set_accels_for_action ("win.tab::NEXT", {"<Ctrl>Page_Down", "<Ctrl>Tab"});
             application.set_accels_for_action ("win.tab::PREVIOUS", {"<Ctrl>Page_Up", "<Shift><Ctrl>Tab"});
-            application.set_accels_for_action ("win.view-mode(0)", {"<Ctrl>1"});
-            application.set_accels_for_action ("win.view-mode(1)", {"<Ctrl>2"});
-            application.set_accels_for_action ("win.view-mode(2)", {"<Ctrl>3"});
+            application.set_accels_for_action (
+                GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (0)), {"<Ctrl>1"}
+            );
+            application.set_accels_for_action (
+                GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (1)), {"<Ctrl>2"}
+            );
+            application.set_accels_for_action (
+                GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (2)), {"<Ctrl>3"}
+            );
             application.set_accels_for_action ("win.zoom::ZOOM_IN", {"<Ctrl>plus", "<Ctrl>equal"});
             application.set_accels_for_action ("win.zoom::ZOOM_OUT", {"<Ctrl>minus"});
             application.set_accels_for_action ("win.zoom::ZOOM_NORMAL", {"<Ctrl>0"});


### PR DESCRIPTION
Fixes #1476

The type and target of generated Variant no longer matches the action signature although the detailed action name has not changed recently.  Maybe due to newer Gtk version?  There also seems to be an upstream bug causing a spurious terminal warning on Window construction (the action callback is triggered with the wrong target type).

Using `GLib.print_detailed_name ()` to get the action string obviates these problems.