### PR TITLE
filechooser-portal: Parent dialog on requester

### DIFF
--- a/filechooser-portal/ExternalWindow.vala
+++ b/filechooser-portal/ExternalWindow.vala
@@ -1,0 +1,86 @@
+/*-
+ * Copyright 2021 elementary LLC <https://elementary.io>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335 USA.
+ *
+ * Authored by: David Hewitt <davidmhewitt@gmail.com>
+ */
+
+public interface ExternalWindow : GLib.Object {
+    public abstract void set_parent_of (Gdk.Window child_window);
+
+    public static ExternalWindow? from_handle (string handle) {
+        const string X11_PREFIX = "x11:";
+        if (handle.has_prefix (X11_PREFIX)) {
+            try {
+                var external_window_x11 = new ExternalWindowX11 (handle.substring (X11_PREFIX.length));
+                return external_window_x11;
+            } catch (Error e) {
+                warning ("Error getting external X11 window: %s", e.message);
+                return null;
+            }
+        }
+
+        // TODO: Handle Wayland
+
+        warning ("Unhandled parent window type %s", handle);
+
+        return null;
+    }
+}
+
+public class ExternalWindowX11 : ExternalWindow, GLib.Object {
+    private static Gdk.Display? x11_display = null;
+
+    private Gdk.Window foreign_gdk_window;
+
+    public ExternalWindowX11 (string handle) throws GLib.IOError {
+        var display = get_x11_display ();
+        if (display == null) {
+            throw new IOError.FAILED ("No X display connection, ignoring X11 parent");
+        }
+
+        int xid;
+        if (!int.try_parse (handle, out xid, null, 16)) {
+            throw new IOError.FAILED ("Failed to reference external X11 window, invalid XID %s", handle);
+        }
+
+        foreign_gdk_window = new Gdk.X11.Window.foreign_for_display ((Gdk.X11.Display)display, xid);
+        if (foreign_gdk_window == null) {
+            throw new IOError.FAILED ("Failed to create foreign window for XID %d", xid);
+        }
+    }
+
+    private static Gdk.Display get_x11_display () {
+        if (x11_display != null) {
+            return x11_display;
+        }
+
+        Gdk.set_allowed_backends ("x11");
+        x11_display = Gdk.Display.open (null);
+        Gdk.set_allowed_backends (null);
+
+        if (x11_display == null) {
+            warning ("Failed to open X11 display");
+        }
+
+        return x11_display;
+    }
+
+    public void set_parent_of (Gdk.Window child_window) {
+        child_window.set_transient_for (foreign_gdk_window);
+    }
+}

--- a/filechooser-portal/FileChooserDialog.vala
+++ b/filechooser-portal/FileChooserDialog.vala
@@ -36,6 +36,16 @@ public class Files.FileChooserDialog : Gtk.FileChooserDialog {
         }
 
         legacy_dialog = new LegacyFileChooserDialog (this);
+
+        ExternalWindow? external_parent = null;
+        if (parent_window != "") {
+            external_parent = ExternalWindow.from_handle (parent_window);
+            if (external_parent == null) {
+                warning ("Failed to associate portal window with parent window %s", parent_window);
+            } else {
+                external_parent.set_parent_of (get_window ());
+            }
+        }
     }
 
     construct {

--- a/filechooser-portal/meson.build
+++ b/filechooser-portal/meson.build
@@ -2,12 +2,14 @@ libexec_dir = join_paths(get_option('prefix'), get_option ('libexecdir'))
 
 executable(
     'io.elementary.files.xdg-desktop-portal',
-    'Main.vala',
+    'ExternalWindow.vala',
     'FileChooserDialog.vala',
     'LegacyFileChooserDialog.vala',
+    'Main.vala',
 
     dependencies : [
         pantheon_files_widgets_dep,
+        dependency('gdk-x11-3.0'),
         project_config_dep
     ],
     install: true,


### PR DESCRIPTION
Fixes #1542 

We need to implement another class on top of the interface here to support Wayland, but I couldn't find the equivalent GTK 3 bindings of https://valadoc.org/gtk4/Gdk.Wayland.Toplevel.set_transient_for_exported.html so I've just left a TODO for now. Can we open an issue once this is merged about this and add it to the Wayland board?