### PR TITLE
Removed BountySource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Files
-[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=65602118)](https://www.bountysource.com/teams/elementary/issues?tracker_ids=65602118)
 [![Packaging status](https://repology.org/badge/tiny-repos/elementary-files.svg)](https://repology.org/metapackage/pantheon-files)
 [![Translation status](https://l10n.elementary.io/widgets/files/-/svg-badge.svg)](https://l10n.elementary.io/projects/files/?utm_source=widget)
 


### PR DESCRIPTION
The elementary team no longer uses BountySource, and since the README.md is potentially one of the the first impressions a user (or, in this case, a developer) will have, it may lead to confusion. I have removed BountySource from the README file for this reason.