### PR TITLE
Do not bypass SidebarItemInterface.activated ()

### DIFF
--- a/src/View/Sidebar/BookmarkListBox.vala
+++ b/src/View/Sidebar/BookmarkListBox.vala
@@ -43,7 +43,7 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
         });
         row_activated.connect ((row) => {
             if (row is SidebarItemInterface) {
-                open_item ((SidebarItemInterface) row);
+                ((SidebarItemInterface) row).activated ();
             }
         });
         row_selected.connect ((row) => {

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -39,7 +39,7 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
         volume_monitor.drive_connected.connect (bookmark_stoppable_or_removeable_drive_if_without_volumes);
         row_activated.connect ((row) => {
             if (row is SidebarItemInterface) {
-                open_item ((SidebarItemInterface) row);
+                ((SidebarItemInterface) row).activated ();
             }
         });
         row_selected.connect ((row) => {

--- a/src/View/Sidebar/NetworkListBox.vala
+++ b/src/View/Sidebar/NetworkListBox.vala
@@ -33,7 +33,7 @@ public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface 
         volume_monitor.mount_added.connect (bookmark_mount_if_not_native_and_not_shadowed);
         row_activated.connect ((row) => {
             if (row is SidebarItemInterface) {
-                open_item ((SidebarItemInterface) row);
+                ((SidebarItemInterface) row).activated ();
             }
         });
         row_selected.connect ((row) => {

--- a/src/View/Sidebar/SidebarItemInterface.vala
+++ b/src/View/Sidebar/SidebarItemInterface.vala
@@ -65,7 +65,7 @@ public interface Sidebar.SidebarItemInterface : Gtk.Widget {
     public virtual void add_extra_menu_items (PopupMenuBuilder menu_builder) {}
     public virtual void update_plugin_data (Marlin.SidebarPluginItem item) {}
 
-    protected virtual void activated (Marlin.OpenFlag flag = Marlin.OpenFlag.DEFAULT) {
+    public virtual void activated (Marlin.OpenFlag flag = Marlin.OpenFlag.DEFAULT) {
         list.open_item (this, flag);
     }
 }


### PR DESCRIPTION
Fixes regression caused by 012b7841a68649e4b68bf77361046a617faa1ddb where unmounted storage locations could not be opened.