### PR TITLE
ConnectServerDialog: Remove STYLE_CLASS_FRAME from info_bar

### DIFF
--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -125,7 +125,6 @@ public class PF.ConnectServerDialog : Gtk.Dialog {
             message_type = Gtk.MessageType.INFO
         };
 
-        info_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FRAME);
         info_bar.get_content_area ().add (info_label);
         dismiss_info ();
 


### PR DESCRIPTION
Fixes #1480

I think we don't need to have a border here anyway―even if the inforbar is revealed.

## Before
![Screenshot from 2020-09-23 06-22-09](https://user-images.githubusercontent.com/26003928/93952699-7776b480-fd84-11ea-88df-6f4465537ca5.png)

![Screenshot from 2020-09-23 09-56-07](https://user-images.githubusercontent.com/26003928/93952851-da684b80-fd84-11ea-9d2c-c3f495fe9500.png)

## After
![Screenshot from 2020-09-23 10-03-03](https://user-images.githubusercontent.com/26003928/93952953-17344280-fd85-11ea-92e9-541732b4b2ca.png)

![Screenshot from 2020-09-23 10-03-15](https://user-images.githubusercontent.com/26003928/93952956-19969c80-fd85-11ea-8368-3d64eabbaf42.png)
