### PR TITLE
Prevent extraneous output when attempting sudo

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -72,15 +72,6 @@ public class Marlin.Application : Gtk.Application {
             Granite.Services.Logger.DisplayLevel = Granite.Services.LogLevel.INFO;
         }
 
-        message ("Report any issues/bugs you might find to https://github.com/elementary/files/issues");
-
-        /* Only allow running with root privileges using pkexec, not using sudo */
-        if (Marlin.is_admin () && GLib.Environment.get_variable ("PKEXEC_UID") == null) {
-            warning ("Running Files as root using sudo is not possible. " +
-                     "Please use the command: io.elementary.files-pkexec [folder]");
-            quit ();
-        };
-
         init_schemas ();
 
         Gtk.IconTheme.get_default ().changed.connect (() => {
@@ -130,6 +121,15 @@ public class Marlin.Application : Gtk.Application {
     }
 
     public override int command_line (ApplicationCommandLine cmd) {
+        /* Only allow running with root privileges using pkexec, not using sudo */
+        if (Marlin.is_admin () && GLib.Environment.get_variable ("PKEXEC_UID") == null) {
+            warning ("Running Files as root using sudo is not possible. " +
+                     "Please use the command: io.elementary.files-pkexec [folder]");
+            quit ();
+            return 1;
+        };
+
+        message ("Report any issues/bugs you might find to https://github.com/elementary/files/issues");
         this.hold ();
         int result = _command_line (cmd);
         this.release ();


### PR DESCRIPTION
Move message and sudo test into `command_line ()` & return early.

Similar to https://github.com/elementary/code/pull/951