### PR TITLE
fm-list-model: Avoid hitting the wrong part of the memory with color management

### DIFF
--- a/libcore/fm-list-model.c
+++ b/libcore/fm-list-model.c
@@ -238,7 +238,7 @@ fm_list_model_get_value (GtkTreeModel *tree_model, GtkTreeIter *iter, int column
 
     case FM_LIST_MODEL_COLOR:
         g_value_init (value, G_TYPE_STRING);
-        if (file != NULL)
+        if (file != NULL && file->color >= 0 && file->color < sizeof(GOF_PREFERENCES_TAGS_COLORS)/sizeof(gchar*))
             g_value_set_string(value, GOF_PREFERENCES_TAGS_COLORS[file->color]);
         break;
 


### PR DESCRIPTION
There is no warranty that the color isn't out of band here, add sanity checks.