### PR TITLE
meson: require granite >= 6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You'll need the following dependencies:
 * libgee-0.8-dev
 * libgit2-glib-1.0-dev
 * libglib2.0-dev
-* libgranite-dev >= 6.0.0
+* libgranite-dev >= 6.1.0
 * libgtk-3-dev
 * libhandy-1-dev >= 0.83.0
 * libnotify-dev

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ gio_unix_dep = dependency('gio-unix-2.0', version: '>='+min_glib_version)
 gmodule_dep = dependency('gmodule-2.0', version: '>='+min_glib_version)
 gee_dep = dependency('gee-0.8')
 gtk_dep = dependency('gtk+-3.0', version: '>=3.22.25')
-granite_dep = dependency('granite', version: '>=6.0.0')
+granite_dep = dependency('granite', version: '>=6.1.0')
 handy_dep = dependency('libhandy-1', version: '>=0.83.0')
 
 common_deps = [


### PR DESCRIPTION
Tab.with_accellabels is used in Files, which was added in granite 6.1.0.

Fixes #1754
