### PR TITLE
Improve trash context menu

### DIFF
--- a/src/View/Sidebar/PopupMenuBuilder.vala
+++ b/src/View/Sidebar/PopupMenuBuilder.vala
@@ -86,11 +86,15 @@ public class PopupMenuBuilder : Object {
     }
 
     public PopupMenuBuilder add_empty_all_trash (MenuitemCallback bookmark_cb) {
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("Permanently Delete All Trash")), bookmark_cb);
+        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Permanently Delete All Trash"));
+        menu_item.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+        return add_item (menu_item, bookmark_cb);
     }
 
     public PopupMenuBuilder add_empty_mount_trash (MenuitemCallback bookmark_cb) {
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("Permanently Delete Trash on this Mount")), bookmark_cb);
+        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Permanently Delete Trash on this Mount"));
+        menu_item.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+        return add_item (menu_item, bookmark_cb);
     }
 
     public PopupMenuBuilder add_separator () {

--- a/src/View/Sidebar/PopupMenuBuilder.vala
+++ b/src/View/Sidebar/PopupMenuBuilder.vala
@@ -86,11 +86,11 @@ public class PopupMenuBuilder : Object {
     }
 
     public PopupMenuBuilder add_empty_all_trash (MenuitemCallback bookmark_cb) {
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("Empty All Trash")), bookmark_cb);
+        return add_item (new Gtk.MenuItem.with_mnemonic (_("Permanently Delete All Trash")), bookmark_cb);
     }
 
     public PopupMenuBuilder add_empty_mount_trash (MenuitemCallback bookmark_cb) {
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("Empty Trash on this Mount")), bookmark_cb);
+        return add_item (new Gtk.MenuItem.with_mnemonic (_("Permanently Delete Trash on this Mount")), bookmark_cb);
     }
 
     public PopupMenuBuilder add_separator () {


### PR DESCRIPTION
Fixes #1719 

Provide more warning by using "Permanently Delete" instead of "Empty" in trash context menu and adding the "Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION" class to the relevant menu items.