### PR TITLE
Avoid unneeded output when attempting sudo.

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -72,15 +72,6 @@ public class Marlin.Application : Gtk.Application {
             Granite.Services.Logger.DisplayLevel = Granite.Services.LogLevel.INFO;
         }
 
-        message ("Report any issues/bugs you might find to https://github.com/elementary/files/issues");
-
-        /* Only allow running with root privileges using pkexec, not using sudo */
-        if (Marlin.is_admin () && GLib.Environment.get_variable ("PKEXEC_UID") == null) {
-            warning ("Running Files as root using sudo is not possible. " +
-                     "Please use the command: io.elementary.files-pkexec [folder]");
-            quit ();
-        };
-
         init_schemas ();
 
         Gtk.IconTheme.get_default ().changed.connect (() => {
@@ -130,6 +121,15 @@ public class Marlin.Application : Gtk.Application {
     }
 
     public override int command_line (ApplicationCommandLine cmd) {
+        /* Only allow running with root privileges using pkexec, not using sudo */
+        if (Marlin.is_admin () && GLib.Environment.get_variable ("PKEXEC_UID") == null) {
+            warning ("Running Files as root using sudo is not possible. " +
+                     "Please use the command: io.elementary.files-pkexec [folder]");
+            quit ();
+            return 1;
+        };
+
+        message ("Report any issues/bugs you might find to https://github.com/elementary/files/issues");
         this.hold ();
         int result = _command_line (cmd);
         this.release ();
@@ -142,6 +142,7 @@ public class Marlin.Application : Gtk.Application {
     private string[]? remaining = null;
 
     private int _command_line (ApplicationCommandLine cmd) {
+warning ("_commandline");
         /* Setup the argument parser */
         bool version = false;
         /* The -t option is redundant but is retained for backward compatability
@@ -258,6 +259,7 @@ public class Marlin.Application : Gtk.Application {
         quitting = true;
         unowned List<Gtk.Window> window_list = this.get_windows ();
         window_list.@foreach ((window) => {
+warning ("quitting window");
             ((Marlin.View.Window)window).quit ();
         });
 

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -1,0 +1,414 @@
+/* DeviceRow.vala
+ *
+ * Copyright 2020 elementary LLC. <https://elementary.io>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ * Authors : Jeremy Wootten <jeremy@elementaryos.org>
+ */
+
+public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, SidebarItemInterface {
+    protected static Gtk.CssProvider devicerow_provider;
+
+    protected Gtk.Stack mount_eject_stack;
+    protected Gtk.Revealer mount_eject_revealer;
+    protected Gtk.Spinner mount_eject_spinner;
+
+    protected bool valid = true;
+    public string? uuid { get; set construct; }
+    public Drive? drive { get; set construct; }
+    public Volume? volume { get; set construct; }
+    public Mount? mount { get; set construct; }
+
+    protected bool _mounted = false;
+    public bool mounted {
+        get {
+            return _mounted;
+        }
+
+        set {
+            _mounted = value;
+             mount_eject_revealer.reveal_child = _mounted && _can_eject;
+        }
+    }
+
+    protected bool _can_eject = false;
+    public bool can_eject {
+        get {
+            return _can_eject;
+        }
+
+        set {
+            _can_eject = value;
+             mount_eject_revealer.reveal_child = _can_eject && _mounted;
+        }
+    }
+
+    public bool working {
+        get {
+            return mount_eject_stack.visible_child_name == "spinner";
+        }
+
+        set {
+            if (!valid) {
+                return;
+            }
+
+            if (value) {
+                mount_eject_revealer.reveal_child = true;
+                mount_eject_stack.visible_child_name = "spinner";
+                mount_eject_spinner.start ();
+            } else {
+                mount_eject_spinner.stop ();
+                mount_eject_stack.visible_child_name = "eject";
+            }
+
+            mount_eject_revealer.reveal_child = _mounted && _can_eject;
+        }
+    }
+
+    protected AbstractMountableRow (string name, string uri, Icon gicon, SidebarListInterface list,
+                         bool pinned, bool permanent,
+                         string? _uuid, Drive? drive, Volume? volume, Mount? mount) {
+        Object (
+            custom_name: name,
+            uri: uri,
+            gicon: gicon,
+            list: list,
+            pinned: pinned,
+            permanent: permanent,
+            uuid: _uuid,
+            drive: drive,
+            volume: volume,
+            mount: mount
+        );
+
+        if (mount != null) {
+            mounted = true;
+            can_eject = mount.can_unmount () || mount.can_eject ();
+        } else if (volume != null) {
+            mounted = volume.get_mount () != null;
+            can_eject = volume.can_eject ();
+        } else if (drive != null) {
+            mounted = true;
+            can_eject = drive.can_eject () || drive.can_stop ();
+        }
+    }
+
+    static construct {
+        devicerow_provider = new Gtk.CssProvider ();
+        devicerow_provider.load_from_resource ("/io/elementary/files/DiskRenderer.css");
+    }
+
+    construct {
+        var eject_button = new Gtk.Button.from_icon_name ("media-eject-symbolic", Gtk.IconSize.MENU) {
+            tooltip_text = _("Eject '%s'").printf (custom_name)
+        };
+        eject_button.get_style_context ().add_provider (devicerow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        mount_eject_spinner = new Gtk.Spinner ();
+
+        mount_eject_stack = new Gtk.Stack () {
+            margin_start = 6,
+            transition_type = Gtk.StackTransitionType.CROSSFADE
+        };
+        mount_eject_stack.add_named (eject_button, "eject");
+        mount_eject_stack.add_named (mount_eject_spinner, "spinner");
+        mount_eject_stack.visible_child_name = "eject";
+
+        mount_eject_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT,
+            valign = Gtk.Align.CENTER
+        };
+        mount_eject_revealer.add (mount_eject_stack);
+        mount_eject_revealer.reveal_child = false;
+
+        content_grid.attach (mount_eject_revealer, 1, 0);
+
+        show_all ();
+
+        var volume_monitor = VolumeMonitor.@get ();
+        volume_monitor.volume_removed.connect (volume_removed);
+        volume_monitor.mount_removed.connect (mount_removed);
+        volume_monitor.mount_added.connect (mount_added);
+        volume_monitor.drive_disconnected.connect (drive_removed);
+
+        add_mountable_tooltip.begin ();
+
+        eject_button.clicked.connect (() => {
+            eject ();
+        });
+    }
+
+    protected override void update_plugin_data (Marlin.SidebarPluginItem item) {
+        base.update_plugin_data (item);
+        working = item.show_spinner;
+    }
+
+    protected override void activated (Marlin.OpenFlag flag = Marlin.OpenFlag.DEFAULT) {
+        if (working) {
+            return;
+        }
+
+        if (mounted || permanent) { //Permanent devices are always accessible
+            list.open_item (this, flag);
+            return;
+        }
+
+        if (volume != null) {
+            working = true;
+            volume.mount.begin (
+                GLib.MountMountFlags.NONE,
+                new Gtk.MountOperation (Marlin.get_active_window ()),
+                null,
+                (obj, res) => {
+                    try {
+                        volume.mount.end (res);
+                        mount = volume.get_mount ();
+                        if (mount != null) {
+                            mounted = true;
+                            can_eject = mount.can_unmount () || mount.can_eject ();
+                            uri = mount.get_default_location ().get_uri ();
+                            list.open_item (this, flag);
+                        }
+                    } catch (GLib.Error error) {
+                        var primary = _("Error mounting volume '%s'").printf (volume.get_name ());
+                        PF.Dialogs.show_error_dialog (primary, error.message, Marlin.get_active_window ());
+                    } finally {
+                        working = false;
+                        add_mountable_tooltip.begin ();
+                    }
+                }
+            );
+        } else if (drive != null && (drive.can_start () || drive.can_start_degraded ())) {
+            working = true;
+            drive.start.begin (
+               DriveStartFlags.NONE,
+               new Gtk.MountOperation (null),
+               null,
+               (obj, res) => {
+                    try {
+                        if (drive.start.end (res)) {
+                            mounted = true;
+                            can_eject = drive.can_eject () || drive.can_stop ();
+                        }
+                    } catch (Error e) {
+                            var primary = _("Unable to start '%s'").printf (drive.get_name ());
+                            PF.Dialogs.show_error_dialog (primary, e.message, Marlin.get_active_window ());
+                    } finally {
+                        working = false;
+                        add_mountable_tooltip.begin ();
+                    }
+                }
+            );
+        }
+    }
+
+    private void eject () {
+        if (working || !valid) {
+            return;
+        }
+
+        var mount_op = new Gtk.MountOperation (Marlin.get_active_window ());
+        if (!permanent && mounted && mount != null) {
+            if (mount.can_eject ()) {
+                working = true;
+                mount.eject_with_operation.begin (
+                    GLib.MountUnmountFlags.NONE,
+                    mount_op,
+                    null,
+                    (obj, res) => {
+                        try {
+                            mounted = !mount.eject_with_operation.end (res);
+                        } catch (GLib.Error error) {
+                            warning ("Error ejecting mount '%s': %s", mount.get_name (), error.message);
+                        } finally {
+                            working = false;
+                            if (!mounted) {
+                                mount = null;
+                            }
+                        }
+                    }
+                );
+
+                return;
+            } else if (mount.can_unmount ()) {
+                working = true;
+                mount.unmount_with_operation.begin (
+                    GLib.MountUnmountFlags.NONE,
+                    mount_op,
+                    null,
+                    (obj, res) => {
+                        try {
+                            mounted = !mount.unmount_with_operation.end (res);
+                        } catch (GLib.Error error) {
+                            warning ("Error while unmounting mount '%s': %s", mount.get_name (), error.message);
+                        } finally {
+                            working = false;
+                            if (!mounted) {
+                                mount = null;
+                            }
+                        }
+                    }
+                );
+            }
+        } else if (drive != null && drive.can_eject () || drive.can_stop ()) {
+            working = true;
+            if (drive.can_stop ()) {
+                drive.stop.begin (
+                    GLib.MountUnmountFlags.NONE,
+                    mount_op,
+                    null,
+                    (obj, res) => {
+                        try {
+                            mounted = drive.stop.end (res);
+                        } catch (Error e) {
+                            warning ("Could not stop drive '%s': %s", drive.get_name (), e.message);
+                        } finally {
+                            working = false;
+                            if (!mounted) {
+                                mount = null;
+                            }
+                        }
+                    }
+                );
+            } else if (drive.can_eject ()) {
+                drive.eject_with_operation.begin (
+                    GLib.MountUnmountFlags.NONE,
+                    mount_op,
+                    null,
+                    (obj, res) => {
+                        try {
+                            mounted = drive.eject_with_operation.end (res);
+                        } catch (Error e) {
+                            warning ("Could not eject drive '%s': %s", drive.get_name (), e.message);
+                        } finally {
+                            working = false;
+                            if (!mounted) {
+                                mount = null;
+                            }
+                        }
+                    }
+                );
+            }
+        }
+    }
+
+    private void drive_removed (Drive removed_drive) {
+        if (valid && drive == removed_drive) {
+            valid = false;
+            list.remove_item_by_id (id);
+        }
+    }
+
+    private void volume_removed (Volume removed_volume) {
+        if (valid && volume == removed_volume) {
+            valid = false;
+            list.remove_item_by_id (id);
+        }
+    }
+
+    /* This handler gets spammed by the monitor! */
+    private void mount_removed (Mount removed_mount) {
+        if (valid && !working && mounted && mount == removed_mount) {
+            if (drive == null && volume == null) {
+                valid = false;
+                list.remove_item_by_id (id);
+            } else {
+                mounted = false;
+                mount = null;
+            }
+        }
+    }
+
+    /* This gets spammed by VolumeMonitor! */
+    private void mount_added (Mount added_mount) {
+        if (working || permanent || volume == null) {
+            return;
+        }
+        working = true;
+        var added_volume = added_mount.get_volume ();
+
+        if (volume.get_name () == added_volume.get_name () &&
+            (mount == null || (mount.get_name () == added_mount.get_name ()))) {
+            mount = added_mount;
+            mounted = true;
+        }
+
+        working = false;
+    }
+
+    protected override void add_extra_menu_items (PopupMenuBuilder menu_builder) {
+        if (mount != null && mounted) {
+            if (Marlin.FileOperations.has_trash_files (mount)) {
+                menu_builder
+                    .add_separator ()
+                    .add_empty_mount_trash (() => {
+                        Marlin.FileOperations.empty_trash_for_mount (this, mount);
+                    })
+                ;
+            }
+
+            if (mount.can_unmount ()) {
+                menu_builder.add_unmount (() => {eject ();});
+            } else if (mount.can_eject ()) {
+                menu_builder.add_eject (() => {eject ();});
+            }
+        }
+
+        menu_builder
+            .add_separator ()
+            .add_drive_property (() => {show_mount_info ();});
+
+
+    }
+
+    private void show_mount_info () {
+        if (!mounted && volume != null) {
+            /* Mount the device if possible, defer showing the dialog after
+             * we're done */
+            working = true;
+            Marlin.FileOperations.mount_volume_full.begin (volume, null, (obj, res) => {
+                try {
+                    mounted = Marlin.FileOperations.mount_volume_full.end (res);
+                } catch (Error e) {
+                    mounted = false;
+                    mount = null;
+                } finally {
+                    working = false;
+                }
+
+                if (mounted) {
+                    new Marlin.View.VolumePropertiesWindow (
+                        volume.get_mount (),
+                        Marlin.get_active_window ()
+                    );
+                }
+            });
+        } else if ((mount != null && mounted) || uri == Marlin.ROOT_FS_URI) {
+            new Marlin.View.VolumePropertiesWindow (
+                mount,
+                Marlin.get_active_window ()
+            );
+        }
+    }
+
+    protected virtual async void add_mountable_tooltip () {
+        set_tooltip_markup (PF.FileUtils.sanitize_path (uri, null, false));
+    }
+
+    public virtual void update_free_space () {}
+}

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -50,20 +50,20 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
         DeviceRow? bm = has_uuid (uuid, uri);
 
         if (bm == null || bm.custom_name != label) { //Could be a bind mount with the same uuid
-            bm = new DeviceRow (
+            var new_bm = new DeviceRow (
                 label,
                 uri,
                 gicon,
                 this,
                 pinned, // Pin all device rows for now
-                permanent, // Permanent devices (like "FileSystem" are always accessible)
+                permanent || (bm != null && bm.permanent), //Ensure bind mount matches permanence of uuid
                 uuid,
                 drive,
                 volume,
                 mount
             );
 
-            add (bm);
+            add (new_bm);
         }
 
         return bm;
@@ -166,7 +166,7 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
             */
             add_bookmark (
                 volume.get_name (),
-                volume.get_name (),
+                "", // Do not know uri until mounted
                 volume.get_icon (),
                 volume.get_uuid (),
                 null,
@@ -191,7 +191,7 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
 
         add_bookmark (
             mount.get_name (),
-            mount.get_root ().get_uri (),
+            mount.get_default_location ().get_uri (),
             mount.get_icon (),
             uuid,
             mount.get_drive (),

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -49,6 +49,7 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
 
         DeviceRow? bm = has_uuid (uuid, uri);
 
+        if (bm == null || bm.custom_name != label) { //Could be a bind mount with the same uuid
         if (bm == null) {
             bm = new DeviceRow (
                 label,

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -50,7 +50,6 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
         DeviceRow? bm = has_uuid (uuid, uri);
 
         if (bm == null || bm.custom_name != label) { //Could be a bind mount with the same uuid
-        if (bm == null) {
             bm = new DeviceRow (
                 label,
                 uri,
@@ -65,17 +64,6 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
             );
 
             add (bm);
-        }
-
-        if (mount != null) {
-            bm.mounted = true;
-            bm.can_eject = mount.can_unmount () || mount.can_eject ();
-        } else if (volume != null) {
-            bm.mounted = volume.get_mount () != null;
-            bm.can_eject = volume.can_eject ();
-        } else if (drive != null) {
-            bm.mounted = true;
-            bm.can_eject = drive.can_eject () || drive.can_stop ();
         }
 
         return bm;
@@ -103,7 +91,7 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
         var root_uri = _(Marlin.ROOT_FS_URI);
         if (root_uri != "") {
             row = add_bookmark (
-                _("FileSystem"),
+                _("File System"),
                 root_uri,
                 new ThemedIcon.with_default_fallbacks (Marlin.ICON_FILESYSTEM),
                 null,

--- a/src/View/Sidebar/DeviceRow.vala
+++ b/src/View/Sidebar/DeviceRow.vala
@@ -20,118 +20,19 @@
  * Authors : Jeremy Wootten <jeremy@elementaryos.org>
  */
 
-public class Sidebar.DeviceRow : Sidebar.BookmarkRow, SidebarItemInterface {
-    private static Gtk.CssProvider devicerow_provider;
-
-    private Gtk.Stack mount_eject_stack;
-    private Gtk.Revealer mount_eject_revealer;
-    private Gtk.Spinner mount_eject_spinner;
-
-    private bool _mounted = false;
-    private bool valid = true;
+public class Sidebar.DeviceRow : Sidebar.AbstractMountableRow {
     private double storage_capacity = 0;
     private double storage_free = 0;
     private string storage_text = "";
 
     public Gtk.LevelBar storage_levelbar { get; set construct; }
-    public string? uuid { get; set construct; }
-    public Drive? drive { get; set construct; }
-    public Volume? volume { get; set construct; }
-    public Mount? mount { get; set construct; }
-
-    public bool mounted {
-        get {
-            return _mounted;
-        }
-
-        set {
-            _mounted = value;
-             mount_eject_revealer.reveal_child = _mounted && _can_eject;
-        }
-    }
-
-    private bool _can_eject = true;
-    public bool can_eject {
-        get {
-            return _can_eject;
-        }
-
-        set {
-            _can_eject = value;
-             mount_eject_revealer.reveal_child = _can_eject && _mounted;
-        }
-    }
-
-    public bool working {
-        get {
-            return mount_eject_stack.visible_child_name == "spinner";
-        }
-
-        set {
-            if (!valid) {
-                return;
-            }
-
-            if (value) {
-                mount_eject_revealer.reveal_child = true;
-                mount_eject_stack.visible_child_name = "spinner";
-                mount_eject_spinner.start ();
-            } else {
-                mount_eject_spinner.stop ();
-                mount_eject_stack.visible_child_name = "eject";
-            }
-
-            mount_eject_revealer.reveal_child = _mounted && _can_eject;
-        }
-    }
 
     public DeviceRow (string name, string uri, Icon gicon, SidebarListInterface list,
                       bool pinned, bool permanent,
                       string? _uuid, Drive? drive, Volume? volume, Mount? mount) {
-        Object (
-            custom_name: name,
-            uri: uri,
-            gicon: gicon,
-            list: list,
-            pinned: pinned,
-            permanent: permanent,
-            uuid: _uuid,
-            drive: drive,
-            volume: volume,
-            mount: mount
-        );
+        base (name, uri, gicon, list, pinned, permanent, _uuid, drive, volume, mount);
     }
-
-    static construct {
-        devicerow_provider = new Gtk.CssProvider ();
-        devicerow_provider.load_from_resource ("/io/elementary/files/DiskRenderer.css");
-    }
-
     construct {
-        var eject_button = new Gtk.Button.from_icon_name ("media-eject-symbolic", Gtk.IconSize.MENU) {
-            tooltip_text = _("Eject '%s'").printf (custom_name)
-        };
-        eject_button.get_style_context ().add_provider (devicerow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-        mount_eject_spinner = new Gtk.Spinner ();
-
-        mount_eject_stack = new Gtk.Stack () {
-            margin_start = 6,
-            transition_type = Gtk.StackTransitionType.CROSSFADE
-        };
-        mount_eject_stack.add_named (eject_button, "eject");
-        mount_eject_stack.add_named (mount_eject_spinner, "spinner");
-        mount_eject_stack.visible_child_name = "eject";
-
-        mount_eject_revealer = new Gtk.Revealer () {
-            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT,
-            valign = Gtk.Align.CENTER
-        };
-        mount_eject_revealer.add (mount_eject_stack);
-        mount_eject_revealer.reveal_child = false;
-
-        content_grid.attach (mount_eject_revealer, 1, 0);
-
         storage_levelbar = new Gtk.LevelBar () {
             value = 0.5,
             hexpand = true
@@ -146,272 +47,6 @@ public class Sidebar.DeviceRow : Sidebar.BookmarkRow, SidebarItemInterface {
         storage_style_context.add_provider (devicerow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         icon_label_grid.attach (storage_levelbar, 1, 1);
-
-        show_all ();
-
-        var volume_monitor = VolumeMonitor.@get ();
-        volume_monitor.volume_removed.connect (volume_removed);
-        volume_monitor.mount_removed.connect (mount_removed);
-        volume_monitor.mount_added.connect (mount_added);
-        volume_monitor.drive_disconnected.connect (drive_removed);
-
-        add_device_tooltip.begin ();
-
-        eject_button.clicked.connect (() => {
-            eject ();
-        });
-    }
-
-    protected override void update_plugin_data (Marlin.SidebarPluginItem item) {
-        base.update_plugin_data (item);
-        working = item.show_spinner;
-    }
-
-    protected override void activated (Marlin.OpenFlag flag = Marlin.OpenFlag.DEFAULT) {
-        if (working) {
-            return;
-        }
-
-        if (mounted || permanent) { //Permanent devices are always accessible
-            list.open_item (this, flag);
-            return;
-        }
-
-        if (volume != null) {
-            working = true;
-            volume.mount.begin (
-                GLib.MountMountFlags.NONE,
-                new Gtk.MountOperation (Marlin.get_active_window ()),
-                null,
-                (obj, res) => {
-                    try {
-                        volume.mount.end (res);
-                        mount = volume.get_mount ();
-                        if (mount != null) {
-                            mounted = true;
-                            can_eject = mount.can_unmount () || mount.can_eject ();
-                            uri = mount.get_default_location ().get_uri ();
-                            list.open_item (this, flag);
-                        }
-                    } catch (GLib.Error error) {
-                        var primary = _("Error mounting volume '%s'").printf (volume.get_name ());
-                        PF.Dialogs.show_error_dialog (primary, error.message, Marlin.get_active_window ());
-                    } finally {
-                        working = false;
-                        add_device_tooltip.begin ();
-                    }
-                }
-            );
-        } else if (drive != null && (drive.can_start () || drive.can_start_degraded ())) {
-            working = true;
-            drive.start.begin (
-               DriveStartFlags.NONE,
-               new Gtk.MountOperation (null),
-               null,
-               (obj, res) => {
-                    try {
-                        if (drive.start.end (res)) {
-                            mounted = true;
-                            can_eject = drive.can_eject () || drive.can_stop ();
-                        }
-                    } catch (Error e) {
-                            var primary = _("Unable to start '%s'").printf (drive.get_name ());
-                            PF.Dialogs.show_error_dialog (primary, e.message, Marlin.get_active_window ());
-                    } finally {
-                        working = false;
-                        add_device_tooltip.begin ();
-                    }
-                }
-            );
-        }
-    }
-
-    private void eject () {
-        if (working || !valid) {
-            return;
-        }
-
-        var mount_op = new Gtk.MountOperation (Marlin.get_active_window ());
-        if (!permanent && mounted && mount != null) {
-            if (mount.can_eject ()) {
-                working = true;
-                mount.eject_with_operation.begin (
-                    GLib.MountUnmountFlags.NONE,
-                    mount_op,
-                    null,
-                    (obj, res) => {
-                        try {
-                            mounted = !mount.eject_with_operation.end (res);
-                        } catch (GLib.Error error) {
-                            warning ("Error ejecting mount '%s': %s", mount.get_name (), error.message);
-                        } finally {
-                            working = false;
-                            if (!mounted) {
-                                mount = null;
-                            }
-                        }
-                    }
-                );
-
-                return;
-            } else if (mount.can_unmount ()) {
-                working = true;
-                mount.unmount_with_operation.begin (
-                    GLib.MountUnmountFlags.NONE,
-                    mount_op,
-                    null,
-                    (obj, res) => {
-                        try {
-                            mounted = !mount.unmount_with_operation.end (res);
-                        } catch (GLib.Error error) {
-                            warning ("Error while unmounting mount '%s': %s", mount.get_name (), error.message);
-                        } finally {
-                            working = false;
-                            if (!mounted) {
-                                mount = null;
-                            }
-                        }
-                    }
-                );
-            }
-        } else if (drive != null && drive.can_eject () || drive.can_stop ()) {
-            working = true;
-            if (drive.can_stop ()) {
-                drive.stop.begin (
-                    GLib.MountUnmountFlags.NONE,
-                    mount_op,
-                    null,
-                    (obj, res) => {
-                        try {
-                            mounted = drive.stop.end (res);
-                        } catch (Error e) {
-                            warning ("Could not stop drive '%s': %s", drive.get_name (), e.message);
-                        } finally {
-                            working = false;
-                            if (!mounted) {
-                                mount = null;
-                            }
-                        }
-                    }
-                );
-            } else if (drive.can_eject ()) {
-                drive.eject_with_operation.begin (
-                    GLib.MountUnmountFlags.NONE,
-                    mount_op,
-                    null,
-                    (obj, res) => {
-                        try {
-                            mounted = drive.eject_with_operation.end (res);
-                        } catch (Error e) {
-                            warning ("Could not eject drive '%s': %s", drive.get_name (), e.message);
-                        } finally {
-                            working = false;
-                            if (!mounted) {
-                                mount = null;
-                            }
-                        }
-                    }
-                );
-            }
-        }
-    }
-
-    private void drive_removed (Drive removed_drive) {
-        if (valid && drive == removed_drive) {
-            valid = false;
-            list.remove_item_by_id (id);
-        }
-    }
-
-    private void volume_removed (Volume removed_volume) {
-        if (valid && volume == removed_volume) {
-            valid = false;
-            list.remove_item_by_id (id);
-        }
-    }
-
-    /* This handler gets spammed by the monitor! */
-    private void mount_removed (Mount removed_mount) {
-        if (valid && !working && mounted && mount == removed_mount) {
-            if (drive == null && volume == null) {
-                valid = false;
-                list.remove_item_by_id (id);
-            } else {
-                mounted = false;
-                mount = null;
-            }
-        }
-    }
-
-    /* This gets spammed by VolumeMonitor! */
-    private void mount_added (Mount added_mount) {
-        if (working || permanent || volume == null) {
-            return;
-        }
-        working = true;
-        var added_volume = added_mount.get_volume ();
-
-        if (volume.get_name () == added_volume.get_name () &&
-            (mount == null || (mount.get_name () == added_mount.get_name ()))) {
-            mount = added_mount;
-            mounted = true;
-        }
-        working = false;
-    }
-
-    protected override void add_extra_menu_items (PopupMenuBuilder menu_builder) {
-        if (mount != null && mounted) {
-            if (Marlin.FileOperations.has_trash_files (mount)) {
-                menu_builder
-                    .add_separator ()
-                    .add_empty_mount_trash (() => {
-                        Marlin.FileOperations.empty_trash_for_mount (this, mount);
-                    })
-                ;
-            }
-
-            if (mount.can_unmount ()) {
-                menu_builder.add_unmount (() => {eject ();});
-            } else if (mount.can_eject ()) {
-                menu_builder.add_eject (() => {eject ();});
-            }
-        }
-
-        menu_builder
-            .add_separator ()
-            .add_drive_property (() => {show_mount_info ();});
-
-
-    }
-
-    private void show_mount_info () {
-        if (!mounted && volume != null) {
-            /* Mount the device if possible, defer showing the dialog after
-             * we're done */
-            working = true;
-            Marlin.FileOperations.mount_volume_full.begin (volume, null, (obj, res) => {
-                try {
-                    mounted = Marlin.FileOperations.mount_volume_full.end (res);
-                } catch (Error e) {
-                    mounted = false;
-                    mount = null;
-                } finally {
-                    working = false;
-                }
-
-                if (mounted) {
-                    new Marlin.View.VolumePropertiesWindow (
-                        volume.get_mount (),
-                        Marlin.get_active_window ()
-                    );
-                }
-            });
-        } else if ((mount != null && mounted) || uri == Marlin.ROOT_FS_URI) {
-            new Marlin.View.VolumePropertiesWindow (
-                mount,
-                Marlin.get_active_window ()
-            );
-        }
     }
 
     private async bool get_filesystem_space (Cancellable? update_cancellable) {
@@ -424,7 +59,7 @@ public class Sidebar.DeviceRow : Sidebar.BookmarkRow, SidebarItemInterface {
 
         File root;
         string scheme = Uri.parse_scheme (uri);
-        if ("sftp davs".contains (scheme)) {
+        if (scheme == null || "sftp davs".contains (scheme)) {
             return false; /* Cannot get info from these protocols */
         }
 
@@ -468,7 +103,7 @@ public class Sidebar.DeviceRow : Sidebar.BookmarkRow, SidebarItemInterface {
         }
     }
 
-    private async void add_device_tooltip () {
+    protected override async void add_mountable_tooltip () {
         if (yield get_filesystem_space (null)) {
             storage_levelbar.@value = (storage_capacity - storage_free) / storage_capacity;
             storage_levelbar.show ();
@@ -493,7 +128,7 @@ public class Sidebar.DeviceRow : Sidebar.BookmarkRow, SidebarItemInterface {
         set_tooltip_markup (PF.FileUtils.sanitize_path (uri, null, false) + storage_text);
     }
 
-    public void update_free_space () {
-        add_device_tooltip.begin ();
+    public override void update_free_space () {
+        add_mountable_tooltip.begin ();
     }
 }

--- a/src/View/Sidebar/NetworkListBox.vala
+++ b/src/View/Sidebar/NetworkListBox.vala
@@ -33,19 +33,19 @@ public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface 
         volume_monitor.mount_added.connect (bookmark_mount_if_not_native_and_not_shadowed);
     }
 
-    private SidebarItemInterface? add_bookmark (string label, string uri, Icon gicon) {
-        var row = new NetworkRow (label, uri, gicon, this, true, true); //Pin all network rows for now
+    private SidebarItemInterface? add_bookmark (string label, string uri, Icon gicon, Mount? mount) {
+        NetworkRow? row = null;
+
         if (!has_uri (uri)) {
+            row = new NetworkRow (label, uri, gicon, this, mount);
             add (row);
-        } else {
-            return null;
         }
 
         return row;
     }
 
     public override uint32 add_plugin_item (Marlin.SidebarPluginItem plugin_item) {
-        var row = add_bookmark (plugin_item.name, plugin_item.uri, plugin_item.icon);
+        var row = add_bookmark (plugin_item.name, plugin_item.uri, plugin_item.icon, null);
 
         row.update_plugin_data (plugin_item);
 
@@ -61,7 +61,8 @@ public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface 
         add_bookmark (
             mount.get_name (),
             mount.get_default_location ().get_uri (),
-            mount.get_icon ()
+            mount.get_icon (),
+            mount
         );
         //Show extra info in tooltip
     }
@@ -80,7 +81,8 @@ public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface 
         var row = add_bookmark (
             _("Entire Network"),
             Marlin.NETWORK_URI,
-            new ThemedIcon (Marlin.ICON_NETWORK)
+            new ThemedIcon (Marlin.ICON_NETWORK),
+            null
         );
 
         row.set_tooltip_markup (

--- a/src/View/Sidebar/NetworkListBox.vala
+++ b/src/View/Sidebar/NetworkListBox.vala
@@ -74,10 +74,6 @@ public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface 
             return;
         }
 
-        foreach (unowned Mount mount in VolumeMonitor.@get ().get_mounts ()) {
-            bookmark_mount_if_not_native_and_not_shadowed (mount);
-        }
-
         var row = add_bookmark (
             _("Entire Network"),
             Marlin.NETWORK_URI,
@@ -88,6 +84,10 @@ public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface 
         row.set_tooltip_markup (
             Granite.markup_accel_tooltip ({"<Alt>N"}, _("Browse the contents of the network"))
         );
+
+        foreach (unowned Mount mount in VolumeMonitor.@get ().get_mounts ()) {
+            bookmark_mount_if_not_native_and_not_shadowed (mount);
+        }
     }
 
     public void unselect_all_items () {

--- a/src/View/Sidebar/NetworkRow.vala
+++ b/src/View/Sidebar/NetworkRow.vala
@@ -1,6 +1,6 @@
 /* NetworkRow.vala
  *
- * Copyright 2020 elementary LLC. <https://elementary.io>
+ * Copyright 2020-21 elementary LLC. <https://elementary.io>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,10 +20,16 @@
  * Authors : Jeremy Wootten <jeremy@elementaryos.org>
  */
 
-//~ public class Sidebar.NetworkRow : Sidebar.BookmarkRow {
 public class Sidebar.NetworkRow : Sidebar.AbstractMountableRow {
-    public NetworkRow (string name, string uri, Icon gicon, SidebarListInterface list, Mount? mount) {
-        // Pinned, permanent, no uuid, drive or volume
-        base (name, uri, gicon, list, true, true, null, null, null, mount);
+    public NetworkRow (
+        string name, string uri, Icon gicon, SidebarListInterface list, Mount? mount
+    ) {
+
+        base (
+            name, uri, gicon, list,
+            true, // Pinned,
+            mount == null || !mount.can_unmount (), // permanent if no mount or unmountable,
+            null, null, null, //No uuid, drive or volume
+            mount);
     }
 }

--- a/src/View/Sidebar/NetworkRow.vala
+++ b/src/View/Sidebar/NetworkRow.vala
@@ -20,16 +20,10 @@
  * Authors : Jeremy Wootten <jeremy@elementaryos.org>
  */
 
-public class Sidebar.NetworkRow : Sidebar.BookmarkRow {
-    public NetworkRow (string name, string uri, Icon gicon, SidebarListInterface list,
-                        bool pinned, bool permanent) {
-        Object (
-            custom_name: name,
-            uri: uri,
-            gicon: gicon,
-            list: list,
-            pinned: pinned,
-            permanent: permanent
-        );
+//~ public class Sidebar.NetworkRow : Sidebar.BookmarkRow {
+public class Sidebar.NetworkRow : Sidebar.AbstractMountableRow {
+    public NetworkRow (string name, string uri, Icon gicon, SidebarListInterface list, Mount? mount) {
+        // Pinned, permanent, no uuid, drive or volume
+        base (name, uri, gicon, list, true, true, null, null, null, mount);
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,7 @@ pantheon_files_exec = executable (
     'View/Sidebar/SidebarWindow.vala',
     'View/Sidebar/BookmarkListBox.vala',
     'View/Sidebar/DeviceListBox.vala',
+    'View/Sidebar/AbstractMountableRow.vala',
     'View/Sidebar/NetworkListBox.vala',
     'View/Sidebar/BookmarkRow.vala',
     'View/Sidebar/DeviceRow.vala',


### PR DESCRIPTION
Return early when sudo used on commandline.  Only output warning message.

Similar to https://github.com/elementary/code/pull/951.  