### PR TITLE
Meson: correct required version to >=0.50

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'io.elementary.files',
     'vala', 'c',
     version: '4.5.0',
-    meson_version: '>= 0.47.0'
+    meson_version: '>= 0.50.0'
 )
 
 #


### PR DESCRIPTION
We're using features from newer than 0.47.

```
WARNING: Project targeting '>= 0.47.0' but tried to use feature introduced in '0.50.0': install arg in configure_file
```

```
WARNING: Project targeting '>= 0.47.0' but tried to use feature introduced in '0.49.0': / with string arguments
```

```
WARNING: Project specifies a minimum meson_version '>= 0.47.0' but uses features which were added in newer versions:
 * 0.49.0: {'/ with string arguments'}
 * 0.50.0: {'install arg in configure_file'}
```