### PR TITLE
Removing annoying message to report bugs

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -130,7 +130,7 @@ public class Files.Application : Gtk.Application {
             return 1;
         };
 
-        message ("Report any issues/bugs you might find to https://github.com/elementary/files/issues");
+        /* message ("Report any issues/bugs you might find to https://github.com/elementary/files/issues"); */
         this.hold ();
         int result = _command_line (cmd);
         this.release ();


### PR DESCRIPTION
Files works great from the command-line, but the standard message it prints to "Report any issues/bugs you might find to https://github.com/elementary/files/issues" starts to get old after 417 times ;-)

This message is more useful for the devs than the user. As a user, I would this line to go away. There is no "quiet" option, so this is the best next thing.