### PR TITLE
SidebarWindow: Rename “Devices” to “Storage”

### DIFF
--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -1,6 +1,6 @@
 /* SidebarWindow.vala
  *
- * Copyright 2020 elementary LLC. <https://elementary.io>
+ * Copyright 2020–2021 elementary, Inc. <https://elementary.io>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,7 +49,8 @@ public class Sidebar.SidebarWindow : Gtk.Grid, Marlin.SidebarInterface {
         var bookmark_revealer = new Gtk.Revealer ();
         bookmark_revealer.add (bookmark_listbox);
 
-        var device_expander = new SidebarExpander (_("Devices")) {
+        /// TRANSLATORS: Generic term for collection of storage devices, mount points, etc.
+        var device_expander = new SidebarExpander (_("Storage")) {
             tooltip_text = _("Internal and connected storage devices")
         };
 


### PR DESCRIPTION
Fixes #1615