### PR TITLE
POTFILES: Remove filechooser-module

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -44,9 +44,6 @@ src/View/Widgets/PermissionButton.vala
 src/View/Widgets/ProgressInfoWidget.vala
 src/View/Widgets/SingleLineEditableLabel.vala
 
-filechooser-module/FileChooserDialog.vala
-filechooser-module/Plugin.vala
-
 libcore/AbstractSidebar.vala
 libcore/AbstractSlot.vala
 libcore/BookmarkList.vala


### PR DESCRIPTION
These were removed in https://github.com/elementary/files/pull/1512