### PR TITLE
Show folder closed after closing tab

### DIFF
--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -155,6 +155,8 @@ public class Files.Directory : Object {
         if (is_trash) {
             disconnect_volume_monitor_signals ();
         }
+
+        file.set_expanded (false); // Ensure any remaining folder icons are not displayed as expanded
     }
 
     /** Views call the following function with null parameter - file_loaded and done_loading

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -384,11 +384,13 @@ namespace Files.View {
             if (directory != null) {
                 directory.cancel ();
                 disconnect_dir_signals ();
+                directory = null;
             }
 
             if (dir_view != null) {
                 dir_view.close ();
                 disconnect_dir_view_signals ();
+                dir_view = null;
             }
         }
 


### PR DESCRIPTION
Fixes #1646 
* Set associated file as unexpanded when Directory destructed
* Ensure Directory ref count reduced when Slot closes.