### PR TITLE
Popover breadcrumbmenu

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -181,6 +181,7 @@ namespace PF.FileUtils {
         return result;
     }
 
+	/* Note: For the root directory this returns the root not the parent */
     private string construct_parent_path (string path, bool include_file_protocol) {
         if (path.length < 2) {
             return Path.DIR_SEPARATOR_S;

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -181,7 +181,7 @@ namespace PF.FileUtils {
         return result;
     }
 
-	/* Note: For the root directory this returns the root not the parent */
+    /* Note: For the root directory this returns the root not the parent */
     private string construct_parent_path (string path, bool include_file_protocol) {
         if (path.length < 2) {
             return Path.DIR_SEPARATOR_S;

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -468,7 +468,7 @@ namespace Marlin.View.Chrome {
                 }
             }
 
-            item = new MenuItem (_("Open with other Application ..."), null);
+            item = new MenuItem (_("Open with other Application…"), null);
             var submenu_open_with_other_section = new Menu ();
             submenu_open_with_other_section.append_item (item);
 

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -435,6 +435,7 @@ namespace Marlin.View.Chrome {
                     item = new MenuItem (app_info.get_name (), null);
                     var data = new Variant ("(ss)", path, app_info.get_commandline ());
                     item.set_action_and_target ("win.open-in-app", "v", data);
+                    item.set_icon (app_info.get_icon ());
                     submenu_open_with_apps_section.append_item (item);
                 }
             }

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -441,6 +441,7 @@ namespace Marlin.View.Chrome {
             }
 
             item = new MenuItem (_("Open with other Application…"), null);
+            item.set_action_and_target ("win.open-in-other-app", "s", path);
             var submenu_open_with_other_section = new Menu ();
             submenu_open_with_other_section.append_item (item);
 

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -446,7 +446,6 @@ namespace Marlin.View.Chrome {
 
             item = new MenuItem (_("Open in New Window"), null);
             item.set_action_and_target ("win.new-window", "s", path);
-            item.set_icon (new ThemedIcon ("missing-image"));
             menu.append_item (item);
 
             var root = GOF.File.get_by_uri (path);
@@ -460,8 +459,6 @@ namespace Marlin.View.Chrome {
                     at_least_one = true;
 
                     item = new MenuItem (app_info.get_name (), null);
-                    //FIXME this does not work! No icon is shown in popover
-                    item.set_icon (app_info.get_icon ());
                     var data = new Variant ("(ss)", path, app_info.get_commandline ());
                     item.set_action_and_target ("win.open-in-app", "v", data);
                     submenu_open_with_apps_section.append_item (item);
@@ -498,7 +495,6 @@ namespace Marlin.View.Chrome {
                     menu.append_section ("", section);
                 }
             }
-
 
             /* Release the Async directory as soon as possible */
             dir.cancel ();

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -44,7 +44,8 @@ namespace Marlin.View {
             {"change-path", action_change_path, "s" },
             {"new-tab", action_new_tab, "s" },
             {"new-window", action_new_window, "s" },
-            {"open-in-app", action_open_in_app, "v"}
+            {"open-in-app", action_open_in_app, "v"},
+            {"open-in-other-app", action_open_in_other_app, "s"}
         };
 
         public uint window_number { get; construct; }
@@ -723,6 +724,12 @@ namespace Marlin.View {
             } catch (Error e) {
                 warning ("Could not launch - %s", e.message);
             }
+        }
+
+        private void action_open_in_other_app (SimpleAction action, Variant? param) {
+            string path;
+            param.@get ("s", out path);
+            Marlin.MimeActions.open_glib_file_request (File.new_for_uri (path), this, null);
         }
 
         private void action_go_to (GLib.SimpleAction action, GLib.Variant? param) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -25,7 +25,7 @@ namespace Marlin.View {
 
     public class Window : Hdy.ApplicationWindow {
         const GLib.ActionEntry [] WIN_ENTRIES = {
-            {"new-window", action_new_window},
+            {"new-home-window", action_new_home_window},
             {"quit", action_quit},
             {"refresh", action_reload},
             {"undo", action_undo},
@@ -40,7 +40,11 @@ namespace Marlin.View {
             {"view-mode", action_view_mode, "u", "0" },
             {"show-hidden", null, null, "false", change_state_show_hidden},
             {"show-remote-thumbnails", null, null, "true", change_state_show_remote_thumbnails},
-            {"hide-local-thumbnails", null, null, "false", change_state_hide_local_thumbnails}
+            {"hide-local-thumbnails", null, null, "false", change_state_hide_local_thumbnails},
+            {"change-path", action_change_path, "s" },
+            {"new-tab", action_new_tab, "s" },
+            {"new-window", action_new_window, "s" },
+            {"open-in-app", action_open_in_app, "v"}
         };
 
         public uint window_number { get; construct; }
@@ -650,7 +654,7 @@ namespace Marlin.View {
         }
 
         private bool adding_window = false;
-        private void action_new_window (GLib.SimpleAction action, GLib.Variant? param) {
+        private void action_new_home_window (GLib.SimpleAction action, GLib.Variant? param) {
             /* Limit rate of adding new windows using the keyboard */
             if (adding_window) {
                 return;
@@ -682,6 +686,43 @@ namespace Marlin.View {
             Marlin.ViewMode mode = real_mode ((ViewMode)(param.get_uint32 ()));
             current_tab.change_view_mode (mode);
             /* ViewContainer takes care of changing appearance */
+        }
+
+        private void action_change_path (SimpleAction action, Variant? param) {
+            string path;
+            param.@get ("s", out path);
+            uri_path_change_request (path, Marlin.OpenFlag.DEFAULT);
+        }
+
+        private void action_new_tab (SimpleAction action, Variant? param) {
+            string path;
+            param.@get ("s", out path);
+            uri_path_change_request (path, Marlin.OpenFlag.NEW_TAB);
+        }
+
+        private void action_new_window (SimpleAction action, Variant? param) {
+            string path;
+            param.@get ("s", out path);
+            uri_path_change_request (path, Marlin.OpenFlag.NEW_WINDOW);
+        }
+
+        private void action_open_in_app (SimpleAction action, Variant? param) {
+            string path;
+            string command_line;
+            Variant variant;
+
+            param.@get ("v", out variant);
+
+            variant.@get ("(ss)", out path, out command_line);
+
+            try {
+                var app_info = AppInfo.create_from_commandline (command_line, null, AppInfoCreateFlags.SUPPORTS_URIS);
+                List<string> uris = null;
+                uris.append (path);
+                app_info.launch_uris (uris, null);
+            } catch (Error e) {
+                warning ("Could not launch - %s", e.message);
+            }
         }
 
         private void action_go_to (GLib.SimpleAction action, GLib.Variant? param) {
@@ -1156,7 +1197,7 @@ namespace Marlin.View {
 
         private void set_accelerators () {
             marlin_app.set_accels_for_action ("win.quit", {"<Ctrl>Q"});
-            application.set_accels_for_action ("win.new-window", {"<Ctrl>N"});
+            application.set_accels_for_action ("win.new-home-window", {"<Ctrl>N"});
             application.set_accels_for_action ("win.undo", {"<Ctrl>Z"});
             application.set_accels_for_action ("win.redo", {"<Ctrl><Shift>Z"});
             application.set_accels_for_action ("win.bookmark", {"<Ctrl>D"});


### PR DESCRIPTION
Related to https://github.com/elementary/applications-menu/issues/423

This avoids a recent problem with using a Gtk.Menu in connection with the headerbar by switching to a Popover built from a GLib.MenuModel.  In order to do this some extra actions were created for Marlin.View.Window for opening paths in new tabs, windows or with an app which could be linked to the GLib.MenuItems.

This results in a basic UI - without icons.  

To get a more complicated UI it will probably be necessary use widgets like ModelButton to construct the menu, but this shows that Gtk.Popover is not affected by the problem of limited height.

