### PR TITLE
DialogUtils: use show_all

### DIFF
--- a/libcore/FileOperations/DialogUtils.vala
+++ b/libcore/FileOperations/DialogUtils.vala
@@ -64,7 +64,7 @@ namespace PF {
                 dialog.show_error_details (details_text);
             }
 
-            dialog.show ();
+            dialog.show_all ();
             return Source.REMOVE;
         });
 


### PR DESCRIPTION
Fixes an issue with https://github.com/elementary/granite/pull/460#pullrequestreview-578173792 where file operation dialogs have no contents