### PR TITLE
Silence critical terminal warnings from Miller View

### DIFF
--- a/libcore/AbstractSlot.vala
+++ b/libcore/AbstractSlot.vala
@@ -34,14 +34,15 @@ namespace Files {
             protected set {_directory = value;}
         }
 
-        public Files.File file {
-            get {return directory.file;}
+        // Directory may be destroyed before the slot so handle case that it is null
+        public Files.File? file {
+            get { return directory != null ? directory.file : null;}
         }
-        public GLib.File location {
-            get {return directory.location;}
+        public GLib.File? location {
+            get { return directory != null ? directory.location : null;}
         }
         public string uri {
-            get {return directory.file.uri;}
+            get { return directory != null ? directory.file.uri : ""; }
         }
 
         public virtual bool locked_focus {
@@ -56,7 +57,7 @@ namespace Files {
         protected Gtk.Box extra_action_widgets;
         protected Gtk.Box content_box;
         public Gtk.Overlay overlay {get; protected set;}
-        protected int slot_number;
+        public int slot_number { get; protected set; }
         protected int width;
 
         public signal void active (bool scroll = true, bool animate = true);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -331,7 +331,7 @@ namespace Files {
         }
 
         ~AbstractDirectoryView () {
-            debug ("ADV destruct");
+            debug ("ADV destruct %s", slot.uri);
         }
 
         protected virtual void set_up_name_renderer () {

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -143,8 +143,8 @@ namespace Files.View {
 
             slot_list.@foreach ((s) => {
                 if (s.slot_number > n) {
-                    s.close ();
                     disconnect_slot_signals (s);
+                    s.close ();
                 }
             });
 

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -90,7 +90,7 @@ namespace Files.View {
         }
 
         ~Slot () {
-            debug ("Slot destruct");
+            debug ("Slot %i destruct", slot_number);
         }
 
         private void connect_slot_signals () {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -291,8 +291,9 @@ namespace Files.View {
         private void before_mode_change () {
             store_selection ();
             /* Make sure async loading and thumbnailing are cancelled and signal handlers disconnected */
-            view.close ();
             disconnect_slot_signals (view);
+            view.close ();
+
             content = null; /* Make sure old slot and directory view are destroyed */
             view = null; /* Pre-requisite for add view */
         }


### PR DESCRIPTION
Fixes #1696 

* Handle case where directory already finalized when Slot is finalized
* Add comments and add extra info in destructor messages
* Disconnect signals before close slot

The warnings were mainly due to trying to get directory information in the slot destructor for debugging purposes - the directory cannot be guaranteed to still exist when the slot is destroyed.  The relevant accessors were modified to handle the case where `directory == null` rather than just modifying the problem debug message identified in case other situations exist or arise.