### PR TITLE
filechooser-portal: Make use of native async capabilities and process the dialog before destroy

### DIFF
--- a/filechooser-portal/Main.vala
+++ b/filechooser-portal/Main.vala
@@ -38,7 +38,7 @@ public class Files.FileChooser : GLib.Object {
         this.connection = connection;
     }
 
-    public void open_file (GLib.ObjectPath handle, string app_id, string parent_window, string title, GLib.HashTable<string, GLib.Variant> options, out uint response, out GLib.HashTable<string, GLib.Variant> results) throws GLib.DBusError, GLib.IOError {
+    public async void open_file (GLib.ObjectPath handle, string app_id, string parent_window, string title, GLib.HashTable<string, GLib.Variant> options, out uint response, out GLib.HashTable<string, GLib.Variant> results) throws GLib.DBusError, GLib.IOError {
         var _results = new GLib.HashTable<string, GLib.Variant> (str_hash, str_equal);
         var dialog = new Files.FileChooserDialog (connection, handle, app_id, parent_window, title, options);
 
@@ -84,7 +84,6 @@ public class Files.FileChooser : GLib.Object {
             dialog.set_extra_widget (box);
         }
 
-        var dialog_loop = new GLib.MainLoop (null, false);
         uint _response = 2;
         dialog.response.connect ((id) => {
             switch ((Gtk.ResponseType) id) {
@@ -107,11 +106,12 @@ public class Files.FileChooser : GLib.Object {
                     _response = 2;
                     break;
             }
-            dialog_loop.quit ();
+
+            open_file.callback ();
         });
 
         dialog.show_all ();
-        dialog_loop.run ();
+        yield;
         response = _response;
         results = _results;
     }
@@ -153,8 +153,8 @@ public class Files.FileChooser : GLib.Object {
         }
     }
 
-    public void save_file (GLib.ObjectPath handle, string app_id, string parent_window, string title, GLib.HashTable<string, GLib.Variant> options, out uint response, out GLib.HashTable<string, GLib.Variant> results) throws GLib.DBusError, GLib.IOError {
-        results = new GLib.HashTable<string, GLib.Variant> (str_hash, str_equal);
+    public async void save_file (GLib.ObjectPath handle, string app_id, string parent_window, string title, GLib.HashTable<string, GLib.Variant> options, out uint response, out GLib.HashTable<string, GLib.Variant> results) throws GLib.DBusError, GLib.IOError {
+        var _results = new GLib.HashTable<string, GLib.Variant> (str_hash, str_equal);
         var dialog = new Files.FileChooserDialog (connection, handle, app_id, parent_window, title, options);
         dialog.action = Gtk.FileChooserAction.SAVE;
 
@@ -201,37 +201,39 @@ public class Files.FileChooser : GLib.Object {
         }
 
         dialog.show_all ();
-        var dialog_loop = new GLib.MainLoop (null, false);
-        Gtk.ResponseType dialog_response = Gtk.ResponseType.DELETE_EVENT;
+        uint _response = 2;
         dialog.response.connect ((id) => {
-            dialog_response = (Gtk.ResponseType) id;
-            dialog_loop.quit ();
+            switch ((Gtk.ResponseType) id) {
+                case Gtk.ResponseType.OK:
+                    _response = 0;
+                    _results["choices"] = dialog.choices;
+                    var builder = new GLib.VariantBuilder (GLib.VariantType.STRING_ARRAY);
+                    dialog.get_uris ().foreach ((uri) => {
+                        builder.add ("s", uri);
+                    });
+
+                    _results["uris"] = builder.end ();
+                    break;
+                case Gtk.ResponseType.CANCEL:
+                    _response = 1;
+                    break;
+                case Gtk.ResponseType.DELETE_EVENT:
+                default:
+                    _response = 2;
+                    break;
+            }
+
+            save_file.callback ();
         });
 
-        dialog_loop.run ();
-        switch (dialog_response) {
-            case Gtk.ResponseType.OK:
-                response = 0;
-                results["choices"] = dialog.choices;
-                var builder = new GLib.VariantBuilder (GLib.VariantType.STRING_ARRAY);
-                dialog.get_uris ().foreach ((uri) => {
-                    builder.add ("s", uri);
-                });
-
-                results["uris"] = builder.end ();
-                break;
-            case Gtk.ResponseType.CANCEL:
-                response = 1;
-                break;
-            case Gtk.ResponseType.DELETE_EVENT:
-            default:
-                response = 2;
-                break;
-        }
+        dialog.show_all ();
+        yield;
+        response = _response;
+        results = _results;
     }
 
-    public void save_files (GLib.ObjectPath handle, string app_id, string parent_window, string title, GLib.HashTable<string, GLib.Variant> options, out uint response, out GLib.HashTable<string, GLib.Variant> results) throws GLib.DBusError, GLib.IOError {
-        results = new GLib.HashTable<string, GLib.Variant> (str_hash, str_equal);
+    public async void save_files (GLib.ObjectPath handle, string app_id, string parent_window, string title, GLib.HashTable<string, GLib.Variant> options, out uint response, out GLib.HashTable<string, GLib.Variant> results) throws GLib.DBusError, GLib.IOError {
+        var _results = new GLib.HashTable<string, GLib.Variant> (str_hash, str_equal);
         var dialog = new Files.FileChooserDialog (connection, handle, app_id, parent_window, title, options);
         dialog.action = Gtk.FileChooserAction.SELECT_FOLDER;
 
@@ -271,38 +273,39 @@ public class Files.FileChooser : GLib.Object {
             dialog.set_data<string[]> ("files", files);
         }
 
-        dialog.show_all ();
-        var dialog_loop = new GLib.MainLoop (null, false);
-        Gtk.ResponseType dialog_response = Gtk.ResponseType.DELETE_EVENT;
+        uint _response = 2;
         dialog.response.connect ((id) => {
-            dialog_response = (Gtk.ResponseType) id;
-            dialog_loop.quit ();
+            switch ((Gtk.ResponseType) id) {
+                case Gtk.ResponseType.OK:
+                    _response = 0;
+                    _results["choices"] = dialog.choices;
+                    var builder = new GLib.VariantBuilder (GLib.VariantType.STRING_ARRAY);
+                    var uri = GLib.File.new_for_uri (dialog.get_uri ());
+                    unowned string[]? files = dialog.get_data<string[]> ("files");
+                    if (files != null) {
+                        foreach (unowned string file in files) {
+                            builder.add ("s", uri.get_child (GLib.Path.get_basename (file)).get_uri ());
+                        }
+                    }
+
+                    _results["uris"] = builder.end ();
+                    break;
+                case Gtk.ResponseType.CANCEL:
+                    _response = 1;
+                    break;
+                case Gtk.ResponseType.DELETE_EVENT:
+                default:
+                    _response = 2;
+                    break;
+            }
+
+            save_files.callback ();
         });
 
-        dialog_loop.run ();
-        switch (dialog_response) {
-            case Gtk.ResponseType.OK:
-                response = 0;
-                results["choices"] = dialog.choices;
-                var builder = new GLib.VariantBuilder (GLib.VariantType.STRING_ARRAY);
-                var uri = GLib.File.new_for_uri (dialog.get_uri ());
-                unowned string[]? files = dialog.get_data<string[]> ("files");
-                if (files != null) {
-                    foreach (unowned string file in files) {
-                        builder.add ("s", uri.get_child (GLib.Path.get_basename (file)).get_uri ());
-                    }
-                }
-
-                results["uris"] = builder.end ();
-                break;
-            case Gtk.ResponseType.CANCEL:
-                response = 1;
-                break;
-            case Gtk.ResponseType.DELETE_EVENT:
-            default:
-                response = 2;
-                break;
-        }
+        dialog.show_all ();
+        yield;
+        response = _response;
+        results = _results;
     }
 }
 


### PR DESCRIPTION
We were previously using some fields of the GtkFilechooser after it has been destroyed.
Fixes #1520