### PR TITLE
Reduce the use of the explicit namespace

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,8 +31,8 @@ namespace Marlin {
 public class Marlin.Application : Gtk.Application {
 
     private VolumeMonitor volume_monitor;
-    private Marlin.Progress.UIHandler progress_handler;
-    private Marlin.ClipboardManager clipboard;
+    private Progress.UIHandler progress_handler;
+    private ClipboardManager clipboard;
     private Gtk.RecentManager recent;
 
     private const int MARLIN_ACCEL_MAP_SAVE_DELAY = 15;
@@ -61,7 +61,7 @@ public class Marlin.Application : Gtk.Application {
         gtk_file_chooser_settings = new Settings ("org.gtk.Settings.FileChooser");
 
         /* Needed by Glib.Application */
-        this.application_id = Marlin.APP_ID; //Ensures an unique instance.
+        this.application_id = APP_ID; //Ensures an unique instance.
         this.flags |= ApplicationFlags.HANDLES_COMMAND_LINE;
     }
 
@@ -78,13 +78,13 @@ public class Marlin.Application : Gtk.Application {
             Marlin.IconInfo.clear_caches ();
         });
 
-        progress_handler = new Marlin.Progress.UIHandler ();
+        progress_handler = new Progress.UIHandler ();
 
-        this.clipboard = Marlin.ClipboardManager.get_for_display ();
+        this.clipboard = ClipboardManager.get_for_display ();
         this.recent = new Gtk.RecentManager ();
 
         /* Global static variable "plugins" declared in PluginManager.vala */
-        plugins = new Marlin.PluginManager (Config.PLUGIN_DIR, (uint)(Posix.getuid ()));
+        plugins = new PluginManager (Config.PLUGIN_DIR, (uint)(Posix.getuid ()));
 
         /**TODO** move the volume manager here? */
         /**TODO** gio: This should be using the UNMOUNTED feature of GFileMonitor instead */
@@ -112,7 +112,7 @@ public class Marlin.Application : Gtk.Application {
         });
     }
 
-    public unowned Marlin.ClipboardManager get_clipboard_manager () {
+    public unowned ClipboardManager get_clipboard_manager () {
         return this.clipboard;
     }
 
@@ -227,8 +227,8 @@ public class Marlin.Application : Gtk.Application {
                 /* Open window with tabs at each requested location. */
                 create_window_with_tabs (files);
             } else {
-                var win = (Marlin.View.Window)(get_active_window ());
-                win.open_tabs (files, Marlin.ViewMode.PREFERRED, true); /* Ignore if duplicate tab in existing window */
+                var win = (View.Window)(get_active_window ());
+                win.open_tabs (files, ViewMode.PREFERRED, true); /* Ignore if duplicate tab in existing window */
             }
         } else if (create_new_window || window_count == 0) {
             create_window_with_tabs ();
@@ -258,7 +258,7 @@ public class Marlin.Application : Gtk.Application {
         quitting = true;
         unowned List<Gtk.Window> window_list = this.get_windows ();
         window_list.@foreach ((window) => {
-            ((Marlin.View.Window)window).quit ();
+            ((View.Window)window).quit ();
         });
 
         base.quit ();
@@ -267,14 +267,14 @@ public class Marlin.Application : Gtk.Application {
     public void folder_deleted (GLib.File file) {
         unowned List<Gtk.Window> window_list = this.get_windows ();
         window_list.@foreach ((window) => {
-            ((Marlin.View.Window)window).folder_deleted (file);
+            ((View.Window)window).folder_deleted (file);
         });
     }
 
     private void mount_removed_callback (VolumeMonitor monitor, Mount mount) {
         /* Notify each window */
         foreach (var window in this.get_windows ()) {
-            ((Marlin.View.Window)window).mount_removed (mount);
+            ((View.Window)window).mount_removed (mount);
         }
     }
 
@@ -297,21 +297,21 @@ public class Marlin.Application : Gtk.Application {
                                         prefs, "sort-directories-first", GLib.SettingsBindFlags.DEFAULT);
     }
 
-    public Marlin.View.Window? create_window (File? location = null,
-                                              Marlin.ViewMode viewmode = Marlin.ViewMode.PREFERRED) {
+    public View.Window? create_window (File? location = null,
+                                       ViewMode viewmode = ViewMode.PREFERRED) {
 
         return create_window_with_tabs ({location}, viewmode);
     }
 
     /* All window creation should be done via this function */
-    private Marlin.View.Window? create_window_with_tabs (File[] locations = {},
-                                                         Marlin.ViewMode viewmode = Marlin.ViewMode.PREFERRED) {
+    private View.Window? create_window_with_tabs (File[] locations = {},
+                                                  ViewMode viewmode = ViewMode.PREFERRED) {
 
         if (this.get_windows ().length () >= MAX_WINDOWS) { //Can be assumed to be limited in length
             return null;
         }
 
-        var win = new Marlin.View.Window (this);
+        var win = new View.Window (this);
         add_window (win as Gtk.Window);
         plugins.interface_loaded (win as Gtk.Widget);
         win.open_tabs (locations, viewmode);

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -62,7 +62,7 @@ public class PropertiesWindow : AbstractPropertiesDialog {
     }
 
     private Mutex mutex;
-    private GLib.List<Marlin.DeepCount>? deep_count_directories = null;
+    private GLib.List<DeepCount>? deep_count_directories = null;
 
     private Gee.Set<string>? mimes;
     private ValueLabel contains_value;
@@ -285,7 +285,7 @@ public class PropertiesWindow : AbstractPropertiesDialog {
                 mutex.unlock ();
 
                 selected_folders++;
-                var d = new Marlin.DeepCount (gof.location); /* Starts counting on creation */
+                var d = new DeepCount (gof.location); /* Starts counting on creation */
                 deep_count_directories.prepend (d);
 
                 d.finished.connect (() => {
@@ -1175,7 +1175,7 @@ public class PropertiesWindow : AbstractPropertiesDialog {
                         AppsColumn.APP_INFO, out app);
 
         if (app == null) {
-            var app_chosen = Marlin.MimeActions.choose_app_for_glib_file (goffile.location, this);
+            var app_chosen = MimeActions.choose_app_for_glib_file (goffile.location, this);
             if (app_chosen != null) {
                 store_apps.prepend (out iter);
                 store_apps.set (iter,

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -34,7 +34,7 @@ namespace Marlin {
         public bool follow_state {get; set;}
         public GOF.File? drop_file {get; set;}
 
-        public Marlin.ZoomLevel zoom_level {
+        public ZoomLevel zoom_level {
             get {
                 return _zoom_level;
             }
@@ -60,7 +60,7 @@ namespace Marlin {
 
         int h_overlap;
         int v_overlap;
-        private Marlin.ZoomLevel _zoom_level = Marlin.ZoomLevel.NORMAL;
+        private ZoomLevel _zoom_level = ZoomLevel.NORMAL;
         private GOF.File? _file;
         private Marlin.IconSize icon_size;
         private int icon_scale = 1;
@@ -73,13 +73,13 @@ namespace Marlin {
         private ClipboardManager clipboard;
 
         construct {
-            clipboard = Marlin.ClipboardManager.get_for_display ();
+            clipboard = ClipboardManager.get_for_display ();
             hover_rect = {0, 0, (int) Marlin.IconSize.NORMAL, (int) Marlin.IconSize.NORMAL};
             hover_helper_rect = {0, 0, (int) Marlin.IconSize.EMBLEM, (int) Marlin.IconSize.EMBLEM};
         }
 
-        public IconRenderer (Marlin.ViewMode view_mode) {
-            xpad = view_mode == Marlin.ViewMode.ICON ? 0 : Marlin.IconSize.EMBLEM;
+        public IconRenderer (ViewMode view_mode) {
+            xpad = view_mode == ViewMode.ICON ? 0 : Marlin.IconSize.EMBLEM;
         }
 
         public override void render (Cairo.Context cr, Gtk.Widget widget, Gdk.Rectangle background_area,
@@ -214,7 +214,7 @@ namespace Marlin {
 
                 Gdk.Rectangle helper_rect = {0, 0, 1, 1};
                 if (special_icon_name != null) {
-                    var helper_size = (int) (zoom_level <= Marlin.ZoomLevel.NORMAL ?
+                    var helper_size = (int) (zoom_level <= ZoomLevel.NORMAL ?
                                              Marlin.IconSize.EMBLEM : Marlin.IconSize.LARGE_EMBLEM);
 
                     helper_rect.width = helper_size;

--- a/src/ProgressUIHandler.vala
+++ b/src/ProgressUIHandler.vala
@@ -104,7 +104,7 @@ public class Marlin.Progress.UIHandler : Object {
     private void add_to_window (PF.Progress.Info info) {
         ensure_window ();
 
-        var progress_widget = new Marlin.Progress.InfoWidget (info);
+        var progress_widget = new Progress.InfoWidget (info);
         window_vbox.pack_start (progress_widget, false, false, 6);
 
         progress_widget.cancelled.connect ((info) => {
@@ -186,7 +186,7 @@ public class Marlin.Progress.UIHandler : Object {
 
         var complete_notification = new GLib.Notification (_("File Operations"));
         complete_notification.set_body (result);
-        complete_notification.set_icon (new GLib.ThemedIcon (Marlin.ICON_APP_LOGO));
+        complete_notification.set_icon (new GLib.ThemedIcon (ICON_APP_LOGO));
         application.send_notification ("Pantheon Files Operation", complete_notification);
     }
 

--- a/src/TextRenderer.vala
+++ b/src/TextRenderer.vala
@@ -26,8 +26,8 @@ namespace Marlin {
         private Gdk.RGBA previous_background_rgba;
         private Gdk.RGBA previous_contrasting_rgba;
 
-        private Marlin.ZoomLevel _zoom_level;
-        public Marlin.ZoomLevel zoom_level {
+        private ZoomLevel _zoom_level;
+        public ZoomLevel zoom_level {
             get {
                 return _zoom_level;
             }
@@ -68,7 +68,7 @@ namespace Marlin {
 
         Pango.Layout layout;
         Gtk.Widget widget;
-        Marlin.AbstractEditableLabel entry;
+        AbstractEditableLabel entry;
 
         construct {
             this.mode = Gtk.CellRendererMode.EDITABLE;
@@ -77,12 +77,12 @@ namespace Marlin {
             previous_contrasting_rgba = { 0, 0, 0, 0 };
         }
 
-        public TextRenderer (Marlin.ViewMode viewmode) {
-            if (viewmode == Marlin.ViewMode.ICON) {
-                entry = new Marlin.MultiLineEditableLabel ();
+        public TextRenderer (ViewMode viewmode) {
+            if (viewmode == ViewMode.ICON) {
+                entry = new MultiLineEditableLabel ();
                 is_list_view = false;
             } else {
-                entry = new Marlin.SingleLineEditableLabel ();
+                entry = new SingleLineEditableLabel ();
                 is_list_view = true;
             }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -25,6 +25,8 @@
      * ColumnView
 */
 
+using Marlin;
+
 namespace FM {
     public abstract class AbstractDirectoryView : Gtk.ScrolledWindow {
 
@@ -93,8 +95,8 @@ namespace FM {
         GLib.SimpleActionGroup selection_actions;
         GLib.SimpleActionGroup background_actions;
 
-        private Marlin.ZoomLevel _zoom_level = Marlin.ZoomLevel.NORMAL;
-        public Marlin.ZoomLevel zoom_level {
+        private ZoomLevel _zoom_level = ZoomLevel.NORMAL;
+        public ZoomLevel zoom_level {
             get {
                 return _zoom_level;
             }
@@ -118,8 +120,8 @@ namespace FM {
             }
         }
 
-        protected Marlin.ZoomLevel minimum_zoom = Marlin.ZoomLevel.SMALLEST;
-        protected Marlin.ZoomLevel maximum_zoom = Marlin.ZoomLevel.LARGEST;
+        protected ZoomLevel minimum_zoom = ZoomLevel.SMALLEST;
+        protected ZoomLevel maximum_zoom = ZoomLevel.LARGEST;
         protected bool large_thumbnails = false;
 
         /* Used only when acting as drag source */
@@ -166,7 +168,7 @@ namespace FM {
         int thumbnail_request = -1;
         uint thumbnail_source_id = 0;
         uint freeze_source_id = 0;
-        Marlin.Thumbnailer thumbnailer = null;
+        Thumbnailer thumbnailer = null;
 
         /* Free space signal support */
         uint add_remove_file_timeout_id = 0;
@@ -260,12 +262,12 @@ namespace FM {
         private bool all_selected = false;
 
         private Gtk.Widget view;
-        private unowned Marlin.ClipboardManager clipboard;
+        private unowned ClipboardManager clipboard;
         protected FM.ListModel model;
         protected Marlin.IconRenderer icon_renderer;
-        protected unowned Marlin.View.Slot slot;
-        protected unowned Marlin.View.Window window; /*For convenience - this can be derived from slot */
-        protected static Marlin.DndHandler dnd_handler = new Marlin.DndHandler ();
+        protected unowned View.Slot slot;
+        protected unowned View.Window window; /*For convenience - this can be derived from slot */
+        protected static DndHandler dnd_handler = new DndHandler ();
 
         protected unowned Gtk.RecentManager recent;
 
@@ -273,7 +275,7 @@ namespace FM {
         public signal void item_hovered (GOF.File? file);
         public signal void selection_changed (GLib.List<GOF.File> gof_file);
 
-        protected AbstractDirectoryView (Marlin.View.Slot _slot) {
+        protected AbstractDirectoryView (View.Slot _slot) {
             slot = _slot;
             window = _slot.window;
             editable_cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), "text");
@@ -284,7 +286,7 @@ namespace FM {
             clipboard = app.get_clipboard_manager ();
             recent = app.get_recent_manager ();
 
-            thumbnailer = Marlin.Thumbnailer.get ();
+            thumbnailer = Thumbnailer.get ();
             thumbnailer.finished.connect ((req) => {
                 if (req == thumbnail_request) {
                     thumbnail_request = -1;
@@ -776,7 +778,7 @@ namespace FM {
                 file = GOF.File.get_by_uri (file.get_display_target_uri ());
             }
 
-            default_app = Marlin.MimeActions.get_default_application_for_file (file);
+            default_app = MimeActions.get_default_application_for_file (file);
             GLib.File location = file.get_target_location ();
 
             if (screen == null) {
@@ -831,7 +833,7 @@ namespace FM {
         /* Open all files through this */
         private void open_file (GOF.File file, Gdk.Screen? screen, GLib.AppInfo? app_info) {
             if (can_open_file (file, true)) {
-                Marlin.MimeActions.open_glib_file_request (file.location, this, app_info);
+                MimeActions.open_glib_file_request (file.location, this, app_info);
             }
         }
 
@@ -890,14 +892,14 @@ namespace FM {
                 locations.reverse ();
 
                 slot.directory.block_monitor ();
-                Marlin.FileOperations.@delete.begin (
+                FileOperations.@delete.begin (
                     locations,
                     window as Gtk.Window,
                     !delete_immediately,
                     null,
                     (obj, res) => {
                         try {
-                            Marlin.FileOperations.@delete.end (res);
+                            FileOperations.@delete.end (res);
                         } catch (Error e) {
                             debug (e.message);
                         }
@@ -947,7 +949,7 @@ namespace FM {
 
             /* Block the async directory file monitor to avoid generating unwanted "add-file" events */
             slot.directory.block_monitor ();
-            Marlin.FileOperations.new_file.begin (
+            FileOperations.new_file.begin (
                 this,
                 parent_uri,
                 null,
@@ -956,7 +958,7 @@ namespace FM {
                 null,
                 (obj, res) => {
                     try {
-                        var file = Marlin.FileOperations.new_file.end (res);
+                        var file = FileOperations.new_file.end (res);
                         create_file_done (file);
                     } catch (Error e) {
                         critical (e.message);
@@ -968,9 +970,9 @@ namespace FM {
         private void new_empty_folder () {
             /* Block the async directory file monitor to avoid generating unwanted "add-file" events */
             slot.directory.block_monitor ();
-            Marlin.FileOperations.new_folder.begin (this, slot.location, null, (obj, res) => {
+            FileOperations.new_folder.begin (this, slot.location, null, (obj, res) => {
                 try {
-                    var file = Marlin.FileOperations.new_folder.end (res);
+                    var file = FileOperations.new_folder.end (res);
                     create_file_done (file);
                 } catch (Error e) {
                     critical (e.message);
@@ -1240,7 +1242,7 @@ namespace FM {
         }
 
         private void on_common_action_properties (GLib.SimpleAction action, GLib.Variant? param) {
-            new Marlin.View.PropertiesWindow (get_files_for_action (), this, window);
+            new View.PropertiesWindow (get_files_for_action (), this, window);
         }
 
         private void on_common_action_copy_link (GLib.SimpleAction action, GLib.Variant? param) {
@@ -1366,7 +1368,7 @@ namespace FM {
         }
 
     /** Handle zoom level change */
-        private void on_zoom_level_changed (Marlin.ZoomLevel zoom) {
+        private void on_zoom_level_changed (ZoomLevel zoom) {
             var size = icon_size * get_scale_factor ();
 
             if (!large_thumbnails && size > 128 || large_thumbnails && size <= 128) {
@@ -1508,7 +1510,7 @@ namespace FM {
                 Gtk.drag_set_icon_name (context, "stock-file", 0, 0);
             }
 
-            Marlin.DndHandler.set_selection_data_from_file_list (selection_data, source_drag_file_list);
+            DndHandler.set_selection_data_from_file_list (selection_data, source_drag_file_list);
         }
 
         /* Signal emitted on source after a DND move operation */
@@ -1596,7 +1598,7 @@ namespace FM {
              * So we have to reset some it here and clear it again after processing the drop. */
             if (info == Marlin.TargetType.TEXT_URI_LIST && destination_drop_file_list == null) {
                 string? text;
-                if (Marlin.DndHandler.selection_data_is_uri_list (selection_data, info, out text)) {
+                if (DndHandler.selection_data_is_uri_list (selection_data, info, out text)) {
                     destination_drop_file_list = PF.FileUtils.files_from_uris (text);
                     destination_data_ready = true;
                 }
@@ -1869,7 +1871,7 @@ namespace FM {
                     run_menuitem.action_name = "selection.open";
 
                     menu.add (run_menuitem);
-                } else if (default_app != null && default_app.get_id () != Marlin.APP_ID + ".desktop") {
+                } else if (default_app != null && default_app.get_id () != APP_ID + ".desktop") {
                     var open_menuitem = new Gtk.MenuItem ();
                     open_menuitem.add (new Granite.AccelLabel (
                         _("Open in %s").printf (default_app.get_display_name ()),
@@ -1880,7 +1882,7 @@ namespace FM {
                     menu.add (open_menuitem);
                 }
 
-                open_with_apps = Marlin.MimeActions.get_applications_for_files (selection);
+                open_with_apps = MimeActions.get_applications_for_files (selection);
 
                 if (selected_file.is_executable () == false) {
                     filter_default_app_from_open_with_apps ();
@@ -2364,7 +2366,7 @@ namespace FM {
         }
 
         private void update_default_app (GLib.List<GOF.File> selection) {
-            default_app = Marlin.MimeActions.get_default_application_for_files (selection);
+            default_app = MimeActions.get_default_application_for_files (selection);
             return;
         }
 
@@ -2498,7 +2500,7 @@ namespace FM {
             /* Block the async directory file monitor to avoid generating unwanted "add-file" events */
             slot.directory.block_monitor ();
             var new_name = (_("Untitled %s")).printf (template.get_basename ());
-            Marlin.FileOperations.new_file_from_template.begin (
+            FileOperations.new_file_from_template.begin (
                 this,
                 slot.location,
                 new_name,
@@ -2506,7 +2508,7 @@ namespace FM {
                 null,
                 (obj, res) => {
                     try {
-                        var file = Marlin.FileOperations.new_file_from_template.end (res);
+                        var file = FileOperations.new_file_from_template.end (res);
                         create_file_done (file);
                     } catch (Error e) {
                         critical (e.message);
@@ -2515,7 +2517,7 @@ namespace FM {
         }
 
         private void open_files_with (GLib.AppInfo app, GLib.List<GOF.File> files) {
-            Marlin.MimeActions.open_multiple_gof_files_request (files, this, app);
+            MimeActions.open_multiple_gof_files_request (files, this, app);
         }
 
 
@@ -2723,11 +2725,11 @@ namespace FM {
             if (path != null) {
                 Marlin.IconSize s;
 
-                for (int z = Marlin.ZoomLevel.SMALLEST;
-                     z <= Marlin.ZoomLevel.LARGEST;
+                for (int z = ZoomLevel.SMALLEST;
+                     z <= ZoomLevel.LARGEST;
                      z++) {
 
-                    s = ((Marlin.ZoomLevel) z).to_icon_size ();
+                    s = ((ZoomLevel) z).to_icon_size ();
                     Marlin.IconInfo.remove_cache (path, s, get_scale_factor ());
                 }
             }
@@ -3184,7 +3186,7 @@ namespace FM {
 
             renaming = true;
 
-            var editable_widget = editable as Marlin.AbstractEditableLabel?;
+            var editable_widget = editable as AbstractEditableLabel?;
             if (editable_widget != null) {
                 original_name = editable_widget.get_chars (0, -1);
                 var path = new Gtk.TreePath.from_string (path_string);
@@ -3689,7 +3691,7 @@ namespace FM {
         }
 
         protected virtual bool handle_default_button_click (Gdk.EventButton event) {
-            /* pass unhandled events to the Marlin.View.Window */
+            /* pass unhandled events to the View.Window */
             return false;
         }
 
@@ -3800,7 +3802,7 @@ namespace FM {
 
         protected abstract Gtk.Widget? create_view ();
         protected abstract void set_up_zoom_level ();
-        protected abstract Marlin.ZoomLevel get_normal_zoom_level ();
+        protected abstract ZoomLevel get_normal_zoom_level ();
         protected abstract bool view_has_focus ();
         protected abstract uint get_selected_files_from_model (out GLib.List<GOF.File> selected_files);
         protected abstract uint get_event_position_info (Gdk.EventButton event,

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -16,13 +16,15 @@
     Authors : Jeremy Wootten <jeremy@elementaryos.org>
 ***/
 
+using Marlin;
+
 namespace FM {
     /* Implement common features of ColumnView and ListView */
     public abstract class AbstractTreeView : AbstractDirectoryView {
         protected FM.TreeView tree;
         protected Gtk.TreeViewColumn name_column;
 
-        protected AbstractTreeView (Marlin.View.Slot _slot) {
+        protected AbstractTreeView (View.Slot _slot) {
             base (_slot);
         }
 
@@ -37,8 +39,8 @@ namespace FM {
                 resizable = true
             };
 
-            name_renderer = new Marlin.TextRenderer (Marlin.ViewMode.LIST);
-            icon_renderer = new Marlin.IconRenderer (Marlin.ViewMode.LIST);
+            name_renderer = new Marlin.TextRenderer (ViewMode.LIST);
+            icon_renderer = new Marlin.IconRenderer (ViewMode.LIST);
 
             set_up_name_renderer ();
             set_up_icon_renderer ();
@@ -72,7 +74,7 @@ namespace FM {
         protected override void set_up_name_renderer () {
             base.set_up_name_renderer ();
             name_renderer.@set ("wrap-width", -1);
-            name_renderer.@set ("zoom-level", Marlin.ZoomLevel.NORMAL);
+            name_renderer.@set ("zoom-level", ZoomLevel.NORMAL);
             name_renderer.@set ("ellipsize-set", true);
             name_renderer.@set ("ellipsize", Pango.EllipsizeMode.END);
             name_renderer.xalign = 0.0f;
@@ -352,8 +354,8 @@ namespace FM {
     }
 
     protected class TreeView : Gtk.TreeView {
-        private Marlin.ZoomLevel _zoom_level = Marlin.ZoomLevel.INVALID;
-        public Marlin.ZoomLevel zoom_level {
+        private ZoomLevel _zoom_level = ZoomLevel.INVALID;
+        public ZoomLevel zoom_level {
             set {
                 if (_zoom_level == value || !get_realized ()) {
                     return;

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -16,6 +16,7 @@
     Authors : Jeremy Wootten <jeremy@elementaryos.org>
 ***/
 
+using Marlin;
 
 namespace FM {
     public class ColumnView : AbstractTreeView {
@@ -23,7 +24,7 @@ namespace FM {
         bool awaiting_double_click = false;
         uint double_click_timeout_id = 0;
 
-        public ColumnView (Marlin.View.Slot _slot) {
+        public ColumnView (View.Slot _slot) {
             base (_slot);
             /* We do not need to load the directory - this is done by Miller View*/
             /* We do not need to connect to "row-activated" signal - we handle left-clicks ourselves */
@@ -64,9 +65,9 @@ namespace FM {
                 GLib.SettingsBindFlags.DEFAULT
             );
 
-            maximum_zoom = (Marlin.ZoomLevel)Marlin.column_view_settings.get_enum ("maximum-zoom-level");
+            maximum_zoom = (ZoomLevel)Marlin.column_view_settings.get_enum ("maximum-zoom-level");
 
-            if (zoom_level < minimum_zoom) { /* Defaults to Marlin.ZoomLevel.SMALLEST */
+            if (zoom_level < minimum_zoom) { /* Defaults to ZoomLevel.SMALLEST */
                 zoom_level = minimum_zoom;
             }
 
@@ -75,11 +76,11 @@ namespace FM {
             }
         }
 
-        public override Marlin.ZoomLevel get_normal_zoom_level () {
+        public override ZoomLevel get_normal_zoom_level () {
             var zoom = Marlin.column_view_settings.get_enum ("default-zoom-level");
             Marlin.column_view_settings.set_enum ("zoom-level", zoom);
 
-            return (Marlin.ZoomLevel)zoom;
+            return (ZoomLevel)zoom;
         }
 
         protected override Gtk.Widget? create_view () {
@@ -122,7 +123,7 @@ namespace FM {
             }
 
             if (iter != null) {
-                model.@get (iter, FM.ListModel.ColumnID.FILE_COLUMN, out file, -1);
+                model.@get (iter, ListModel.ColumnID.FILE_COLUMN, out file, -1);
             }
 
             if (file == null || !file.is_folder ()) {

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -16,6 +16,8 @@
     Authors : Jeremy Wootten <jeremy@elementaryos.org>
 ***/
 
+using Marlin;
+
 namespace FM {
     public class IconView : AbstractDirectoryView {
         protected new Gtk.IconView tree;
@@ -26,7 +28,7 @@ namespace FM {
         protected bool linear_select_required = false;
         protected Gtk.TreePath? most_recently_selected = null;
 
-        public IconView (Marlin.View.Slot _slot) {
+        public IconView (View.Slot _slot) {
             base (_slot);
         }
 
@@ -40,8 +42,8 @@ namespace FM {
             tree.set_columns (-1);
             tree.set_reorderable (false);
 
-            name_renderer = new Marlin.TextRenderer (Marlin.ViewMode.ICON);
-            icon_renderer = new Marlin.IconRenderer (Marlin.ViewMode.ICON);
+            name_renderer = new Marlin.TextRenderer (ViewMode.ICON);
+            icon_renderer = new Marlin.IconRenderer (ViewMode.ICON);
 
             set_up_name_renderer ();
             set_up_icon_renderer ();
@@ -49,10 +51,10 @@ namespace FM {
             tree.pack_start (icon_renderer, false);
             tree.pack_end (name_renderer, false);
 
-            tree.add_attribute (name_renderer, "text", FM.ListModel.ColumnID.FILENAME);
-            tree.add_attribute (name_renderer, "file", FM.ListModel.ColumnID.FILE_COLUMN);
-            tree.add_attribute (name_renderer, "background", FM.ListModel.ColumnID.COLOR);
-            tree.add_attribute (icon_renderer, "file", FM.ListModel.ColumnID.FILE_COLUMN);
+            tree.add_attribute (name_renderer, "text", ListModel.ColumnID.FILENAME);
+            tree.add_attribute (name_renderer, "file", ListModel.ColumnID.FILE_COLUMN);
+            tree.add_attribute (name_renderer, "background", ListModel.ColumnID.COLOR);
+            tree.add_attribute (icon_renderer, "file", ListModel.ColumnID.FILE_COLUMN);
 
             connect_tree_signals ();
             tree.realize.connect ((w) => {
@@ -94,8 +96,8 @@ namespace FM {
                 GLib.SettingsBindFlags.DEFAULT
             );
 
-            minimum_zoom = (Marlin.ZoomLevel)Marlin.icon_view_settings.get_enum ("minimum-zoom-level");
-            maximum_zoom = (Marlin.ZoomLevel)Marlin.icon_view_settings.get_enum ("maximum-zoom-level");
+            minimum_zoom = (ZoomLevel)Marlin.icon_view_settings.get_enum ("minimum-zoom-level");
+            maximum_zoom = (ZoomLevel)Marlin.icon_view_settings.get_enum ("maximum-zoom-level");
 
             if (zoom_level < minimum_zoom) {
                 zoom_level = minimum_zoom;
@@ -106,11 +108,11 @@ namespace FM {
             }
         }
 
-        public override Marlin.ZoomLevel get_normal_zoom_level () {
+        public override ZoomLevel get_normal_zoom_level () {
             var zoom = Marlin.icon_view_settings.get_enum ("default-zoom-level");
             Marlin.icon_view_settings.set_enum ("zoom-level", zoom);
 
-            return (Marlin.ZoomLevel)zoom;
+            return (ZoomLevel)zoom;
         }
 
         public override void change_zoom_level () {
@@ -242,8 +244,7 @@ namespace FM {
                     Gtk.TreeIter iter;
                     model.get_iter (out iter, path);
                     string? text = null;
-                    model.@get (iter,
-                            FM.ListModel.ColumnID.FILENAME, out text);
+                    model.@get (iter, ListModel.ColumnID.FILENAME, out text);
 
                     ((Marlin.TextRenderer) cell_renderer).set_up_layout (text, area.width);
 

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -16,6 +16,8 @@
     Authors : Jeremy Wootten <jeremy@elementaryos.org>
 ***/
 
+using Marlin;
+
 namespace FM {
     public class ListView : AbstractTreeView {
 
@@ -34,7 +36,7 @@ namespace FM {
         private GLib.List<Gtk.TreeRowReference> subdirectories_to_unload = null;
         private GLib.List<GOF.Directory.Async> loaded_subdirectories = null;
 
-        public ListView (Marlin.View.Slot _slot) {
+        public ListView (View.Slot _slot) {
             base (_slot);
         }
 
@@ -45,10 +47,10 @@ namespace FM {
         }
 
         private void append_extra_tree_columns () {
-            int fnc = FM.ListModel.ColumnID.FILENAME;
+            int fnc = ListModel.ColumnID.FILENAME;
 
             int preferred_column_width = Marlin.column_view_settings.get_int ("preferred-column-width");
-            for (int k = fnc; k < FM.ListModel.ColumnID.NUM_COLUMNS; k++) {
+            for (int k = fnc; k < ListModel.ColumnID.NUM_COLUMNS; k++) {
                 if (k == fnc) {
                     /* name_column already created by AbstractTreeVIew */
                     name_column.set_title (column_titles [0]);
@@ -64,7 +66,7 @@ namespace FM {
                         min_width = 24
                     };
 
-                    if (k == FM.ListModel.ColumnID.SIZE || k == FM.ListModel.ColumnID.MODIFIED) {
+                    if (k == ListModel.ColumnID.SIZE || k == ListModel.ColumnID.MODIFIED) {
                         renderer.@set ("xalign", 1.0f);
                     } else {
                         renderer.@set ("xalign", 0.0f);
@@ -205,9 +207,9 @@ namespace FM {
                 GLib.SettingsBindFlags.DEFAULT
             );
 
-            maximum_zoom = (Marlin.ZoomLevel)Marlin.list_view_settings.get_enum ("maximum-zoom-level");
+            maximum_zoom = (ZoomLevel)Marlin.list_view_settings.get_enum ("maximum-zoom-level");
 
-            if (zoom_level < minimum_zoom) { /* Defaults to Marlin.ZoomLevel.SMALLEST */
+            if (zoom_level < minimum_zoom) { /* Defaults to ZoomLevel.SMALLEST */
                 zoom_level = minimum_zoom;
             }
 
@@ -216,11 +218,11 @@ namespace FM {
             }
         }
 
-        public override Marlin.ZoomLevel get_normal_zoom_level () {
+        public override ZoomLevel get_normal_zoom_level () {
             var zoom = Marlin.list_view_settings.get_enum ("default-zoom-level");
             Marlin.list_view_settings.set_enum ("zoom-level", zoom);
 
-            return (Marlin.ZoomLevel)zoom;
+            return (ZoomLevel)zoom;
         }
 
         private void add_subdirectory_at_path (Gtk.TreePath path) {

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -18,7 +18,7 @@
 
 namespace Marlin.View {
     public class Miller : GOF.AbstractSlot {
-        private unowned Marlin.View.ViewContainer ctab;
+        private unowned View.ViewContainer ctab;
 
         /* Need private copy of initial location as Miller
          * does not have its own Asyncdirectory object */
@@ -30,8 +30,8 @@ namespace Marlin.View {
 
         public Gtk.ScrolledWindow scrolled_window;
         public Gtk.Adjustment hadj;
-        public unowned Marlin.View.Slot? current_slot;
-        public GLib.List<Marlin.View.Slot> slot_list = null;
+        public unowned View.Slot? current_slot;
+        public GLib.List<View.Slot> slot_list = null;
         public int total_width = 0;
 
         public override bool is_frozen {
@@ -46,7 +46,7 @@ namespace Marlin.View {
             }
         }
 
-        public Miller (GLib.File loc, Marlin.View.ViewContainer ctab, Marlin.ViewMode mode) {
+        public Miller (GLib.File loc, View.ViewContainer ctab, ViewMode mode) {
             this.ctab = ctab;
             this.root_location = loc;
 
@@ -89,10 +89,10 @@ namespace Marlin.View {
         }
 
         /** Creates a new slot in the host slot hpane */
-        public void add_location (GLib.File loc, Marlin.View.Slot? host = null,
+        public void add_location (GLib.File loc, View.Slot? host = null,
                                   bool scroll = true, bool animate = true) {
 
-            var new_slot = new Marlin.View.Slot (loc, ctab, Marlin.ViewMode.MILLER_COLUMNS);
+            var new_slot = new View.Slot (loc, ctab, ViewMode.MILLER_COLUMNS);
             /* Notify view container of path change - will set tab to working and change pathbar */
             path_changed ();
             new_slot.slot_number = (host != null) ? host.slot_number + 1 : 0;
@@ -106,7 +106,7 @@ namespace Marlin.View {
             new_slot.active (scroll, animate);
         }
 
-        private void nest_slot_in_host_slot (Marlin.View.Slot slot, Marlin.View.Slot? host) {
+        private void nest_slot_in_host_slot (View.Slot slot, View.Slot? host) {
             var hpane1 = new Gtk.Paned (Gtk.Orientation.HORIZONTAL) {
                 hexpand = true
             };
@@ -134,7 +134,7 @@ namespace Marlin.View {
             }
         }
 
-        private void truncate_list_after_slot (Marlin.View.Slot slot) {
+        private void truncate_list_after_slot (View.Slot slot) {
             if (slot_list.length () <= 0) { //Can be assumed to limited in length
                 return;
             }
@@ -148,7 +148,7 @@ namespace Marlin.View {
                 }
             });
 
-            ((Marlin.View.Slot)(slot)).colpane.@foreach ((w) => {
+            ((View.Slot)(slot)).colpane.@foreach ((w) => {
                 w.destroy ();
             });
 
@@ -192,7 +192,7 @@ namespace Marlin.View {
                 /* Try to add location relative to each slot in turn, starting at end */
                 var copy_slot_list = slot_list.copy ();
                 copy_slot_list.reverse ();
-                foreach (Marlin.View.Slot s in copy_slot_list) {
+                foreach (View.Slot s in copy_slot_list) {
                     if (add_relative_path (s, loc)) {
                         found = true;
                         break;
@@ -217,7 +217,7 @@ namespace Marlin.View {
             }
         }
 
-        private bool add_relative_path (Marlin.View.Slot root, GLib.File loc) {
+        private bool add_relative_path (View.Slot root, GLib.File loc) {
             if (root.location.get_uri () == loc.get_uri ()) {
                 truncate_list_after_slot (root);
                 return true;
@@ -278,7 +278,7 @@ namespace Marlin.View {
 
         }
 
-        private void on_miller_slot_request (Marlin.View.Slot slot, GLib.File loc, bool make_root) {
+        private void on_miller_slot_request (View.Slot slot, GLib.File loc, bool make_root) {
             if (make_root) {
                 /* Start a new tree with root at loc */
                 change_path (loc, true);
@@ -311,12 +311,12 @@ namespace Marlin.View {
          *  Should not be called directly
          **/
         private void on_slot_active (GOF.AbstractSlot aslot, bool scroll = true, bool animate = true) {
-            Marlin.View.Slot slot;
+            View.Slot slot;
 
-            if (!(aslot is Marlin.View.Slot)) {
+            if (!(aslot is View.Slot)) {
                 return;
             } else {
-                slot = aslot as Marlin.View.Slot;
+                slot = aslot as View.Slot;
             }
 
             if (scroll) {
@@ -359,7 +359,7 @@ namespace Marlin.View {
                 }
 
                 /* Remove hidden slots and make the slot before the first hidden slot active */
-                Marlin.View.Slot slot = slot_list.nth_data (hidden - 1);
+                View.Slot slot = slot_list.nth_data (hidden - 1);
                 truncate_list_after_slot (slot);
                 slot.active ();
             }
@@ -377,7 +377,7 @@ namespace Marlin.View {
                 return false;
             }
 
-            Marlin.View.Slot to_activate = null;
+            View.Slot to_activate = null;
 
             switch (event.keyval) {
                 case Gdk.Key.Left:
@@ -440,7 +440,7 @@ namespace Marlin.View {
             /* Ensure all slots synchronise the frozen state */
 
             slot_list.@foreach ((abstract_slot) => {
-                var s = abstract_slot as Marlin.View.Slot;
+                var s = abstract_slot as View.Slot;
                 if (s != null) {
                     s.frozen_changed.disconnect (on_slot_frozen_changed);
                     s.is_frozen = frozen;
@@ -452,7 +452,7 @@ namespace Marlin.View {
 
 /** Helper functions */
 
-        private void schedule_scroll_to_slot (Marlin.View.Slot slot, bool animate = true) {
+        private void schedule_scroll_to_slot (View.Slot slot, bool animate = true) {
             if (scroll_to_slot_timeout_id > 0) {
                 GLib.Source.remove (scroll_to_slot_timeout_id);
             }
@@ -467,7 +467,7 @@ namespace Marlin.View {
             });
         }
 
-        private bool scroll_to_slot (Marlin.View.Slot slot, bool animate = true) {
+        private bool scroll_to_slot (View.Slot slot, bool animate = true) {
             /* Cannot accurately scroll until directory finishes loading because width will change
              * according the length of the longest filename */
             if (!scrolled_window.get_realized () || slot.directory.state != GOF.Directory.Async.State.LOADED) {
@@ -505,7 +505,7 @@ namespace Marlin.View {
             }
 
             if (animate) {
-                Marlin.Animation.smooth_adjustment_to (this.hadj, new_value);
+                Animation.smooth_adjustment_to (this.hadj, new_value);
                 return true;
             } else { /* On startup we do not want to animate */
                 hadj.set_value (new_value);
@@ -520,7 +520,7 @@ namespace Marlin.View {
         }
 
         public override unowned GLib.List<GOF.File>? get_selected_files () {
-            return ((Marlin.View.Slot)(current_slot)).get_selected_files ();
+            return ((View.Slot)(current_slot)).get_selected_files ();
         }
 
         public override void set_active_state (bool set_active, bool animate = true) {
@@ -555,27 +555,27 @@ namespace Marlin.View {
         }
 
         public override void zoom_in () {
-            ((Marlin.View.Slot)(current_slot)).zoom_in ();
+            ((View.Slot)(current_slot)).zoom_in ();
         }
 
         public override void zoom_out () {
-            ((Marlin.View.Slot)(current_slot)).zoom_out ();
+            ((View.Slot)(current_slot)).zoom_out ();
         }
 
         public override void zoom_normal () {
-            ((Marlin.View.Slot)(current_slot)).zoom_normal ();
+            ((View.Slot)(current_slot)).zoom_normal ();
         }
 
         public override void grab_focus () {
-            ((Marlin.View.Slot)(current_slot)).grab_focus ();
+            ((View.Slot)(current_slot)).grab_focus ();
         }
 
         public override void initialize_directory () {
-            ((Marlin.View.Slot)(current_slot)).initialize_directory ();
+            ((View.Slot)(current_slot)).initialize_directory ();
         }
 
         public override void reload (bool non_local_only = false) {
-            ((Marlin.View.Slot)(current_slot)).reload (non_local_only);
+            ((View.Slot)(current_slot)).reload (non_local_only);
         }
 
         public override void close () {
@@ -589,7 +589,7 @@ namespace Marlin.View {
         }
 
         public override bool set_all_selected (bool all) {
-            return ((Marlin.View.Slot)(current_slot)).set_all_selected (all);
+            return ((View.Slot)(current_slot)).set_all_selected (all);
         }
 
         public override FileInfo? lookup_file_info (GLib.File loc) {

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -19,8 +19,8 @@
 
 namespace Marlin.View {
     public class Slot : GOF.AbstractSlot {
-        private unowned Marlin.View.ViewContainer ctab;
-        private Marlin.ViewMode mode;
+        private unowned View.ViewContainer ctab;
+        private ViewMode mode;
         private int preferred_column_width;
         private FM.AbstractDirectoryView? dir_view = null;
 
@@ -44,7 +44,7 @@ namespace Marlin.View {
             }
         }
 
-        public unowned Marlin.View.Window window {
+        public unowned View.Window window {
             get {return ctab.window;}
         }
 
@@ -74,7 +74,7 @@ namespace Marlin.View {
         public signal void miller_slot_request (GLib.File file, bool make_root);
         public signal void size_change ();
 
-        public Slot (GLib.File _location, Marlin.View.ViewContainer _ctab, Marlin.ViewMode _mode) {
+        public Slot (GLib.File _location, View.ViewContainer _ctab, ViewMode _mode) {
             ctab = _ctab;
             mode = _mode;
             is_active = false;
@@ -152,7 +152,7 @@ namespace Marlin.View {
             directory_loaded (dir);
 
             /*  Column View requires slots to determine their own width (other views' width determined by Window */
-            if (mode == Marlin.ViewMode.MILLER_COLUMNS) {
+            if (mode == ViewMode.MILLER_COLUMNS) {
 
                 if (dir.is_empty ()) { /* No files in the file cache */
                     Pango.Rectangle extents;
@@ -231,7 +231,7 @@ namespace Marlin.View {
 
         private void on_dir_view_path_change_request (GLib.File loc, Marlin.OpenFlag flag, bool make_root) {
             if (flag == 0) { /* make view in existing container */
-                if (mode == Marlin.ViewMode.MILLER_COLUMNS) {
+                if (mode == ViewMode.MILLER_COLUMNS) {
                     miller_slot_request (loc, make_root); /* signal to parent MillerView */
                 } else {
                     user_path_change_request (loc, make_root); /* Handle ourselves */
@@ -276,15 +276,15 @@ namespace Marlin.View {
             assert (dir_view == null);
 
             switch (mode) {
-                case Marlin.ViewMode.MILLER_COLUMNS:
+                case ViewMode.MILLER_COLUMNS:
                     dir_view = new FM.ColumnView (this);
                     break;
 
-                case Marlin.ViewMode.LIST:;
+                case ViewMode.LIST:;
                     dir_view = new FM.ListView (this);
                     break;
 
-                case Marlin.ViewMode.ICON:
+                case ViewMode.ICON:
                     dir_view = new FM.IconView (this);
                     break;
 
@@ -293,7 +293,7 @@ namespace Marlin.View {
             }
 
             /* Miller View creates its own overlay and handles packing of the directory view */
-            if (mode != Marlin.ViewMode.MILLER_COLUMNS) {
+            if (mode != ViewMode.MILLER_COLUMNS) {
                 add_overlay (dir_view);
             }
         }

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -23,8 +23,6 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA.
 ***/
 
-using Marlin;
-
 namespace Marlin.View {
     public class ViewContainer : Gtk.Bin {
         private static int container_id;
@@ -40,8 +38,8 @@ namespace Marlin.View {
         public int id {get; construct;}
         public Gtk.Widget? content_item;
         public bool can_show_folder { get; private set; default = false; }
-        private Marlin.View.Window? _window = null;
-        public Marlin.View.Window window {
+        private View.Window? _window = null;
+        public View.Window window {
             get {
                 return _window;
             }
@@ -57,7 +55,7 @@ namespace Marlin.View {
         }
 
         public GOF.AbstractSlot? view = null;
-        public Marlin.ViewMode view_mode = Marlin.ViewMode.INVALID;
+        public ViewMode view_mode = ViewMode.INVALID;
 
         public GLib.File? location {
             get {
@@ -108,7 +106,7 @@ namespace Marlin.View {
 
         public bool is_loading {get; private set; default = false;}
 
-        private Marlin.View.OverlayBar overlay_statusbar;
+        private View.OverlayBar overlay_statusbar;
         private Browser browser;
         private GLib.List<GLib.File>? selected_locations = null;
 
@@ -122,7 +120,7 @@ namespace Marlin.View {
         }
 
         /* Initial location now set by Window.make_tab after connecting signals */
-        public ViewContainer (Marlin.View.Window win) {
+        public ViewContainer (View.Window win) {
             window = win;
             browser = new Browser ();
 
@@ -243,7 +241,7 @@ namespace Marlin.View {
         }
 
         // the locations in @to_select must be children of @loc
-        public void add_view (Marlin.ViewMode mode, GLib.File loc, File[]? to_select = null) {
+        public void add_view (ViewMode mode, GLib.File loc, File[]? to_select = null) {
             assert (view == null);
             view_mode = mode;
 
@@ -254,13 +252,13 @@ namespace Marlin.View {
                 }
             }
 
-            if (mode == Marlin.ViewMode.MILLER_COLUMNS) {
+            if (mode == ViewMode.MILLER_COLUMNS) {
                 this.view = new Miller (loc, this, mode);
             } else {
                 this.view = new Slot (loc, this, mode);
             }
 
-            overlay_statusbar = new Marlin.View.OverlayBar (view.overlay);
+            overlay_statusbar = new View.OverlayBar (view.overlay);
 
             connect_slot_signals (this.view);
             directory_is_loading (loc);
@@ -274,7 +272,7 @@ namespace Marlin.View {
         /** By default changes the view mode to @mode at the same location.
             @loc - new location to show.
         **/
-        public void change_view_mode (Marlin.ViewMode mode, GLib.File? loc = null) {
+        public void change_view_mode (ViewMode mode, GLib.File? loc = null) {
             var aslot = get_current_slot ();
             assert (aslot != null);
             if (loc == null) {
@@ -397,32 +395,32 @@ namespace Marlin.View {
             /* First deal with all cases where directory could not be loaded */
             if (!can_show_folder) {
                 if (dir.is_recent && !GOF.Preferences.get_default ().remember_history) {
-                    content = new Marlin.View.PrivacyModeOn (this);
+                    content = new View.PrivacyModeOn (this);
                 } else if (!dir.file.exists) {
                     if (!dir.is_trash) {
                         content = new DirectoryNotFound (slot.directory, this);
                     } else {
-                        content = new Marlin.View.Welcome (_("This Folder Does Not Exist"),
-                                                           _("You cannot create a folder here."));
+                        content = new View.Welcome (_("This Folder Does Not Exist"),
+                                                    _("You cannot create a folder here."));
                     }
                 } else if (!dir.network_available) {
-                    content = new Marlin.View.Welcome (_("The network is unavailable"),
-                                                       _("A working network is needed to reach this folder") + "\n\n" +
-                                                       dir.last_error_message);
+                    content = new View.Welcome (_("The network is unavailable"),
+                                                _("A working network is needed to reach this folder") + "\n\n" +
+                                                dir.last_error_message);
                 } else if (dir.permission_denied) {
-                    content = new Marlin.View.Welcome (_("This Folder Does Not Belong to You"),
-                                                       _("You don't have permission to view this folder."));
+                    content = new View.Welcome (_("This Folder Does Not Belong to You"),
+                                                _("You don't have permission to view this folder."));
                 } else if (!dir.file.is_connected) {
-                    content = new Marlin.View.Welcome (_("Unable to Mount Folder"),
-                                                       _("Could not connect to the server for this folder.") + "\n\n" +
-                                                       dir.last_error_message);
+                    content = new View.Welcome (_("Unable to Mount Folder"),
+                                                _("Could not connect to the server for this folder.") + "\n\n" +
+                                                dir.last_error_message);
                 } else if (slot.directory.state == GOF.Directory.Async.State.TIMED_OUT) {
-                    content = new Marlin.View.Welcome (_("Unable to Display Folder Contents"),
-                                                       _("The operation timed out.") + "\n\n" + dir.last_error_message);
+                    content = new View.Welcome (_("Unable to Display Folder Contents"),
+                                                _("The operation timed out.") + "\n\n" + dir.last_error_message);
                 } else {
-                    content = new Marlin.View.Welcome (_("Unable to Show Folder"),
-                                                       _("The server for this folder could not be located.") + "\n\n" +
-                                                       dir.last_error_message);
+                    content = new View.Welcome (_("Unable to Show Folder"),
+                                                _("The server for this folder could not be located.") + "\n\n" +
+                                                dir.last_error_message);
                 }
             /* Now deal with cases where file (s) within the loaded folder has to be selected */
             } else if (selected_locations != null) {
@@ -432,8 +430,8 @@ namespace Marlin.View {
                 if (dir.selected_file.query_exists ()) {
                     focus_location_if_in_current_directory (dir.selected_file);
                 } else {
-                    content = new Marlin.View.Welcome (_("File not Found"),
-                                                       _("The file selected no longer exists."));
+                    content = new View.Welcome (_("File not Found"),
+                                                _("The file selected no longer exists."));
                     can_show_folder = false;
                 }
             } else {

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -43,7 +43,7 @@ namespace Marlin.View.Chrome {
         private bool drop_data_ready = false; /* whether the drop data was received already */
         private bool drop_occurred = false; /* whether the data was dropped */
         private GLib.List<GLib.File> drop_file_list = null; /* the list of URIs in the drop data */
-        protected static Marlin.DndHandler dnd_handler = new Marlin.DndHandler ();
+        protected static DndHandler dnd_handler = new DndHandler ();
         Gdk.DragAction current_suggested_action = 0; /* No action */
         Gdk.DragAction current_actions = 0; /* No action */
         GOF.File? drop_target_file = null;
@@ -349,7 +349,7 @@ namespace Marlin.View.Chrome {
             if (!drop_data_ready) {
                 /* We don't have the drop data - extract uri list from selection data */
                 string? text;
-                if (Marlin.DndHandler.selection_data_is_uri_list (selection_data, info, out text)) {
+                if (DndHandler.selection_data_is_uri_list (selection_data, info, out text)) {
                     drop_file_list = PF.FileUtils.files_from_uris (text);
                     drop_data_ready = true;
                 }
@@ -465,7 +465,7 @@ namespace Marlin.View.Chrome {
             var submenu_open_with = new Gtk.Menu ();
             var loc = File.new_for_uri (PF.FileUtils.escape_uri (path));
             var root = GOF.File.get_by_uri (path);
-            var app_info_list = Marlin.MimeActions.get_applications_for_folder (root);
+            var app_info_list = MimeActions.get_applications_for_folder (root);
             bool at_least_one = false;
             foreach (AppInfo app_info in app_info_list) {
                 if (app_info != null && app_info.get_executable () != Environment.get_application_name ()) {

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -59,14 +59,14 @@ public class Marlin.View.Chrome.HeaderBar : Hdy.HeaderBar {
     }
 
     construct {
-        button_back = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name (
+        button_back = new View.Chrome.ButtonWithMenu.from_icon_name (
             "go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR
         );
 
         button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
         button_back.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        button_forward = new Marlin.View.Chrome.ButtonWithMenu.from_icon_name (
+        button_forward = new View.Chrome.ButtonWithMenu.from_icon_name (
             "go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR
         );
 

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -80,8 +80,8 @@ namespace Marlin.View.Chrome {
             path_change_request (gof.get_target_location ().get_uri ());
         }
         private void on_search_results_file_activated (GLib.File file) {
-            AppInfo? app = Marlin.MimeActions.get_default_application_for_glib_file (file);
-            Marlin.MimeActions.open_glib_file_request (file, this, app);
+            AppInfo? app = MimeActions.get_default_application_for_glib_file (file);
+            MimeActions.open_glib_file_request (file, this, app);
             on_search_results_exit ();
         }
 

--- a/src/View/Widgets/OverlayBar.vala
+++ b/src/View/Widgets/OverlayBar.vala
@@ -33,7 +33,7 @@ namespace Marlin.View {
         private Gdk.PixbufLoader loader;
         private uint update_timeout_id = 0;
         private uint hover_timeout_id = 0;
-        private Marlin.DeepCount? deep_counter = null;
+        private DeepCount? deep_counter = null;
         private uint deep_count_timeout_id = 0;
 
         public OverlayBar (Gtk.Overlay overlay) {
@@ -239,7 +239,7 @@ namespace Marlin.View {
             deep_count_cancel ();
 
             deep_count_timeout_id = GLib.Timeout.add_full (GLib.Priority.LOW, 1000, () => {
-                deep_counter = new Marlin.DeepCount (goffile.location);
+                deep_counter = new DeepCount (goffile.location);
                 deep_counter.finished.connect (update_status_after_deep_count);
 
                 cancel_cancellable ();

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -58,7 +58,7 @@ namespace Marlin.View {
         public Chrome.ViewSwitcher view_switcher;
         public Granite.Widgets.DynamicNotebook tabs;
         private Gtk.Paned lside_pane;
-        public Marlin.SidebarInterface sidebar;
+        public SidebarInterface sidebar;
         public ViewContainer? current_tab = null;
 
         private bool tabs_restored = false;
@@ -76,7 +76,7 @@ namespace Marlin.View {
                 height_request: 300,
                 icon_name: "system-file-manager",
                 screen: myscreen,
-                title: _(Marlin.APP_TITLE),
+                title: _(APP_TITLE),
                 width_request: 500,
                 window_number: application.window_count
             );
@@ -95,7 +95,7 @@ namespace Marlin.View {
 
             undo_actions_set_insensitive ();
 
-            undo_manager = Marlin.UndoManager.instance ();
+            undo_manager = UndoManager.instance ();
 
             build_window ();
 
@@ -376,7 +376,7 @@ namespace Marlin.View {
         }
 
         public void open_tabs (File[]? files = null,
-                               Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED,
+                               ViewMode mode = ViewMode.PREFERRED,
                                bool ignore_duplicate = false) {
 
             if (files == null || files.length == 0 || files[0] == null) {
@@ -401,7 +401,7 @@ namespace Marlin.View {
             }
         }
 
-        private void add_tab_by_uri (string uri, Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED) {
+        private void add_tab_by_uri (string uri, ViewMode mode = ViewMode.PREFERRED) {
             var file = get_file_from_uri (uri);
             if (file != null) {
                 add_tab (file, mode);
@@ -411,7 +411,7 @@ namespace Marlin.View {
         }
 
         private void add_tab (File _location = File.new_for_commandline_arg (Environment.get_home_dir ()),
-                             Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED,
+                             ViewMode mode = ViewMode.PREFERRED,
                              bool ignore_duplicate = false) {
 
             File location;
@@ -610,7 +610,7 @@ namespace Marlin.View {
         }
 
         private void add_window (GLib.File location = GLib.File.new_for_path (PF.UserUtils.get_real_user_home ()),
-                                 Marlin.ViewMode mode = Marlin.ViewMode.PREFERRED) {
+                                 ViewMode mode = ViewMode.PREFERRED) {
 
             marlin_app.create_window (location, real_mode (mode));
         }
@@ -683,7 +683,7 @@ namespace Marlin.View {
         }
 
         private void action_view_mode (GLib.SimpleAction action, GLib.Variant? param) {
-            Marlin.ViewMode mode = real_mode ((ViewMode)(param.get_uint32 ()));
+            ViewMode mode = real_mode ((ViewMode)(param.get_uint32 ()));
             current_tab.change_view_mode (mode);
             /* ViewContainer takes care of changing appearance */
         }
@@ -877,21 +877,21 @@ namespace Marlin.View {
             return (GLib.SimpleAction?)(lookup_action (action_name));
         }
 
-        private Marlin.ViewMode real_mode (Marlin.ViewMode mode) {
+        private ViewMode real_mode (ViewMode mode) {
             switch (mode) {
-                case Marlin.ViewMode.ICON:
-                case Marlin.ViewMode.LIST:
-                case Marlin.ViewMode.MILLER_COLUMNS:
+                case ViewMode.ICON:
+                case ViewMode.LIST:
+                case ViewMode.MILLER_COLUMNS:
                     return mode;
 
-                case Marlin.ViewMode.CURRENT:
+                case ViewMode.CURRENT:
                     return current_tab.view_mode;
 
                 default:
                     break;
             }
 
-            return (Marlin.ViewMode)(Marlin.app_settings.get_enum ("default-viewmode"));
+            return (ViewMode)(Marlin.app_settings.get_enum ("default-viewmode"));
         }
 
         public void quit () {
@@ -906,7 +906,7 @@ namespace Marlin.View {
 
             foreach (var tab in tabs.tabs) {
                 current_tab = null;
-                ((Marlin.View.ViewContainer)(tab.page)).close ();
+                ((View.ViewContainer)(tab.page)).close ();
             }
 
             this.destroy ();
@@ -975,7 +975,7 @@ namespace Marlin.View {
             GLib.Variant tab_info_array = Marlin.app_settings.get_value ("tab-info-list");
             GLib.VariantIter iter = new GLib.VariantIter (tab_info_array);
 
-            Marlin.ViewMode mode = Marlin.ViewMode.INVALID;
+            ViewMode mode = ViewMode.INVALID;
             string? root_uri = null;
             string? tip_uri = null;
 
@@ -985,7 +985,7 @@ namespace Marlin.View {
 
             while (iter.next ("(uss)", out mode, out root_uri, out tip_uri)) {
 
-                if (mode < 0 || mode >= Marlin.ViewMode.INVALID ||
+                if (mode < 0 || mode >= ViewMode.INVALID ||
                     root_uri == null || root_uri == "" || tip_uri == null) {
 
                     continue;
@@ -1000,11 +1000,11 @@ namespace Marlin.View {
                 restoring_tabs++;
                 add_tab_by_uri (root_uri, mode);
 
-                if (mode == Marlin.ViewMode.MILLER_COLUMNS && tip_uri != root_uri) {
+                if (mode == ViewMode.MILLER_COLUMNS && tip_uri != root_uri) {
                     expand_miller_view (tip_uri, root_uri);
                 }
 
-                mode = Marlin.ViewMode.INVALID;
+                mode = ViewMode.INVALID;
                 root_uri = null;
                 tip_uri = null;
 
@@ -1106,7 +1106,7 @@ namespace Marlin.View {
             GLib.File root = mount.get_root ();
 
             foreach (var page in tabs.get_children ()) {
-                var view_container = (Marlin.View.ViewContainer)page ;
+                var view_container = (View.ViewContainer)page ;
                 GLib.File location = view_container.location;
 
                 if (location == null || location.has_prefix (root) || location.equal (root)) {

--- a/src/ZeitgeistManager.vala
+++ b/src/ZeitgeistManager.vala
@@ -18,7 +18,7 @@
 namespace Marlin {
     public class ZeitgeistManager : Object {
 
-        const string FILES_ACTOR = "application://" + Marlin.APP_DESKTOP;
+        const string FILES_ACTOR = "application://" + APP_DESKTOP;
         const string ATTRS = FileAttribute.STANDARD_DISPLAY_NAME + "," + FileAttribute.STANDARD_CONTENT_TYPE;
 
         public static void report_event (string uri, string interpretation) {


### PR DESCRIPTION
Only keep the explicit namespace for disambiguity cases.