### PR TITLE
Use AppInfo.launch_default_uri_async (), not Gtk.show_uri ()

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -856,11 +856,13 @@ namespace Marlin.View {
         }
 
         void show_app_help () {
-            try {
-                Gtk.show_uri (screen, Marlin.HELP_URL, -1);
-            } catch (Error e) {
-                critical ("Can't open the link");
-            }
+            AppInfo.launch_default_for_uri_async.begin (Marlin.HELP_URL, null, null, (obj, res) => {
+                try {
+                    AppInfo.launch_default_for_uri_async.end (res);
+                } catch (Error e) {
+                    warning ("Could not open help - %s", e.message);
+                }
+            });
         }
 
         private GLib.SimpleAction? get_action (string action_name) {


### PR DESCRIPTION
Launching a remote uri for help is deprecated but until a suitable replacement is decided we might as well not use deprecated code.