### PR TITLE
GOF.File: Make certain immutable members construct properties

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -42,16 +42,16 @@ public class GOF.File : GLib.Object {
     public signal void destroy ();
 
     public bool is_gone;
-    public GLib.File location = null;
+    public GLib.File location { get; construct; }
     public GLib.File target_location = null;
     public GOF.File target_gof = null;
-    public GLib.File directory = null; /* parent directory location */
+    public GLib.File directory { get; construct; } /* parent directory location */
     public GLib.Icon? icon = null;
     public GLib.List<string>? emblems_list = null;
     public GLib.FileInfo? info = null;
-    public string basename = null;
+    public string basename { get; construct; }
     public string? custom_display_name = null;
-    public string uri = null;
+    public string uri { get; construct; }
     public uint64 size = 0;
     public string format_size = null;
     public int color = 0;
@@ -158,10 +158,12 @@ public class GOF.File : GLib.Object {
     }
 
     public File (GLib.File location, GLib.File? dir = null) {
-        this.location = location;
-        uri = location.get_uri ();
-        directory = dir;
-        basename = location.get_basename ();
+        Object (
+            location: location,
+            uri: location.get_uri (),
+            basename: location.get_basename (),
+            directory: dir
+        );
     }
 
     construct {

--- a/libcore/fm-list-model.c
+++ b/libcore/fm-list-model.c
@@ -534,15 +534,14 @@ fm_list_model_file_entry_compare_func (gconstpointer a,
     file_entry1 = (FileEntry *)a;
     file_entry2 = (FileEntry *)b;
 
-    if (file_entry1->file != NULL && file_entry2->file != NULL &&
-        file_entry1->file->location != NULL && file_entry2->file->location != NULL) {
+    if (file_entry1->file != NULL && file_entry2->file != NULL) {
 
         result = gof_file_compare_for_sort (file_entry1->file, file_entry2->file,
                                             model->details->sort_id,
                                             model->details->sort_directories_first,  /* Get value from GOF.Preferences */
                                             (model->details->order == GTK_SORT_DESCENDING));
 
-    } else if (file_entry1->file == NULL || file_entry1->file->location == NULL) {
+    } else if (file_entry1->file == NULL) {
         /* Dummy rows representing expanded empty directories have null files */
         result = -1;
     } else {
@@ -702,7 +701,7 @@ fm_list_model_add_file (FMListModel *model, GOFFile *file,
     gboolean replaced_dummy;
     GHashTable *parent_hash;
 
-    g_return_val_if_fail (file != NULL && file->location != NULL, FALSE);
+    g_return_val_if_fail (file != NULL, FALSE);
     parent_ptr = g_hash_table_lookup (model->details->directory_reverse_map,
                                       directory);
     if (parent_ptr) {


### PR DESCRIPTION
* directory
* location
* uri
* basename

We need to be sure that, once created, a GOF File cannot change these properties (and, with the exception of the parent directory, they cannot be null).