### PR TITLE
Show translated bookmarks when user language changed

### DIFF
--- a/libcore/Bookmark.vala
+++ b/libcore/Bookmark.vala
@@ -24,23 +24,13 @@ namespace Files {
         public signal void contents_changed ();
         public signal void deleted ();
 
-        private string? custom_name = null;
-        public string label {
-            get {
-                if (custom_name != null && custom_name._strip () != "") {
-                    return custom_name;
-                } else {
-                    return gof_file.get_display_name ();
-                }
-            }
-
-            set {
-                custom_name = value;
-                contents_changed ();
-            }
-        }
+        public string custom_name { get; set; default = "";}
 
         public Files.File gof_file { get; private set; }
+
+        public string basename {
+            get { return gof_file.get_display_name (); }
+        }
 
         public string uri {
             get {
@@ -51,20 +41,20 @@ namespace Files {
         private GLib.FileMonitor monitor;
 
         public static CompareFunc<Bookmark> compare_with = (a, b) => {
-            return (a.gof_file.location.equal (b.gof_file.location)) && (a.label == b.label) ? 0: 1;
+            return (a.gof_file.location.equal (b.gof_file.location)) && (a.custom_name == b.custom_name) ? 0: 1;
         };
 
         public static CompareFunc<Bookmark> compare_uris = (a, b) => {
             return a.gof_file.location.equal (b.gof_file.location) ? 0 : 1;
         };
 
-        public Bookmark (Files.File gof_file, string? label = null) {
+        public Bookmark (Files.File gof_file, string label = "") {
             this.gof_file = gof_file;
             this.custom_name = label;
             connect_file ();
         }
 
-        public Bookmark.from_uri (string uri, string? label = null) {
+        public Bookmark.from_uri (string uri, string label = "") {
             this.gof_file = Files.File.get_by_uri (uri);
             this.custom_name = label;
             connect_file ();

--- a/libcore/Bookmark.vala
+++ b/libcore/Bookmark.vala
@@ -50,13 +50,19 @@ namespace Files {
 
         public Bookmark (Files.File gof_file, string label = "") {
             this.gof_file = gof_file;
-            this.custom_name = label;
+            if (label != gof_file.basename) {
+                this.custom_name = label;
+            }
+
             connect_file ();
         }
 
         public Bookmark.from_uri (string uri, string label = "") {
             this.gof_file = Files.File.get_by_uri (uri);
-            this.custom_name = label;
+            if (label != gof_file.basename) {
+                this.custom_name = label;
+            }
+
             connect_file ();
         }
 

--- a/libcore/Bookmark.vala
+++ b/libcore/Bookmark.vala
@@ -40,11 +40,8 @@ namespace Files {
 
         private GLib.FileMonitor monitor;
 
+        // Do not consider custom name when comparing bookmarks.  We only want one bookmark per URI.
         public static CompareFunc<Bookmark> compare_with = (a, b) => {
-            return (a.gof_file.location.equal (b.gof_file.location)) && (a.custom_name == b.custom_name) ? 0: 1;
-        };
-
-        public static CompareFunc<Bookmark> compare_uris = (a, b) => {
             return a.gof_file.location.equal (b.gof_file.location) ? 0 : 1;
         };
 

--- a/libcore/BookmarkList.vala
+++ b/libcore/BookmarkList.vala
@@ -135,15 +135,15 @@ namespace Files {
             return instance;
         }
 
-        public Bookmark insert_uri (string uri, uint index, string? label = null) {
-            var bm = new Bookmark.from_uri (uri, label);
+        public Bookmark insert_uri (string uri, uint index, string custom_name = "") {
+            var bm = new Bookmark.from_uri (uri, custom_name);
             insert_item_internal (bm, index);
             save_bookmarks_file ();
             return bm;
         }
 
-        public Bookmark insert_uri_at_end (string uri, string? label = null) {
-            var bm = new Bookmark.from_uri (uri, label);
+        public Bookmark insert_uri_at_end (string uri, string custom_name = "") {
+            var bm = new Bookmark.from_uri (uri, custom_name);
             append_internal (bm);
             save_bookmarks_file ();
             return bm;
@@ -155,7 +155,7 @@ namespace Files {
                 return;
             }
             uris.@foreach ((uri) => {
-                insert_item_internal (new Bookmark.from_uri (uri, null), index);
+                insert_item_internal (new Bookmark.from_uri (uri), index);
                 index++;
             });
             save_bookmarks_file ();
@@ -179,7 +179,7 @@ namespace Files {
         public void rename_item_with_uri (string uri, string new_name) {
             foreach (unowned Files.Bookmark bookmark in list) {
                 if (uri == bookmark.uri) {
-                    bookmark.label = new_name;
+                    bookmark.custom_name = new_name;
                     save_bookmarks_file ();
                     return;
                 }
@@ -335,7 +335,7 @@ namespace Files {
 
             list.@foreach ((bookmark) => {
                 sb.append (bookmark.uri);
-                sb.append (" " + bookmark.label);
+                sb.append (" " + bookmark.custom_name);
                 sb.append ("\n");
             });
 

--- a/libcore/BookmarkList.vala
+++ b/libcore/BookmarkList.vala
@@ -310,6 +310,7 @@ namespace Files {
             list.@foreach (stop_monitoring_bookmark);
 
             uint count = 0;
+            bool change_made = false;
             string [] lines = contents.split ("\n");
             foreach (string line in lines) {
                 if (line[0] == '\0' || line[0] == ' ') {
@@ -317,18 +318,21 @@ namespace Files {
                 }
 
                 string [] parts = line.split (" ", 2);
-                if (parts.length == 2) {
-                    append_internal (new Files.Bookmark.from_uri (parts [0], parts [1]));
-                } else {
-                    append_internal (new Files.Bookmark.from_uri (parts [0]));
+                string uri = parts[0];
+                string custom_name = parts.length == 2 ? parts[1] : "";
+                if (custom_name == Path.get_basename (uri)) { // Custom names cannot be the same as the default name
+                    custom_name = "";
+                    change_made = true; // Write back corrected bookmark
                 }
+
+                append_internal (new Files.Bookmark.from_uri (uri, custom_name));
 
                 count++;
             }
 
             list.@foreach (start_monitoring_bookmark);
 
-            if (list.length () > count) { // Can be assumed to be limited in length
+            if (change_made || list.length () > count) { // Can be assumed to be limited in length
                 /* renew bookmark that was deleted when bookmarks file was changed externally */
                 save_bookmarks_file ();
             }

--- a/libcore/BookmarkList.vala
+++ b/libcore/BookmarkList.vala
@@ -320,7 +320,10 @@ namespace Files {
                 string [] parts = line.split (" ", 2);
                 string uri = parts[0];
                 string custom_name = parts.length == 2 ? parts[1] : "";
-                if (custom_name == Path.get_basename (uri)) { // Custom names cannot be the same as the default name
+                if (custom_name != "" &&
+                    (custom_name.strip () == "" || // Custom name cannot be all whitespace
+                    custom_name == Path.get_basename (uri))) { // Custom names cannot be the same as the default name
+
                     custom_name = "";
                     change_made = true; // Write back corrected bookmark
                 }
@@ -344,7 +347,10 @@ namespace Files {
 
             list.@foreach ((bookmark) => {
                 sb.append (bookmark.uri);
-                sb.append (" " + bookmark.custom_name);
+                if (bookmark.custom_name.strip () != "") {
+                    sb.append (" " + bookmark.custom_name);
+                }
+
                 sb.append ("\n");
             });
 

--- a/libcore/BookmarkList.vala
+++ b/libcore/BookmarkList.vala
@@ -179,7 +179,12 @@ namespace Files {
         public void rename_item_with_uri (string uri, string new_name) {
             foreach (unowned Files.Bookmark bookmark in list) {
                 if (uri == bookmark.uri) {
-                    bookmark.custom_name = new_name;
+                    if (new_name == Path.get_basename (uri)) {
+                        // Do not use basename as a custom name
+                        bookmark.custom_name = "";
+                    } else {
+                        bookmark.custom_name = new_name;
+                    }
                     save_bookmarks_file ();
                     return;
                 }

--- a/libcore/Interfaces/SidebarInterface.vala
+++ b/libcore/Interfaces/SidebarInterface.vala
@@ -43,7 +43,7 @@ public interface Files.SidebarInterface : Gtk.Widget {
         public signal void sync_needed ();
         public signal void path_change_request (string uri, Files.OpenFlag flag);
         public signal void connect_server_request ();
-        public abstract void add_favorite_uri (string uri, string? label = null);
+        public abstract void add_favorite_uri (string uri, string custom_name = "");
         public abstract bool has_favorite_uri (string uri);
         public abstract void sync_uri (string uri);
         public abstract void reload ();

--- a/libwidgets/View/SearchResults.vala
+++ b/libwidgets/View/SearchResults.vala
@@ -72,8 +72,8 @@ namespace Files.View.Chrome {
 
             public Match.from_bookmark (Bookmark bookmark, SearchResults.Category category) {
                 var _name = bookmark.custom_name != "" && bookmark.custom_name != bookmark.basename ?
-                _("%s (%s)").printf (bookmark.custom_name, bookmark.basename) :
-                bookmark.basename;
+                    _("%s (%s)").printf (bookmark.custom_name, bookmark.basename) :
+                    bookmark.basename;
                 Object (
                         name: Markup.escape_text (_name),
                         mime: "inode/directory",

--- a/libwidgets/View/SearchResults.vala
+++ b/libwidgets/View/SearchResults.vala
@@ -70,12 +70,13 @@ namespace Files.View.Chrome {
             }
 
             public Match.from_bookmark (Bookmark bookmark, SearchResults.Category category) {
-                Object (name: Markup.escape_text (bookmark.label),
+                Object (name: Markup.escape_text (bookmark.basename),
                         mime: "inode/directory",
                         icon: bookmark.get_icon (),
                         path_string: "",
                         file: bookmark.get_location (),
-                        sortkey: category.to_string () + bookmark.label);
+                        sortkey: category.to_string () + bookmark.basename
+                );
             }
 
             public Match.ellipsis (SearchResults.Category category) {
@@ -400,7 +401,7 @@ namespace Files.View.Chrome {
             var bookmarks_matched = new Gee.LinkedList<Match> ();
             var begins_with = false;
             foreach (var bookmark in BookmarkList.get_instance ().list) {
-                if (term_matches (search_term, bookmark.label, out begins_with)) {
+                if (term_matches (search_term, bookmark.basename, out begins_with)) {
                     var category = begins_with ? Category.BOOKMARK_BEGINS : Category.BOOKMARK_CONTAINS;
                     bookmarks_matched.add (new Match.from_bookmark (bookmark, category));
                 }

--- a/libwidgets/View/SearchResults.vala
+++ b/libwidgets/View/SearchResults.vala
@@ -67,15 +67,20 @@ namespace Files.View.Chrome {
                         path_string: path_string,
                         file: parent.resolve_relative_path (info.get_name ()),
                         sortkey: category.to_string () + _name);
+
             }
 
             public Match.from_bookmark (Bookmark bookmark, SearchResults.Category category) {
-                Object (name: Markup.escape_text (bookmark.basename),
+                var _name = bookmark.custom_name != "" && bookmark.custom_name != bookmark.basename ?
+                _("%s (%s)").printf (bookmark.custom_name, bookmark.basename) :
+                bookmark.basename;
+                Object (
+                        name: Markup.escape_text (_name),
                         mime: "inode/directory",
                         icon: bookmark.get_icon (),
                         path_string: "",
                         file: bookmark.get_location (),
-                        sortkey: category.to_string () + bookmark.basename
+                        sortkey: category.to_string () + _name
                 );
             }
 
@@ -401,7 +406,7 @@ namespace Files.View.Chrome {
             var bookmarks_matched = new Gee.LinkedList<Match> ();
             var begins_with = false;
             foreach (var bookmark in BookmarkList.get_instance ().list) {
-                if (term_matches (search_term, bookmark.basename, out begins_with)) {
+                if (term_matches (search_term, bookmark.basename + bookmark.custom_name, out begins_with)) {
                     var category = begins_with ? Category.BOOKMARK_BEGINS : Category.BOOKMARK_CONTAINS;
                     bookmarks_matched.add (new Match.from_bookmark (bookmark, category));
                 }

--- a/po/extra/ru.po
+++ b/po/extra/ru.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: pantheon-files\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-08-26 21:31+0000\n"
-"PO-Revision-Date: 2021-08-27 17:39+0000\n"
-"Last-Translator: asdffdsdaf <asdffdsdaf@gmail.com>\n"
+"PO-Revision-Date: 2021-08-29 10:04+0000\n"
+"Last-Translator: DartDeaDia <dartdeadia@protonmail.com>\n"
 "Language-Team: Russian <https://l10n.elementary.io/projects/files/extra/ru/>"
 "\n"
 "Language: ru\n"
@@ -28,7 +28,7 @@ msgstr "Файлы"
 
 #: data/io.elementary.files.desktop.in.in:4
 msgid "Browse your files"
-msgstr "Обзор ваших файлов"
+msgstr "Просматривайте свои файлы"
 
 #: data/io.elementary.files.desktop.in.in:5
 msgid "folder;manager;explore;disk;filesystem;"

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1150,7 +1150,7 @@ namespace Files {
                 location = slot.directory.file.get_target_location ();
             }
 
-            window.bookmark_uri (location.get_uri (), null);
+            window.bookmark_uri (location.get_uri ());
         }
 
         /** Background actions */

--- a/src/View/Sidebar/BookmarkListBox.vala
+++ b/src/View/Sidebar/BookmarkListBox.vala
@@ -144,10 +144,10 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
         }
 
         foreach (unowned Files.Bookmark bm in bookmark_list.list) {
-            row = add_bookmark (bm.label, bm.uri, bm.get_icon ());
+            row = add_bookmark (bm.custom_name, bm.uri, bm.get_icon ());
             row.set_tooltip_text (Files.FileUtils.sanitize_path (bm.uri, null, false));
             row.notify["custom-name"].connect (() => {
-                bm.label = row.custom_name;
+                bm.custom_name = row.custom_name;
             });
         }
 
@@ -176,7 +176,7 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
     }
 
     public override bool add_favorite (string uri,
-                                       string? label = null,
+                                       string custom_name = "",
                                        int pos = 0) {
 
         int pinned = 0; // Assume pinned items only at start and end of list
@@ -192,9 +192,9 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
             pos = pinned;
         }
 
-        var bm = bookmark_list.insert_uri (uri, pos - pinned, label); //Assume non_builtin items are not pinned
+        var bm = bookmark_list.insert_uri (uri, pos - pinned, custom_name); //Assume non_builtin items are not pinned
         if (bm != null) {
-            insert_bookmark (bm.label, bm.uri, bm.get_icon (), pos);
+            insert_bookmark (bm.custom_name, bm.uri, bm.get_icon (), pos);
             return true;
         } else {
             return false;

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -69,7 +69,17 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
     protected Gtk.Label label;
     protected Gtk.Revealer drop_revealer;
 
-    public string custom_name { get; set construct; }
+    public string custom_name { get; set; default = "";}
+    public string display_name {
+        get {
+            if (custom_name.strip () != "") {
+                return custom_name;
+            } else {
+                return target_file.get_display_name ();
+            }
+        }
+    }
+
     public SidebarListInterface list { get; construct; }
     public uint32 id { get; construct; }
     public string uri { get; set construct; }
@@ -81,14 +91,14 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
     public ActionGroup? action_group {get; set; default = null;}
     public string? action_group_namespace { get; set; default = null;}
 
-    public BookmarkRow (string name,
+    public BookmarkRow (string _custom_name,
                         string uri,
                         Icon gicon,
                         SidebarListInterface list,
                         bool pinned,
                         bool permanent) {
         Object (
-            custom_name: name,
+            custom_name: _custom_name,
             uri: uri,
             gicon: gicon,
             list: list,
@@ -116,19 +126,18 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
         SidebarItemInterface.item_id_map.@set (id, this);
         item_map_lock.unlock ();
 
-        var label = new Gtk.Label (custom_name) {
+        var label = new Gtk.Label (display_name) {
             xalign = 0.0f,
             halign = Gtk.Align.START,
             hexpand = true,
             ellipsize = Pango.EllipsizeMode.END
         };
 
-        bind_property ("custom-name", label, "label", BindingFlags.DEFAULT);
-
         label_stack = new Gtk.Stack () {
             homogeneous = false
         };
         label_stack.add_named (label, "label");
+
         if (!pinned) {
             editable = new Gtk.Entry ();
             label_stack.add_named (editable, "editable");
@@ -171,10 +180,14 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
         notify["gicon"].connect (() => {
             icon.set_from_gicon (gicon, Gtk.IconSize.MENU);
         });
+
+        notify["custom-name"].connect (() => {
+            label.label = display_name;
+        });
     }
 
     protected override void update_plugin_data (Files.SidebarPluginItem item) {
-        name = item.name;
+        custom_name = item.name;
         uri = item.uri;
         update_icon (item.icon);
         menu_model = item.menu_model;
@@ -184,7 +197,7 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
 
     private void rename () {
         if (!pinned) {
-            editable.text = custom_name;
+            editable.text = display_name;
             label_stack.visible_child_name = "editable";
             editable.grab_focus ();
         }
@@ -532,7 +545,7 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
 
             var pos = get_index ();
             pos++;
-            return list.add_favorite (drop_file_list.data.get_uri (), null, pos);
+            return list.add_favorite (drop_file_list.data.get_uri (), "", pos);
         } else {
             var dnd_handler = new Files.DndHandler ();
             var real_action = ctx.get_selected_action ();

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -463,6 +463,12 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
             // Set the suggested action only when revealer state changes
             if (reveal && !drop_revealer.reveal_child) {
                 current_suggested_action = Gdk.DragAction.LINK; //A bookmark is effectively a link
+                if (target.name () == "text/uri-list" && drop_text != null &&
+                    list.has_uri (drop_text.strip ())) { //Need to remove trailing newline
+
+                    current_suggested_action = Gdk.DragAction.DEFAULT; //Do not allowing dropping duplicate URI
+                    reveal = false;
+                }
             } else if (!reveal && drop_revealer.reveal_child &&
                        drop_text != null &&
                        target.name () == "text/uri-list") {

--- a/src/View/Sidebar/SidebarItemInterface.vala
+++ b/src/View/Sidebar/SidebarItemInterface.vala
@@ -45,7 +45,7 @@ public interface Sidebar.SidebarItemInterface : Gtk.Widget {
     public abstract SidebarListInterface list { get; construct; }
     public abstract uint32 id { get; construct; }
     public abstract string uri { get; set construct; }
-    public abstract string custom_name { get; set construct; }
+    public abstract string custom_name { get; set ; }
     public abstract Icon gicon { get; set construct; }
     public abstract bool pinned { get; construct; default = false;} //Whether can be reordered
     public abstract bool permanent { get; construct; default = false;} //Whether can be deleted

--- a/src/View/Sidebar/SidebarListInterface.vala
+++ b/src/View/Sidebar/SidebarListInterface.vala
@@ -92,7 +92,7 @@ public interface Sidebar.SidebarListInterface : Gtk.Container {
     }
 
     /* Returns true if favorite successfully added */
-    public virtual bool add_favorite (string uri, string? label = null, int index = 0) { return false; }
+    public virtual bool add_favorite (string uri, string label = "", int index = 0) { return false; }
 
     public virtual SidebarItemInterface? get_item_at_index (int index) { return null; }
 

--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -248,8 +248,8 @@ public class Sidebar.SidebarWindow : Gtk.Grid, Files.SidebarInterface {
         });
     }
 
-    public void add_favorite_uri (string uri, string? label = null) {
-        bookmark_listbox.add_favorite (uri, label);
+    public void add_favorite_uri (string uri, string custom_name = "") {
+        bookmark_listbox.add_favorite (uri, custom_name);
     }
 
     public bool has_favorite_uri (string uri) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -595,8 +595,8 @@ namespace Files.View {
             return prefix + name;
         }
 
-        public void bookmark_uri (string uri, string? name = null) {
-            sidebar.add_favorite_uri (uri, name);
+        public void bookmark_uri (string uri, string custom_name = "") {
+            sidebar.add_favorite_uri (uri, custom_name);
         }
 
         public bool can_bookmark_uri (string uri) {


### PR DESCRIPTION
Fixes #1818

The custom name was being filled in with the basename when there was no custom name and this was being written to the bookmark list. This resulted in the untranslated ("custom") name being shown even if the bookmarked locations names were changed as a result of a system language change.  This PR stops the blurring of the custom name property - it now always returns the custom name or blank if none is set.

* Custom_name always returns custom name or blank
* Add BookmarkRow property `display_name` to return visible name
* Avoid `null` for custom name
* Avoid some ambiguous property and parameter names

