### PR TITLE
Use DateTime not TimeVal

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -87,7 +87,6 @@ public class GOF.File : GLib.Object {
     public GLib.Mount? mount = null;
     public bool is_connected = true;
     public string? utf8_collation_key = null;
-    public time_t trash_time;
 
     public static new GOF.File @get (GLib.File location) {
         var parent = location.get_parent ();
@@ -586,7 +585,6 @@ public class GOF.File : GLib.Object {
             _can_unmount = info.get_attribute_boolean (GLib.FileAttribute.MOUNTABLE_CAN_UNMOUNT);
         }
 
-        update_trash_info ();
         update_emblem ();
     }
 
@@ -884,17 +882,6 @@ public class GOF.File : GLib.Object {
         }
 
         return true;
-    }
-
-    public void update_trash_info () {
-        unowned string time_string = info.get_attribute_string ("trash::deletion-date");
-        if (time_string != null) {
-            var timeval = GLib.TimeVal ();
-            timeval.from_iso8601 (time_string);
-            trash_time = timeval.tv_sec;
-        } else {
-            trash_time = 0;
-        }
     }
 
     public int compare_for_sort (GOF.File other, int sort_type, bool directories_first, bool reversed) {

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -526,9 +526,11 @@ namespace PF.FileUtils {
 
             case FileAttribute.TRASH_DELETION_DATE:
                 var deletion_date = info.get_attribute_string (attr);
-                var tv = TimeVal ();
-                if (deletion_date != null && !tv.from_iso8601 (deletion_date)) {
-                    dt = new DateTime.from_timeval_local (tv);
+                if (deletion_date != null) {
+                    dt = new DateTime.from_iso8601 (deletion_date, new TimeZone.local ());
+                    if (dt == null) {
+                        critical ("TRASH_DELETION_DATE: %s is not a valid ISO8601 datetime", deletion_date);
+                    }
                 }
 
                 break;


### PR DESCRIPTION
Rather thatn update trash_time in File.vala, it is removed, as it is not currently used.
The deletion date is only accessed when the Properties Dialog is shown.

Note that this also fixes an unreported issue in master where the deletion date was not actually shown in the dialog.