### PR TITLE
Paste into background folder by default

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -82,7 +82,8 @@ namespace Files {
 
         const GLib.ActionEntry [] COMMON_ENTRIES = {
             {"copy", on_common_action_copy},
-            {"paste-into", on_common_action_paste_into},
+            {"paste-into", on_common_action_paste_into}, // Paste into selected folder
+            {"paste", on_common_action_paste}, // Paste into background folder
             {"open-in", on_common_action_open_in, "s"},
             {"bookmark", on_common_action_bookmark},
             {"properties", on_common_action_properties},
@@ -223,6 +224,7 @@ namespace Files {
                         action_set_enabled (selection_actions, "cut", false);
                         action_set_enabled (common_actions, "copy", false);
                         action_set_enabled (common_actions, "paste-into", false);
+                        action_set_enabled (common_actions, "paste", false);
 
                         /* Fix problems when navigating away from directory with large number
                          * of selected files (e.g. OverlayBar critical errors)
@@ -1262,6 +1264,19 @@ namespace Files {
             clipboard.copy_files (get_selected_files_for_transfer (get_files_for_action ()));
         }
 
+        private void on_common_action_paste (GLib.SimpleAction action, GLib.Variant? param) {
+            if (clipboard.can_paste && !(clipboard.files_linked && in_trash)) {
+                var target = slot.location;
+                clipboard.paste_files.begin (target, this as Gtk.Widget, (obj, res) => {
+                    clipboard.paste_files.end (res);
+                    if (target.has_uri_scheme ("trash")) {
+                        /* Pasting files into trash is equivalent to trash or delete action */
+                        after_trash_or_delete ();
+                    }
+                });
+            }
+        }
+
         private void on_common_action_paste_into (GLib.SimpleAction action, GLib.Variant? param) {
             var file = get_files_for_action ().nth_data (0);
 
@@ -1960,8 +1975,8 @@ namespace Files {
                 menu.add (open_submenu_item);
             }
 
-            var paste_menuitem = new Gtk.MenuItem.with_label (_("Paste"));
-            paste_menuitem.action_name = "common.paste-into";
+            var paste_menuitem = new Gtk.MenuItem ();
+            paste_menuitem.action_name = "common.paste";
 
             var bookmark_menuitem = new Gtk.MenuItem ();
             bookmark_menuitem.add (new Granite.AccelLabel (
@@ -2032,9 +2047,7 @@ namespace Files {
                     menu.add (new Gtk.SeparatorMenuItem ());
                     menu.add (properties_menuitem);
                 } else {
-                    if (slot.directory.file.is_smb_server () && clipboard != null && clipboard.can_paste) {
-                        menu.add (paste_menuitem);
-                    } else if (valid_selection_for_edit ()) {
+                    if (valid_selection_for_edit ()) {
                         var rename_menuitem = new Gtk.MenuItem ();
                         rename_menuitem.add (new Granite.AccelLabel (
                             _("Rename…"),
@@ -2057,17 +2070,34 @@ namespace Files {
                         menu.add (copy_menuitem);
                         menu.add (copy_link_menuitem);
 
+                        if (common_actions.get_action_enabled ("paste") &&
+                            clipboard != null && clipboard.can_paste) {
+
+                            paste_menuitem.add (new Granite.AccelLabel (
+                                _("Paste"),
+                                "<Ctrl>v"
+                            ));
+                            menu.add (paste_menuitem);
+                        }
+
                         // Do not display the 'Paste into' menuitem if nothing to paste
                         if (common_actions.get_action_enabled ("paste-into") &&
                             clipboard != null && clipboard.can_paste) {
 
+                            var paste_into_menuitem = new Gtk.MenuItem ();
                             if (clipboard.files_linked) {
-                                paste_menuitem.label = _("Paste Link into Folder");
+                                paste_into_menuitem.add (new Granite.AccelLabel (
+                                    _("Paste Link into Selected Folder"),
+                                    "<Shift><Ctrl>v"
+                                ));
                             } else {
-                                paste_menuitem.label = _("Paste into Folder");
+                                paste_into_menuitem.add (new Granite.AccelLabel (
+                                    _("Paste into Selected Folder"),
+                                    "<Shift><Ctrl>v"
+                                ));
                             }
 
-                            menu.add (paste_menuitem);
+                            menu.add (paste_into_menuitem);
                         }
 
                         menu.add (new Gtk.SeparatorMenuItem ());
@@ -2091,7 +2121,7 @@ namespace Files {
                     menu.add (new Gtk.SeparatorMenuItem ());
                     menu.add (properties_menuitem);
                 }
-            } else {
+            } else { // No selected files
                 var show_hidden_menuitem = new Gtk.CheckMenuItem ();
                 show_hidden_menuitem.add (new Granite.AccelLabel (
                     _("Show Hidden Files"),
@@ -2107,6 +2137,10 @@ namespace Files {
 
                 if (in_trash) {
                     if (clipboard != null && clipboard.has_cutted_file (null)) {
+                        paste_menuitem.add (new Granite.AccelLabel (
+                            _("Paste into Trash"),
+                            "<Ctrl>v"
+                        ));
                         menu.add (paste_menuitem);
                     }
                 } else if (in_recent) {
@@ -2122,7 +2156,15 @@ namespace Files {
                         /* If something is pastable in the clipboard, show the option even if it is not enabled */
                         if (clipboard != null && clipboard.can_paste) {
                             if (clipboard.files_linked) {
-                                paste_menuitem.label = _("Paste Link");
+                                paste_menuitem.add (new Granite.AccelLabel (
+                                    _("Paste Link"),
+                                    "<Ctrl>v"
+                                ));
+                            } else {
+                                paste_menuitem.add (new Granite.AccelLabel (
+                                    _("Paste"),
+                                    "<Ctrl>v"
+                                ));
                             }
 
                             menu.add (paste_menuitem);
@@ -2345,6 +2387,7 @@ namespace Files {
             can_open = can_open_file (file);
             can_show_properties = !(in_recent && more_than_one_selected);
 
+            action_set_enabled (common_actions, "paste", !in_recent && is_writable);
             action_set_enabled (common_actions, "paste-into", can_paste_into);
             action_set_enabled (common_actions, "open-in", only_folders);
             action_set_enabled (selection_actions, "rename", is_selected && !more_than_one_selected && can_rename);
@@ -3051,8 +3094,23 @@ namespace Files {
 
                     break;
 
-                case Gdk.Key.v:
-                case Gdk.Key.V:
+                case Gdk.Key.v:  // Standard paste shortcut action - always paste into background folder
+                    if (only_control_pressed) {
+                        if (!in_recent && is_writable) {
+                            action_set_enabled (common_actions, "paste", true);
+                            common_actions.activate_action ("paste", null);
+                        } else {
+                            PF.Dialogs.show_warning_dialog (_("Cannot paste files here"),
+                                                            _("You do not have permission to change this location"),
+                                                            window as Gtk.Window);
+                        }
+
+                        res = true;
+                    }
+
+                    break;
+
+                case Gdk.Key.V: // Alternative paste shortcut action - paste into selected folder if there is one
                     if (only_control_pressed) {
                         update_selected_files_and_menu ();
                         if (!in_recent && is_writable) {


### PR DESCRIPTION
Fixes #1827 

* `<Ctrl>v` always pastes into background (in line with other file managers (e.g. Nautilus, Dolphin etc)
* `<Shift><Ctrl>v` pastes into selected folder