### PR TITLE
fm-list-model: Add FMListModel creation method

### DIFF
--- a/libcore/fm-list-model.c
+++ b/libcore/fm-list-model.c
@@ -1324,6 +1324,12 @@ fm_list_model_set_property (GObject      *object,
     }
 }
 
+FMListModel *
+fm_list_model_new (void)
+{
+    return FM_LIST_MODEL (g_object_new (FM_TYPE_LIST_MODEL, NULL));
+}
+
 const gchar *
 fm_list_model_column_id_to_string (FMListModelColumnID id)
 {

--- a/libcore/fm-list-model.h
+++ b/libcore/fm-list-model.h
@@ -55,6 +55,7 @@ struct _FMListModelClass
                                   GOFDirectoryAsync *subdirectory);
 };
 
+FMListModel *fm_list_model_new (void);
 gboolean fm_list_model_add_file                          (FMListModel *model, GOFFile *file, GOFDirectoryAsync *directory);
 void     fm_list_model_file_changed                      (FMListModel *model, GOFFile *file, GOFDirectoryAsync *directory);
 gboolean fm_list_model_is_empty                          (FMListModel *model);

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -31,13 +31,14 @@ namespace FM
             public static ColumnID from_string (string colstr);
         }
 
+        [CCode (has_construct_function = false)]
+        public ListModel ();
         public bool load_subdirectory(Gtk.TreePath path, out GOF.Directory.Async dir);
         public bool unload_subdirectory(Gtk.TreeIter iter);
         public void add_file(GOF.File file, GOF.Directory.Async dir);
         public bool remove_file (GOF.File file, GOF.Directory.Async dir);
         public void file_changed (GOF.File file, GOF.Directory.Async dir);
         public GOF.File? file_for_path (Gtk.TreePath path);
-        public static GLib.Type get_type ();
         public bool get_first_iter_for_file (GOF.File file, out Gtk.TreeIter iter);
         public bool get_tree_iter_from_file (GOF.File file, GOF.Directory.Async directory, out Gtk.TreeIter iter);
         public bool get_directory_file (Gtk.TreePath path, out unowned GOF.Directory.Async directory, out unowned GOF.File file);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -298,7 +298,7 @@ namespace FM {
 
                 draw_when_idle ();
             });
-            model = GLib.Object.@new (FM.ListModel.get_type (), null) as FM.ListModel;
+            model = new FM.ListModel ();
             Marlin.app_settings.bind ("single-click",
                                                              this, "single_click_mode", SettingsBindFlags.GET);
             Marlin.app_settings.bind ("show-remote-thumbnails",


### PR DESCRIPTION
Allows Vala to know that the created object type is a Gtk.Widget subclass.