### PR TITLE
Fix clicking on folder in Column view after mixed-mode

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -127,8 +127,8 @@ namespace FM {
         int drag_y = 0;
         int drag_button;
         uint drag_timer_id = 0;
-        GLib.List<GOF.File> source_drag_file_list = null;
-        Gdk.Atom current_target_type = Gdk.Atom.NONE;
+        protected GLib.List<GOF.File> source_drag_file_list = null;
+        protected Gdk.Atom current_target_type = Gdk.Atom.NONE;
 
         /* Used only when acting as drag destination */
         uint drag_scroll_timer_id = 0;

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -45,14 +45,15 @@ namespace FM {
 
         private bool not_double_click (Gdk.EventButton event, Gtk.TreePath? path) {
             if (double_click_timeout_id != 0) {
-                double_click_timeout_id = 0;
                 awaiting_double_click = false;
+                double_click_timeout_id = 0;
                 is_frozen = false;
 
-                if (should_activate) { /* button already released */
+                if (source_drag_file_list == null && selection_only_contains_folders (get_selected_files ())) {
                     activate_selected_items ();
                 }
             }
+
             return false;
         }
 


### PR DESCRIPTION
Fixes #1643 

* Do not activate if dragging
* Do not activate if selection contains non-folders
* Otherwise activate after double-click timeout