### PR TITLE
Fix empty trash context menu item when already empty

### DIFF
--- a/libcore/FileOperations/EmptyTrashJob.vala
+++ b/libcore/FileOperations/EmptyTrashJob.vala
@@ -107,9 +107,9 @@ public class Files.FileOperations.EmptyTrashJob : CommonJob {
         }
     }
 
-    public async void empty_trash () {
+    public async void empty_trash (bool confirm = Files.Preferences.get_default ().confirm_trash) {
         inhibit_power_manager (_("Emptying Trash"));
-        if (!Files.Preferences.get_default ().confirm_trash || confirm_empty_trash ()) {
+        if (!confirm || confirm_empty_trash ()) {
             progress.start ();
             foreach (unowned GLib.File dir in trash_dirs) {
                 if (aborted ()) {

--- a/libcore/Plugin.vala
+++ b/libcore/Plugin.vala
@@ -19,8 +19,8 @@
 public abstract class Files.Plugins.Base {
     public virtual void directory_loaded (Gtk.ApplicationWindow window, Files.AbstractSlot view, Files.File directory) { }
     public virtual void context_menu (Gtk.Widget widget, List<Files.File> files) { }
-    public virtual void sidebar_loaded (Gtk.Widget widget) { }
-    public virtual void update_sidebar (Gtk.Widget widget) { }
+    public virtual void sidebar_loaded (Gtk.Widget widget) { } // When sidebar first created
+    public virtual void update_sidebar (Gtk.Widget widget) { } // When sidebar cleared
     public virtual void update_file_info (Files.File file) { }
 
     public Gtk.Widget window;

--- a/libcore/SidebarPluginItem.vala
+++ b/libcore/SidebarPluginItem.vala
@@ -21,20 +21,19 @@ public class Files.SidebarPluginItem : Object {
     //TODO This can be simplified with rewritten Sidebar
     public const PlaceType PLACE_TYPE = PlaceType.PLUGIN_ITEM;
     public string name { get; set; }
-    public string? uri { get; set; }
-    public Drive? drive { get; set; }
-    public Volume? volume { get; set; }
-    public Mount? mount { get; set; }
-    public Icon? icon { get; set; }
-    public uint index { get; set; }
-    public bool can_eject { get; set; }
-    public string? tooltip { get; set; }
-    public Icon? action_icon { get; set; }
+    public string? uri { get; set; default = null;}
+    public Drive? drive { get; set; default = null;}
+    public Volume? volume { get; set; default = null;}
+    public Mount? mount { get; set; default = null;}
+    public Icon? icon { get; set; default = null;}
+    public bool can_eject { get; set; default = false;}
+    public string? tooltip { get; set; default = null;}
+    public Icon? action_icon { get; set; default = null;}
     public bool show_spinner { get; set; default = false; }
     public uint64 free_space { get; set; default = 0; }
     public uint64 disk_size { get; set; default = 0; }
-    public ActionGroup? action_group { get; set; }
-    public string? action_group_namespace { get; set; }
-    public MenuModel? menu_model { get; set; }
-    public SidebarCallbackFunc? cb { get; set; } //Not currently used?
+    public ActionGroup? action_group { get; set; default = null;}
+    public string? action_group_namespace { get; set; default = null;}
+    public MenuModel? menu_model { get; set; default = null;}
+    public SidebarCallbackFunc? cb { get; set; default = null;} //Not currently used?
 }

--- a/plugins/pantheon-files-trash/plugin.vala
+++ b/plugins/pantheon-files-trash/plugin.vala
@@ -79,7 +79,7 @@ public class Files.Plugins.Trash : Files.Plugins.Base {
         trash_model.append (_("Permanently Delete All Trash"), "trash.delete-all");
         var item = new Files.SidebarPluginItem () {
             name = _("Trash"),
-            tooltip =  Granite.markup_accel_tooltip ({"<Alt>T"}, _("Open the Trash")),
+            tooltip = Granite.markup_accel_tooltip ({"<Alt>T"}, _("Open the Trash")),
             uri = _(Files.TRASH_URI),
             icon = trash_monitor.get_icon (),
             show_spinner = false,

--- a/src/View/Sidebar/BookmarkListBox.vala
+++ b/src/View/Sidebar/BookmarkListBox.vala
@@ -23,7 +23,6 @@
 public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
     private Files.BookmarkList bookmark_list;
     private unowned Files.TrashMonitor trash_monitor;
-    private SidebarItemInterface? trash_bookmark;
 
     public Files.SidebarInterface sidebar {get; construct;}
 
@@ -150,25 +149,6 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
                 bm.label = row.custom_name;
             });
         }
-
-        if (!Files.is_admin ()) {
-            trash_bookmark = add_bookmark (
-                _("Trash"),
-                _(Files.TRASH_URI),
-                trash_monitor.get_icon (),
-                true
-            );
-        }
-
-        trash_bookmark.set_tooltip_markup (
-            Granite.markup_accel_tooltip ({"<Alt>T"}, _("Open the Trash"))
-        );
-
-        trash_monitor.notify["is-empty"].connect (() => {
-            if (trash_bookmark != null) {
-                trash_bookmark.update_icon (trash_monitor.get_icon ());
-            }
-        });
     }
 
     public override bool add_favorite (string uri,

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -171,12 +171,31 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
     }
 
     protected override void update_plugin_data (Files.SidebarPluginItem item) {
-        name = item.name;
-        uri = item.uri;
-        update_icon (item.icon);
-        menu_model = item.menu_model;
-        action_group = item.action_group;
-        action_group_namespace = item.action_group_namespace;
+        // To remove anything should create a new item.
+        if (item.name != null) {
+            name = item.name;
+        }
+
+        if (item.uri != null) {
+            uri = item.uri;
+        }
+
+        if (item.icon != null) {
+            update_icon (item.icon);
+        }
+
+        if (item.tooltip != null) {
+            set_tooltip_markup (item.tooltip);
+        }
+
+        if (item.menu_model != null) {
+            menu_model = item.menu_model;
+        }
+
+        if (item.action_group != null) {
+            action_group = item.action_group;
+            action_group_namespace = item.action_group_namespace;
+        }
     }
 
     private void rename () {
@@ -272,17 +291,6 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
             menu_builder.add_rename (() => {
                 rename ();
             });
-        }
-
-        if (Uri.parse_scheme (uri) == "trash") {
-            menu_builder
-                .add_separator ()
-                .add_empty_all_trash (() => {
-                    new Files.FileOperations.EmptyTrashJob (
-                        (Gtk.Window)get_ancestor (typeof (Gtk.Window)
-                    )).empty_trash.begin ();
-                })
-            ;
         }
     }
 

--- a/src/View/Sidebar/PopupMenuBuilder.vala
+++ b/src/View/Sidebar/PopupMenuBuilder.vala
@@ -35,7 +35,10 @@ public class PopupMenuBuilder : Object {
                                       ActionGroup? action_group = null) {
 
         var menu = new Gtk.Menu.from_model (model);
-        menu.insert_action_group (action_group_namespace, action_group);
+
+        if (action_group_namespace != null && action_group != null) {
+            menu.insert_action_group (action_group_namespace, action_group);
+        }
 
         for (int i = 0; i < menu_items.length; i++) {
             menu.append (menu_items[i]);
@@ -83,12 +86,6 @@ public class PopupMenuBuilder : Object {
 
     public PopupMenuBuilder add_bookmark (MenuitemCallback bookmark_cb) {
         return add_item (new Gtk.MenuItem.with_mnemonic (_("Add to Bookmarks")), bookmark_cb);
-    }
-
-    public PopupMenuBuilder add_empty_all_trash (MenuitemCallback bookmark_cb) {
-        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Permanently Delete All Trash"));
-        menu_item.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-        return add_item (menu_item, bookmark_cb);
     }
 
     public PopupMenuBuilder add_empty_mount_trash (MenuitemCallback bookmark_cb) {


### PR DESCRIPTION
Fixes #1738 

Rather than patching up the existing code, this PR makes the sidebar Trash Item a plugin item under the control of the Trash plugin which seemed cleaner than the special case code under Sidebar.  However, a drawback of this is that it is not possible to add custom styling to the context menuitems produced so the "Permanently Delete all Trash" item no longer has destructive action styling. 

It could be argued that allowing permanent deletion of trash items "sight unseen" from the sidebar is not a good idea and that that menu option should be removed altogether so that the used must open Trash to see its contents before emptying. That would be simpler.