### PR TITLE
build: use define_variable

### DIFF
--- a/filechooser-portal/meson.build
+++ b/filechooser-portal/meson.build
@@ -23,7 +23,7 @@ if systemd_systemduserunitdir != 'no'
   if systemd_systemduserunitdir == ''
     systemd_dep = dependency('systemd', version: '>= 206', required: false)
     assert(systemd_dep.found(), 'systemd required but not found, please provide a valid systemd user unit dir or disable it')
-    systemd_systemduserunitdir = systemd_dep.get_pkgconfig_variable('systemduserunitdir')
+    systemd_systemduserunitdir = systemd_dep.get_pkgconfig_variable('systemduserunitdir', define_variable: ['prefix', get_option('prefix')])
   endif
 
   configure_file(


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this systemd_dep.get_pkgconfig_variable will return a
path from within systemd's prefix and we cannot write to it.
By using define_variable we can replace the prefix to be from the
paths from meson. This should have no affect on elementary OS.