### PR TITLE
Scroll to selected file after loading, regardless of sort order.

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1356,8 +1356,6 @@ namespace FM {
             in_recent = slot.directory.is_recent;
             in_network_root = slot.directory.file.is_root_network_folder ();
 
-            thaw_tree ();
-
             if (slot.directory.can_load) {
                 is_writable = slot.directory.file.is_writable ();
                 if (in_recent) {
@@ -1368,6 +1366,8 @@ namespace FM {
             } else {
                 is_writable = false;
             }
+
+            thaw_tree ();
 
             schedule_thumbnail_timeout ();
         }


### PR DESCRIPTION
Fixes #1187 

AbstractDirectoryView: Set sort order before thawing tree after loading