### PR TITLE
Unmount instead of ejecting drives with multiple volumes

### DIFF
--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -169,6 +169,8 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
     }
 
     protected void update_visibilities () {
+        unmount_eject_button.tooltip_text =
+            (can_eject ? _("Eject '%s'") : _("Unmount '%s'")).printf (custom_name);
         unmount_eject_revealer.reveal_child = can_unmount;
         storage_levelbar.visible = is_mounted;
     }

--- a/src/View/Sidebar/VolumeRow.vala
+++ b/src/View/Sidebar/VolumeRow.vala
@@ -41,6 +41,13 @@ public class Sidebar.VolumeRow : Sidebar.AbstractMountableRow, SidebarItemInterf
         }
     }
 
+    public override bool can_eject {
+        get {
+            bool should_eject = drive != null ? drive.get_volumes ().length () == 1 : true;
+            return (is_mounted && volume.get_mount ().can_eject () && should_eject);
+        }
+    }
+
     public VolumeRow (string name, string uri, Icon gicon, SidebarListInterface list,
                          bool pinned, bool permanent,
                          string? _uuid, Volume _volume) {


### PR DESCRIPTION

If a removable drive has multiple partitions and we mount one or more, then clicking the unmount/eject button ejects the drive including unmounting any other partitions that are still mounted, preventing the ability to only unmount the intended partition while not affecting the rest, as a user might expect.

This PR sets the eject button and tooltip to say "unmount" instead of "eject" and also fixes the blank custom name (label) in the tooltip due to the virtual property `can_eject` being called too early in the object construction.

If the drive has only a single volume/partition then the behaviour is unchanged - the button ejects and the tooltip shows "eject...".
