### PR TITLE
Reduce left gutter in column views

### DIFF
--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -44,7 +44,7 @@ namespace Files {
                 icon_size = value.to_icon_size ();
                 helper_size = (int) (_zoom_level <= ZoomLevel.NORMAL ?
                                      Files.IconSize.EMBLEM : Files.IconSize.LARGE_EMBLEM);
-                h_overlap = helper_size / 2;
+                h_overlap = int.max (12, helper_size / 2);
                 v_overlap = h_overlap;
             }
         }

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -41,8 +41,10 @@ namespace Files {
             set {
                 _zoom_level = value;
                 icon_size = value.to_icon_size ();
-                h_overlap = int.min (icon_size / 8, Files.IconSize.EMBLEM / 2);
-                v_overlap = int.min (icon_size / 8, Files.IconSize.EMBLEM);
+                helper_size = (int) (_zoom_level <= ZoomLevel.NORMAL ?
+                                     Files.IconSize.EMBLEM : Files.IconSize.LARGE_EMBLEM);
+                h_overlap = helper_size / 2;
+                v_overlap = h_overlap;
             }
         }
 
@@ -58,9 +60,9 @@ namespace Files {
             }
         }
 
-        private int h_overlap;
-        private int v_overlap;
-        private int lpad;
+        private int h_overlap; // Horizontal overlap between helper and icon
+        private int v_overlap; // Vertical overlap between helper and icon
+        private int helper_size;
         private bool show_emblems;
         private ZoomLevel _zoom_level = ZoomLevel.NORMAL;
         private Files.File? _file;
@@ -81,7 +83,6 @@ namespace Files {
         }
 
         public IconRenderer (ViewMode view_mode) {
-            lpad = view_mode == ViewMode.LIST ? 4 : 0;
             show_emblems = view_mode == ViewMode.ICON;
             xpad = 0;
         }
@@ -223,9 +224,6 @@ namespace Files {
 
                 Gdk.Rectangle helper_rect = {0, 0, 1, 1};
                 if (special_icon_name != null) {
-                    var helper_size = (int) (zoom_level <= ZoomLevel.NORMAL ?
-                                             Files.IconSize.EMBLEM : Files.IconSize.LARGE_EMBLEM);
-
                     helper_rect.width = helper_size;
                     helper_rect.height = helper_size;
 
@@ -290,13 +288,12 @@ namespace Files {
         }
 
         public override void get_preferred_width (Gtk.Widget widget, out int minimum_size, out int natural_size) {
-            // Add extra width for helper icon and make it easier to click on expander
-            minimum_size = (int) (icon_size) + Files.IconSize.EMBLEM + lpad;
+            minimum_size = (int) (icon_size) + Files.IconSize.EMBLEM - h_overlap;
             natural_size = minimum_size;
         }
 
         public override void get_preferred_height (Gtk.Widget widget, out int minimum_size, out int natural_size) {
-            natural_size = (int) (icon_size);
+            natural_size = (int) (icon_size) + Files.IconSize.EMBLEM - v_overlap;
             minimum_size = natural_size;
         }
 

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -32,6 +32,7 @@ namespace Files {
         public Gdk.Rectangle hover_helper_rect;
         public Gdk.Rectangle hover_rect;
         public bool follow_state {get; set;}
+        public int lpad {get; set; default = 0;}
         public Files.File? drop_file {get; set;}
 
         public ZoomLevel zoom_level {
@@ -99,6 +100,7 @@ namespace Files {
                 file.update_icon (icon_size, icon_scale);
             }
 
+            bool is_rtl = widget.get_direction () == Gtk.TextDirection.RTL;
             Gdk.Pixbuf? pb = pixbuf;
 
             var pix_rect = Gdk.Rectangle ();
@@ -106,9 +108,16 @@ namespace Files {
             pix_rect.width = pixbuf.width / icon_scale;
             pix_rect.height = pixbuf.height / icon_scale;
             if (show_emblems) {
+                // Only IconView uses IconRenderer to show emblems
+                // Center the icon in available width
                 pix_rect.x = cell_area.x + (cell_area.width - pix_rect.width) / 2;
             } else {
-                pix_rect.x = cell_area.x + (cell_area.width - pix_rect.width);
+                // Align.END
+                if (is_rtl) {
+                    pix_rect.x = cell_area.x;
+                } else {
+                    pix_rect.x = cell_area.x + (cell_area.width - pix_rect.width);
+                }
             }
 
             pix_rect.y = cell_area.y + (cell_area.height - pix_rect.height) / 2;
@@ -235,9 +244,15 @@ namespace Files {
                     }
 
                     if (pix != null) {
-                        helper_rect.x = int.max (cell_area.x, draw_rect.x - helper_size + h_overlap);
-                        helper_rect.y = int.max (cell_area.y, draw_rect.y - helper_size + v_overlap);
+                        // Align at start of icon
+                        if (is_rtl) {
+                            helper_rect.x = int.min (cell_area.x + cell_area.width - helper_size,
+                                                     draw_rect.x + draw_rect.width - h_overlap);
+                        } else {
+                            helper_rect.x = int.max (cell_area.x, draw_rect.x - helper_size + h_overlap);
+                        }
 
+                        helper_rect.y = int.max (cell_area.y, draw_rect.y - helper_size + v_overlap);
                         style_context.render_icon (cr, pix, helper_rect.x * icon_scale, helper_rect.y * icon_scale);
                     }
                 }
@@ -255,40 +270,46 @@ namespace Files {
                 var emblem_area = Gdk.Rectangle ();
 
                 foreach (string emblem in file.emblems_list) {
-                     if (pos - 1 > zoom_level) {
-                         break;
-                     }
+                    if (pos - 1 > zoom_level) {
+                        break;
+                    }
 
                     Gdk.Pixbuf? pix = null;
                     var nicon = Files.IconInfo.lookup_from_name (emblem, emblem_size, icon_scale);
 
-                     if (nicon == null) {
-                         continue;
-                     }
+                    if (nicon == null) {
+                        continue;
+                    }
 
-                     pix = nicon.get_pixbuf_nodefault ();
+                    pix = nicon.get_pixbuf_nodefault ();
 
-                     if (pix == null) {
-                         continue;
-                     }
+                    if (pix == null) {
+                        continue;
+                    }
 
-                     emblem_area.y = draw_rect.y + pix_rect.height - v_overlap;
-                     emblem_area.y = int.min (emblem_area.y, cell_area.y + cell_area.height - emblem_size);
+                    emblem_area.y = draw_rect.y + pix_rect.height - v_overlap;
+                    emblem_area.y = int.min (emblem_area.y, cell_area.y + cell_area.height - emblem_size);
 
-                     emblem_area.y -= emblem_size * pos;
-                     emblem_area.y = int.max (cell_area.y, emblem_area.y);
+                    emblem_area.y -= emblem_size * pos;
+                    emblem_area.y = int.max (cell_area.y, emblem_area.y);
 
-                     emblem_area.x = draw_rect.x + pix_rect.width - h_overlap;
-                     emblem_area.x = int.min (emblem_area.x, cell_area.x + cell_area.width - emblem_size);
+                    // Align at end of icon
+                    if (is_rtl) {
+                        emblem_area.x = draw_rect.x - emblem_size + h_overlap;
+                        emblem_area.x = int.max (emblem_area.x, cell_area.x);
+                    } else {
+                        emblem_area.x = draw_rect.x + pix_rect.width - h_overlap;
+                        emblem_area.x = int.min (emblem_area.x, cell_area.x + cell_area.width - emblem_size);
+                    }
 
-                     style_context.render_icon (cr, pix, emblem_area.x * icon_scale, emblem_area.y * icon_scale);
-                     pos++;
+                    style_context.render_icon (cr, pix, emblem_area.x * icon_scale, emblem_area.y * icon_scale);
+                    pos++;
                 }
             }
         }
 
         public override void get_preferred_width (Gtk.Widget widget, out int minimum_size, out int natural_size) {
-            minimum_size = (int) (icon_size) + Files.IconSize.EMBLEM - h_overlap;
+            minimum_size = (int) (icon_size) + Files.IconSize.EMBLEM - h_overlap + lpad;
             natural_size = minimum_size;
         }
 

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -29,8 +29,10 @@ namespace Files {
         }
 
         protected override void set_up_icon_renderer () {
-            icon_renderer = new IconRenderer (ViewMode.MILLER_COLUMNS);
-            icon_renderer.set_property ("follow-state", true);
+            icon_renderer = new IconRenderer (ViewMode.MILLER_COLUMNS) {
+                follow_state = true,
+                lpad = 6
+            };
         }
 
         protected new void on_view_selection_changed () {

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -39,8 +39,10 @@ namespace Files {
         }
 
         protected override void set_up_icon_renderer () {
-            icon_renderer = new Files.IconRenderer (Files.ViewMode.LIST);
-            icon_renderer.set_property ("follow-state", true);
+            icon_renderer = new IconRenderer (ViewMode.LIST) {
+                follow_state = true,
+                lpad = 3
+            };
         }
 
         private void connect_additional_signals () {

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -41,7 +41,7 @@ namespace Files {
         protected override void set_up_icon_renderer () {
             icon_renderer = new IconRenderer (ViewMode.LIST) {
                 follow_state = true,
-                lpad = 3
+                lpad = 6
             };
         }
 


### PR DESCRIPTION
Fixes #1578 

Removes left padding and overlaps helper with icon by half the helper size thereby moving the icon closer to the left margin.

Note that at large icon sizes the helper may not overlap the visible part of the icon because the icon may have a transparent border (e.g. folder icons).