### PR TITLE
Reverse the sorting of dates so that default is most recent first

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -1153,11 +1153,12 @@ public class Files.File : GLib.Object {
         return split[3] == null || split[3] == "";
     }
 
+    // We want date to sort in reverse order by default
     private int compare_files_by_time (Files.File other) {
         if (modified < other.modified)
-            return -1;
-        else if (modified > other.modified)
             return 1;
+        else if (modified > other.modified)
+            return -1;
 
         return 0;
     }


### PR DESCRIPTION
Fixes #1683 

Because we do not control the behaviour of sorting by clicking on the headers (the default is always ASCENDING - not reversed) we have to change the way the model sorts.  So ASCENDING (not reversed) order now gives the most recent date first.