### PR TITLE
ConnectServerDialog: Use Granite.ValidatedEntry

### DIFF
--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -181,8 +181,8 @@ public class PF.ConnectServerDialog : Granite.Dialog {
         var share_label = new DetailLabel (_("Share:"), share_entry);
 
         folder_entry = new Gtk.Entry () {
-            placeholder_text = "/",
-            tooltip_text = _("Path of shared folder on server")
+            placeholder_text = _("Path of shared folder on server"),
+            text = "/"
         };
 
         var folder_label = new DetailLabel (_("Folder:"), folder_entry);

--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -130,10 +130,16 @@ public class PF.ConnectServerDialog : Granite.Dialog {
 
         var server_header_label = new Granite.HeaderLabel (_("Server Details"));
 
-        server_entry = new Granite.ValidatedEntry () {
-            hexpand = true,
-            placeholder_text = _("Server name or IP address")
-        };
+        try {
+            var server_regex = new Regex ("""^[^\s]+\.[^\s]+$""");
+            server_entry = new Granite.ValidatedEntry.from_regex (server_regex);
+        } catch (Error e) {
+            server_entry = new Granite.ValidatedEntry ();
+            critical (e.message);
+        }
+
+        server_entry.hexpand = true;
+        server_entry.placeholder_text = _("Server name or IP address");
 
         var server_label = new DetailLabel (_("Server:"), server_entry);
 
@@ -314,7 +320,6 @@ public class PF.ConnectServerDialog : Granite.Dialog {
         type_combobox.changed.connect (() => type_changed ());
 
         server_entry.changed.connect (() => {
-            server_entry.is_valid = server_entry.text.length > 3;
             set_button_sensitivity ();
         });
 

--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -297,6 +297,8 @@ public class PF.ConnectServerDialog : Granite.Dialog {
         content_area.add (stack);
         content_area.add (button_box);
 
+        default_width = 400;
+
         /* skip methods that don't have corresponding gvfs uri schemes */
         unowned string[] supported_schemes = GLib.Vfs.get_default ().get_supported_uri_schemes ();
         foreach (var method in methods) {

--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -425,7 +425,7 @@ public class PF.ConnectServerDialog : Granite.Dialog {
 
     private bool valid_entries () {
         bool valid = server_entry.is_valid &&
-            (user_entry.is_valid ||!user_entry.visible) &&
+            (user_entry.is_valid || !user_entry.visible) &&
             (domain_entry.is_valid || !domain_entry.visible) &&
             (password_entry.is_valid || !password_entry.visible);
 

--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -133,7 +133,7 @@ public class PF.ConnectServerDialog : Granite.Dialog {
 
         server_entry = new Granite.ValidatedEntry () {
             hexpand = true,
-            tooltip_text = _("Server name or IP address")
+            placeholder_text = _("Server name or IP address")
         };
 
         var server_label = new DetailLabel (_("Server:"), server_entry);
@@ -191,14 +191,16 @@ public class PF.ConnectServerDialog : Granite.Dialog {
         user_header_label = new Granite.HeaderLabel (_("User Details"));
 
         domain_entry = new Granite.ValidatedEntry () {
-            placeholder_text = "WORKGROUP",
-            tooltip_text = _("Name of Windows domain")
+            is_valid = true,
+            text = "WORKGROUP",
+            placeholder_text = _("Name of Windows domain")
         };
         var domain_label = new DetailLabel (_("Domain name:"), domain_entry);
 
         user_entry = new Granite.ValidatedEntry () {
-            placeholder_text = Environment.get_user_name (),
-            tooltip_text = _("Name of user on server")
+            is_valid = true,
+            text = Environment.get_user_name (),
+            placeholder_text = _("Name of user on server")
         };
         var user_label = new DetailLabel (_("User name:"), user_entry);
 
@@ -318,17 +320,17 @@ public class PF.ConnectServerDialog : Granite.Dialog {
         });
 
         user_entry.changed.connect (() => {
-            user_entry.is_valid = true;
+            user_entry.is_valid = user_entry.text.length > 0;
             set_button_sensitivity ();
         });
 
         domain_entry.changed.connect (() => {
-            domain_entry.is_valid = true;
+            domain_entry.is_valid = domain_entry.text.length > 0;
             set_button_sensitivity ();
         });
 
         password_entry.changed.connect (() => {
-            password_entry.is_valid = true;
+            password_entry.is_valid = password_entry.text.length > 0;
             set_button_sensitivity ();
         });
     }

--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -319,9 +319,7 @@ public class PF.ConnectServerDialog : Granite.Dialog {
 
         type_combobox.changed.connect (() => type_changed ());
 
-        server_entry.changed.connect (() => {
-            set_button_sensitivity ();
-        });
+        server_entry.changed.connect (set_button_sensitivity);
 
         user_entry.changed.connect (() => {
             user_entry.is_valid = user_entry.text.length > 0;

--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -116,7 +116,6 @@ public class PF.ConnectServerDialog : Granite.Dialog {
     }
 
     construct {
-        deletable = false;
         resizable = false;
 
         info_label = new Gtk.Label (null);
@@ -176,7 +175,7 @@ public class PF.ConnectServerDialog : Granite.Dialog {
         var type_label = new DetailLabel (_("Type:"), type_combobox);
 
         share_entry = new Gtk.Entry () {
-            tooltip_text = _("Name of share on server")
+            placeholder_text = _("Name of share on server")
         };
 
         var share_label = new DetailLabel (_("Share:"), share_entry);

--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -116,8 +116,6 @@ public class PF.ConnectServerDialog : Granite.Dialog {
     }
 
     construct {
-        resizable = false;
-
         info_label = new Gtk.Label (null);
 
         info_bar = new Gtk.InfoBar () {
@@ -130,16 +128,10 @@ public class PF.ConnectServerDialog : Granite.Dialog {
 
         var server_header_label = new Granite.HeaderLabel (_("Server Details"));
 
-        try {
-            var server_regex = new Regex ("""^[^\s]+\.[^\s]+$""");
-            server_entry = new Granite.ValidatedEntry.from_regex (server_regex);
-        } catch (Error e) {
-            server_entry = new Granite.ValidatedEntry ();
-            critical (e.message);
-        }
-
-        server_entry.hexpand = true;
-        server_entry.placeholder_text = _("Server name or IP address");
+        server_entry = new Granite.ValidatedEntry () {
+            hexpand = true,
+            placeholder_text = _("Server name or IP address")
+        };
 
         var server_label = new DetailLabel (_("Server:"), server_entry);
 
@@ -181,13 +173,13 @@ public class PF.ConnectServerDialog : Granite.Dialog {
         var type_label = new DetailLabel (_("Type:"), type_combobox);
 
         share_entry = new Gtk.Entry () {
-            placeholder_text = _("Name of share on server")
+            placeholder_text = _("Name of share on server (Optional)")
         };
 
         var share_label = new DetailLabel (_("Share:"), share_entry);
 
         folder_entry = new Gtk.Entry () {
-            placeholder_text = _("Path of shared folder on server"),
+            placeholder_text = _("Path of shared folder on server (Optional)"),
             text = "/"
         };
 
@@ -248,7 +240,8 @@ public class PF.ConnectServerDialog : Granite.Dialog {
 
         var grid = new Gtk.Grid () {
             row_spacing = 6,
-            column_spacing = 6
+            column_spacing = 6,
+            vexpand = true
         };
 
         grid.attach (info_bar, 0, 0, 2, 1);
@@ -319,7 +312,10 @@ public class PF.ConnectServerDialog : Granite.Dialog {
 
         type_combobox.changed.connect (() => type_changed ());
 
-        server_entry.changed.connect (set_button_sensitivity);
+        server_entry.changed.connect (() => {
+            server_entry.is_valid = server_entry.text.length > 3;
+            set_button_sensitivity ();
+        });
 
         user_entry.changed.connect (() => {
             user_entry.is_valid = user_entry.text.length > 0;

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: marlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-02-18 13:28+0000\n"
-"PO-Revision-Date: 2021-02-24 16:52+0000\n"
+"PO-Revision-Date: 2021-02-24 22:16+0000\n"
 "Last-Translator: Uwe S <saabisto@gmx.de>\n"
 "Language-Team: German <https://l10n.elementary.io/projects/files/files/de/>\n"
 "Language: de\n"
@@ -41,7 +41,7 @@ msgstr "Nachrichten zur Fehlerdiagnose anzeigen"
 
 #: src/Application.vala:169
 msgid "[URI…]"
-msgstr "[Adresse…]"
+msgstr "[Adresse …]"
 
 #: src/Application.vala:172
 msgid ""
@@ -431,7 +431,7 @@ msgstr "Aus dem Verlauf entfernen"
 
 #: src/View/AbstractDirectoryView.vala:2033
 msgid "Rename…"
-msgstr "Umbenennen…"
+msgstr "Umbenennen …"
 
 #: src/View/AbstractDirectoryView.vala:2040
 msgid "Copy as Link"
@@ -772,7 +772,7 @@ msgstr "Ordner neu laden"
 
 #: src/View/Widgets/LocationBar.vala:207
 msgid "Searching…"
-msgstr "Suchen…"
+msgstr "Suchen …"
 
 #: src/View/Widgets/OverlayBar.vala:209
 #, c-format
@@ -945,7 +945,7 @@ msgstr "Weiter"
 
 #: libcore/ConnectServerDialog.vala:249
 msgid "Connecting…"
-msgstr "Verbindungsaufbau…"
+msgstr "Verbinden …"
 
 #: libcore/ConnectServerDialog.vala:371
 msgid "Please verify your user details."
@@ -1444,7 +1444,7 @@ msgstr ""
 msgid "Cannot move file to trash.  Try to delete it?"
 msgstr ""
 "Datei konnte nicht in den Papierkorb verschoben werden. Soll die Datei "
-"komplett gelöscht werden?"
+"sofort gelöscht werden?"
 
 #: libcore/marlin-file-operations.c:843
 msgid ""
@@ -1478,8 +1478,8 @@ msgstr "Dateien werden gelöscht"
 #, c-format
 msgid "Preparing to copy %'d file (%s)"
 msgid_plural "Preparing to copy %'d files (%s)"
-msgstr[0] "Kopieren von %'d Datei wird vorbereitet (%s)"
-msgstr[1] "Kopieren von %'d Dateien wird vorbereitet (%s)"
+msgstr[0] "Kopieren von %'d Datei vorbereiten (%s)"
+msgstr[1] "Kopieren von %'d Dateien vorbereiten (%s)"
 
 #. TRANSLATORS: %'d is a placeholder for a number. It must be translated or removed.
 #. %s is a placeholder for a size like "2 bytes" or "3 MB".  It must not be translated or removed.
@@ -1489,8 +1489,8 @@ msgstr[1] "Kopieren von %'d Dateien wird vorbereitet (%s)"
 #, c-format
 msgid "Preparing to move %'d file (%s)"
 msgid_plural "Preparing to move %'d files (%s)"
-msgstr[0] "Verschieben von %'d Datei wird vorbereitet (%s)"
-msgstr[1] "Verschieben von %'d Dateien wird vorbereitet (%s)"
+msgstr[0] "Verschieben von %'d Datei vorbereiten (%s)"
+msgstr[1] "Verschieben von %'d Dateien vorbereiten (%s)"
 
 #. TRANSLATORS: %'d is a placeholder for a number. It must be translated or removed.
 #. %s is a placeholder for a size like "2 bytes" or "3 MB".  It must not be translated or removed.
@@ -1500,15 +1500,15 @@ msgstr[1] "Verschieben von %'d Dateien wird vorbereitet (%s)"
 #, c-format
 msgid "Preparing to delete %'d file (%s)"
 msgid_plural "Preparing to delete %'d files (%s)"
-msgstr[0] "Entfernen von %'d Datei wird vorbereitet (%s)"
-msgstr[1] "Entfernen von %'d Dateien wird vorbereitet (%s)"
+msgstr[0] "Entfernen von %'d Datei vorbereiten (%s)"
+msgstr[1] "Entfernen von %'d Dateien vorbereiten (%s)"
 
 #: libcore/marlin-file-operations.c:1104
 #, c-format
 msgid "Preparing to trash %'d file"
 msgid_plural "Preparing to trash %'d files"
-msgstr[0] "Verschieben von %'d Datei in den Papierkorb wird vorbereitet"
-msgstr[1] "Verschieben von %'d Dateien in den Papierkorb wird vorbereitet"
+msgstr[0] "Verschieben von %'d Datei in den Papierkorb vorbereiten"
+msgstr[1] "Verschieben von %'d Dateien in den Papierkorb vorbereiten"
 
 #: libcore/marlin-file-operations.c:1135 libcore/marlin-file-operations.c:2061
 #: libcore/marlin-file-operations.c:2203 libcore/marlin-file-operations.c:2257
@@ -1592,7 +1592,7 @@ msgid ""
 "There is not enough space on the destination. Try to remove files to make "
 "space."
 msgstr ""
-"Am Ziel ist nicht genügend freier Platz. Entfernen Sie einige Dateien, um "
+"Am Ziel ist nicht ausreichend freier Platz. Entfernen Sie einige Dateien, um "
 "Platz zu schaffen."
 
 #. TRANSLATORS: %s is a placeholder for a size like "2 bytes" or "3 MB".  It must not be translated or removed.
@@ -1633,15 +1633,15 @@ msgstr "»%s« duplizieren"
 #, c-format
 msgid "Moving %'d file (in \"%s\") to \"%s\""
 msgid_plural "Moving %'d files (in \"%s\") to \"%s\""
-msgstr[0] "Verschieben von %'d Datei (in »%s«) nach »%s«"
-msgstr[1] "Verschieben von %'d Dateien (in »%s«) nach »%s«"
+msgstr[0] "%'d Datei (in »%s«) nach »%s« verschieben"
+msgstr[1] "%'d Dateien (in »%s«) nach »%s« verschieben"
 
 #: libcore/marlin-file-operations.c:1669
 #, c-format
 msgid "Copying %'d file (in \"%s\") to \"%s\""
 msgid_plural "Copying %'d files (in \"%s\") to \"%s\""
-msgstr[0] "Kopieren von %'d Datei (in »%s«) nach »%s«"
-msgstr[1] "Kopieren von %'d Dateien (in »%s«) nach »%s«"
+msgstr[0] "%'d Datei (in »%s«) nach »%s« kopieren"
+msgstr[1] "%'d Dateien (in »%s«) nach »%s« kopieren"
 
 #. TRANSLATORS: \"%s\" is a placeholder for the quoted basename of a file.  It may change position but must not be translated or removed.
 #. \" is an escaped quotation mark.  This may be replaced with another suitable character (escaped if necessary).
@@ -1649,8 +1649,8 @@ msgstr[1] "Kopieren von %'d Dateien (in »%s«) nach »%s«"
 #, c-format
 msgid "Duplicating %'d file (in \"%s\")"
 msgid_plural "Duplicating %'d files (in \"%s\")"
-msgstr[0] "Duplizieren von %'d Datei (in »%s«)"
-msgstr[1] "Duplizieren von %'d Dateien (in »%s«)"
+msgstr[0] "%'d Datei (in »%s«) duplizieren"
+msgstr[1] "%'d Dateien (in »%s«) duplizieren"
 
 #. TRANSLATORS: \"%s\" is a placeholder for the quoted basename of a file.  It may change position but must not be translated or removed.
 #. \" is an escaped quotation mark.  This may be replaced with another suitable character (escaped if necessary).
@@ -1660,22 +1660,22 @@ msgstr[1] "Duplizieren von %'d Dateien (in »%s«)"
 #, c-format
 msgid "Moving %'d file to \"%s\""
 msgid_plural "Moving %'d files to \"%s\""
-msgstr[0] "Verschieben von %'d Datei nach »%s«"
-msgstr[1] "Verschieben von %'d Dateien nach »%s«"
+msgstr[0] "%'d Datei nach »%s« verschieben"
+msgstr[1] "%'d Dateien nach »%s« verschieben"
 
 #: libcore/marlin-file-operations.c:1693
 #, c-format
 msgid "Copying %'d file to \"%s\""
 msgid_plural "Copying %'d files to \"%s\""
-msgstr[0] "Kopieren von %'d Datei nach »%s«"
-msgstr[1] "Kopieren von %'d Dateien nach »%s«"
+msgstr[0] "%'d Datei nach »%s« kopieren"
+msgstr[1] "%'d Dateien nach »%s« kopieren"
 
 #: libcore/marlin-file-operations.c:1699
 #, c-format
 msgid "Duplicating %'d file"
 msgid_plural "Duplicating %'d files"
-msgstr[0] "Duplizieren von %'d Datei"
-msgstr[1] "Duplizieren von %'d Dateien"
+msgstr[0] "%'d Datei duplizieren"
+msgstr[1] "%'d Dateien duplizieren"
 
 #. TRANSLATORS: %s is a placeholder for a size like "2 bytes" or "3 MB".  It must not be translated or removed. So this represents something like "4 kb of 4 MB".
 #: libcore/marlin-file-operations.c:1729
@@ -1801,8 +1801,8 @@ msgstr "Die Quelldatei würde durch das Ziel überschrieben werden."
 #, c-format
 msgid "Could not remove the already existing file with the same name in %s."
 msgstr ""
-"Die bereits vorhandene Datei mit dem gleichen Namen in %s konnte nicht "
-"entfernt werden."
+"Die bereits vorhandene Datei gleichen Namens in %s konnte nicht entfernt "
+"werden."
 
 #. TRANSLATORS: '\"%s\"' is a placeholder for the quoted basename of a file.  It may change position but must not be translated or removed
 #. '\"' is an escaped quoted mark.  This may be replaced with another suitable character (escaped if necessary)
@@ -1819,21 +1819,21 @@ msgstr "Beim Kopieren der Datei nach %s ist ein Fehler aufgetreten."
 
 #: libcore/marlin-file-operations.c:3254
 msgid "Copying Files"
-msgstr "Dateien werden kopiert"
+msgstr "Dateien kopieren"
 
 #. TRANSLATORS: '\"%s\"' is a placeholder for the quoted basename of a file.  It may change position but must not be translated or removed
 #. '\"' is an escaped quoted mark.  This may be replaced with another suitable character (escaped if necessary)
 #: libcore/marlin-file-operations.c:3289
 #, c-format
 msgid "Preparing to move to \"%s\""
-msgstr "Verschieben nach »%s« wird vorbereitet"
+msgstr "Verschieben nach »%s« vorbereiten"
 
 #: libcore/marlin-file-operations.c:3294
 #, c-format
 msgid "Preparing to move %'d file"
 msgid_plural "Preparing to move %'d files"
-msgstr[0] "Verschieben von %'d Datei wird vorbereitet"
-msgstr[1] "Verschieben von %'d Dateien wird vorbereitet"
+msgstr[0] "Verschieben von %'d Datei vorbereiten"
+msgstr[1] "Verschieben von %'d Dateien vorbereiten"
 
 #. TRANSLATORS: %s is a placeholder for the full path of a file.  It may change position but must not be translated or removed
 #: libcore/marlin-file-operations.c:3540
@@ -1850,13 +1850,13 @@ msgstr "Dateien werden verschoben"
 #: libcore/marlin-file-operations.c:3802
 #, c-format
 msgid "Creating links in \"%s\""
-msgstr "Verknüpfungen werden in \"%s\" erstellt"
+msgstr "Verknüpfungen werden in »%s« erstellt"
 
 #: libcore/marlin-file-operations.c:3807
 #, c-format
 msgid "Making link to %'d file"
 msgid_plural "Making links to %'d files"
-msgstr[0] "Verknüpfung mit %'d Datei wird angelegt"
+msgstr[0] "Verknüpfung mit %'d Datei anlegen"
 msgstr[1] "Verknüpfungen mit %'d Dateien werden angelegt"
 
 #. TRANSLATORS: %s is a placeholder for the basename of a file.  It may change position but must not be translated or removed
@@ -1880,7 +1880,7 @@ msgstr "Dieses Ablegeziel unterstützt keine symbolischen Verknüpfungen."
 #, c-format
 msgid "There was an error creating the symlink in %s."
 msgstr ""
-"Beim Erstellen der symbolischen Verknüpfung in \"%s\" ist ein Fehler "
+"Beim Erstellen der symbolischen Verknüpfung in »%s« ist ein Fehler "
 "aufgetreten."
 
 #: libcore/marlin-file-operations.c:4218
@@ -1945,7 +1945,7 @@ msgstr "Pfad eingeben"
 
 #: libwidgets/View/SearchResults.vala:82
 msgid "More Results …"
-msgstr "Weitere Suchergebnisse…"
+msgstr "Weitere Suchergebnisse …"
 
 #: libwidgets/View/SearchResults.vala:274
 msgid "In This Folder"


### PR DESCRIPTION
Looks like the only validation we're actually doing is that the entry isn't blank

This uses ValidatedEntry instead of a private widget. We now validate entries when they change, not every time any entry changes, and the logic for only validating shown entries is clearer