### PR TITLE
Pathbar visual glitch

### DIFF
--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -102,6 +102,7 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         var state = button_context.get_state ();
         var is_rtl = Gtk.StateFlags.DIR_RTL in state;
         var scale = widget.scale_factor;
+
         button_context.save ();
         if (pressed) {
             state |= Gtk.StateFlags.ACTIVE;
@@ -113,6 +114,10 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
 
         cr.restore ();
         cr.save ();
+
+        /* Supress drawing outside widget */
+        cr.rectangle (0.0, 0.0, widget.get_allocated_width (), widget.get_allocated_height ());
+        cr.clip ();
 
         var half_height = height / 2;
         var y_half_height = y + half_height;
@@ -252,9 +257,7 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
             }
         } else {
             cr.save ();
-            /* Supress drawing outside widget */
-            cr.rectangle (0.0, 0.0, widget.get_allocated_width (), widget.get_allocated_height ());
-            cr.clip ();
+
 
             if (icon_to_draw == null) {
                 if (room_for_text) {

--- a/libwidgets/Chrome/BreadcrumbElement.vala
+++ b/libwidgets/Chrome/BreadcrumbElement.vala
@@ -115,7 +115,7 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
         cr.restore ();
         cr.save ();
 
-        /* Supress drawing outside widget */
+        /* Suppress all drawing outside widget */
         cr.rectangle (0.0, 0.0, widget.get_allocated_width (), widget.get_allocated_height ());
         cr.clip ();
 
@@ -312,7 +312,7 @@ public class Marlin.View.Chrome.BreadcrumbElement : Object {
             button_context.render_frame (cr, -height / 2, -height / 2, height, height);
             button_context.restore ();
             cr.restore ();
-        } else if (x > height / 4) { /* Avoid drawing outside LH edge of entry */
+        } else {
             cr.save ();
             cr.translate (x - height / 4, y + height / 2);
             cr.rectangle (0, -height / 2 + line_width, height, height - 2 * line_width);


### PR DESCRIPTION
Fixes #645 

This issue has resurface recently in Odin, presumably due to changes in stylesheet.  This PR aims to ensure breadcrumbs do not draw outside the pathbar by clipping the Cairo context.