### PR TITLE
Hide network widgets when admin

### DIFF
--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -57,7 +57,9 @@ public class Sidebar.SidebarWindow : Gtk.Grid, Marlin.SidebarInterface {
         device_revealer.add (device_listbox);
 
         var network_expander = new SidebarExpander (_("Network")) {
-            tooltip_text = _("Devices and places available via a network")
+            tooltip_text = _("Devices and places available via a network"),
+            no_show_all = true,
+            visible = !Marlin.is_admin ()
         };
 
         var network_revealer = new Gtk.Revealer ();
@@ -80,10 +82,15 @@ public class Sidebar.SidebarWindow : Gtk.Grid, Marlin.SidebarInterface {
         var connect_server_button = new Gtk.Button.with_label (_("Connect Server…")) {
             always_show_image = true,
             image = new Gtk.Image.from_icon_name ("network-server-symbolic", Gtk.IconSize.MENU),
-            tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>C"})
+            tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>C"}),
+            no_show_all = true,
+            visible = !Marlin.is_admin ()
         };
 
-        var action_bar = new Gtk.ActionBar ();
+        var action_bar = new Gtk.ActionBar () {
+            no_show_all = true
+        };
+
         action_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         action_bar.add (connect_server_button);
 
@@ -96,6 +103,9 @@ public class Sidebar.SidebarWindow : Gtk.Grid, Marlin.SidebarInterface {
         plugins.sidebar_loaded (this);
 
         reload ();
+
+        //Hide actionbar for now when admin as only a hidden network related action is present
+        action_bar.visible = !Marlin.is_admin ();
         show_all ();
 
         Marlin.app_settings.bind (


### PR DESCRIPTION
Fixes regression since sidebar-listbox.  Network operations should be hidden when running as admin.