### PR TITLE
Refactor change_view_mode () to avoid race with slot destruction

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -411,10 +411,12 @@ namespace Files {
             zoom_level = get_normal_zoom_level ();
         }
 
+        private uint set_cursor_timeout_id = 0;
         public void focus_first_for_empty_selection (bool select) {
             if (selected_files == null) {
-                Idle.add_full (GLib.Priority.LOW, () => {
+                set_cursor_timeout_id = Idle.add_full (GLib.Priority.LOW, () => {
                     if (!tree_frozen) {
+                        set_cursor_timeout_id = 0;
                         set_cursor (new Gtk.TreePath.from_indices (0), false, select, true);
                         return GLib.Source.REMOVE;
                     } else {
@@ -3704,6 +3706,7 @@ namespace Files {
             cancel_drag_timer ();
             cancel_timeout (ref drag_scroll_timer_id);
             cancel_timeout (ref add_remove_file_timeout_id);
+            cancel_timeout (ref set_cursor_timeout_id);
             /* List View will take care of unloading subdirectories */
         }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -263,7 +263,7 @@ namespace Files {
         private unowned ClipboardManager clipboard;
         protected Files.ListModel model;
         protected Files.IconRenderer icon_renderer;
-        protected unowned View.Slot slot;
+        protected unowned View.Slot slot; // Must be unowned else cyclic reference stops destruction
         protected unowned View.Window window; /*For convenience - this can be derived from slot */
         protected static DndHandler dnd_handler = new DndHandler ();
 
@@ -331,7 +331,7 @@ namespace Files {
         }
 
         ~AbstractDirectoryView () {
-            debug ("ADV destruct %s", slot.uri);
+            debug ("ADV destruct"); // Cannot reference slot here as it is already invalid
         }
 
         protected virtual void set_up_name_renderer () {

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -278,11 +278,13 @@ namespace Files {
         }
 
         protected override void scroll_to_cell (Gtk.TreePath? path, bool scroll_to_top) {
-            if (tree == null || path == null || slot == null || /* slot should not be null but see lp:1595438 */
+            /* slot && directory should not be null but see lp:1595438  & https://github.com/elementary/files/issues/1699 */
+            if (tree == null || path == null || slot == null || slot.directory == null ||
                 slot.directory.permission_denied || slot.directory.is_empty ()) {
 
                 return;
             }
+
             tree.scroll_to_cell (path, name_column, scroll_to_top, 0.5f, 0.5f);
         }
 

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -277,6 +277,7 @@ namespace Files {
         protected override void scroll_to_cell (Gtk.TreePath? path, bool scroll_to_top) {
             /* slot && directory should not be null but see lp:1595438  & https://github.com/elementary/files/issues/1699 */
             if (tree == null || path == null || slot == null || slot.directory == null ||
+                slot.directory.permission_denied || slot.directory.is_empty ()) {
 
                 return;
             }

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -275,11 +275,12 @@ namespace Files {
         }
 
         protected override void scroll_to_cell (Gtk.TreePath? path, bool scroll_to_top) {
-            if (tree == null || path == null || slot == null || /* slot should not be null but see lp:1595438 */
-                slot.directory.permission_denied || slot.directory.is_empty ()) {
+            /* slot && directory should not be null but see lp:1595438  & https://github.com/elementary/files/issues/1699 */
+            if (tree == null || path == null || slot == null || slot.directory == null ||
 
                 return;
             }
+
             tree.scroll_to_path (path, scroll_to_top, 0.5f, 0.5f);
         }
 

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -384,13 +384,11 @@ namespace Files.View {
             if (directory != null) {
                 directory.cancel ();
                 disconnect_dir_signals ();
-                directory = null;
             }
 
             if (dir_view != null) {
                 dir_view.close ();
                 disconnect_dir_view_signals ();
-                dir_view = null;
             }
         }
 


### PR DESCRIPTION
Fixes #1695
Fixes #1699 

* Do not prematurely force slot, directory and directoryview to null
* Combine some single use functions
* Do not refer to unowned slot in directoryview destructor (its gone)
* Add comments
* Cancel set cursor timeout when closing view
* 
These changes are aimed at stopping code referring to a slot or its directory after that slot or directory has been destroyed.