### PR TITLE
check for drop below trash icon

### DIFF
--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -498,7 +498,15 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
             var pos = get_index ();
             if (pos > 0) {
                 var previous_item = (BookmarkRow?)(list.get_item_at_index (pos - 1));
-                if (previous_item != null) {
+                var next_item = list.get_item_at_index (pos + 1);
+                // Drop below trash icon
+                if(!(next_item is BookmarkRow)) {
+                    // Do not allow dropping below trash icon
+                    current_suggested_action = Gdk.DragAction.DEFAULT; 
+                    reveal = false;
+                }
+                else if (previous_item != null) {
+
                     previous_item.reveal_drop_target (false);
                 }
             }

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -500,9 +500,9 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
                 var previous_item = (BookmarkRow?)(list.get_item_at_index (pos - 1));
                 var next_item = list.get_item_at_index (pos + 1);
                 // Drop below trash icon
-                if(!(next_item is BookmarkRow)) {
+                if ( !(next_item is BookmarkRow)) {
                     // Do not allow dropping below trash icon
-                    current_suggested_action = Gdk.DragAction.DEFAULT; 
+                    current_suggested_action = Gdk.DragAction.DEFAULT;
                     reveal = false;
                 } else if (previous_item != null) {
                     previous_item.reveal_drop_target (false);

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -504,9 +504,7 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
                     // Do not allow dropping below trash icon
                     current_suggested_action = Gdk.DragAction.DEFAULT; 
                     reveal = false;
-                }
-                else if (previous_item != null) {
-
+                } else if (previous_item != null) {
                     previous_item.reveal_drop_target (false);
                 }
             }


### PR DESCRIPTION
Here it is checked if the lower element is still of type BookmarkRow. 
If not, the drop is not allowed, so the error message does not appear anymore. 
So the trash can icon always remains the last bookmark in the list.

This is aimed at issue #1821 