### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,9 +1,11 @@
 #ifndef H_CONFIG_H
 #define H_CONFIG_H
 
+#define GETTEXT_PACKAGE "@gettext_package@"
 #define VERSION "@version@"
 #define PLUGIN_DIR "@plugin_dir@"
 #define TESTDATA_DIR "@testdata_dir@"
+#define LOCALE_DIR "@locale_dir@"
 #define APP_NAME "@app_name@"
 #define TERMINAL_NAME "@terminal_name@"
 

--- a/filechooser-portal/Main.vala
+++ b/filechooser-portal/Main.vala
@@ -330,6 +330,7 @@ public int main (string[] args) {
     GLib.Intl.setlocale (GLib.LocaleCategory.ALL, "");
     GLib.Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
     GLib.Intl.textdomain (Config.GETTEXT_PACKAGE);
+    GLib.Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALE_DIR);
 
     /* Avoid pointless and confusing recursion */
     GLib.Environment.unset_variable ("GTK_USE_PORTAL");

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -7,6 +7,7 @@ namespace Config {
     public const string VERSION;
     public const string PLUGIN_DIR;
     public const string TESTDATA_DIR;
+    public const string LOCALE_DIR;
     public const string APP_NAME;
     public const string TERMINAL_NAME;
 }

--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,8 @@ config_data.set('version', meson.project_version())
 config_data.set('testdata_dir', join_paths(meson.source_root(), 'data', 'tests'))
 config_data.set('app_name', meson.project_name())
 config_data.set('terminal_name', terminal_name)
+config_data.set('gettext_package', meson.project_name())
+config_data.set('locale_dir', join_paths(get_option('prefix'), get_option('localedir')))
 
 config_file = configure_file(
     input: 'config.h.in',

--- a/src/main.vala
+++ b/src/main.vala
@@ -17,6 +17,8 @@ public static int main (string[] args) {
     /* Initiliaze gettext support */
     Intl.setlocale (LocaleCategory.ALL, "");
     Intl.textdomain (Config.GETTEXT_PACKAGE);
+    Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALE_DIR);
+    Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
 
     Environment.set_application_name (Config.APP_NAME);
     Environment.set_prgname (Config.APP_NAME);


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)