### PR TITLE
File: Fallback to generic icon if lookup fails

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -425,7 +425,7 @@ public class Files.File : GLib.Object {
 
         if (gicon != null) {
             icon = Files.IconInfo.lookup (gicon, size, scale);
-            if (icon != null && icon.is_fallback ()) {
+            if (icon == null || icon.is_fallback ()) {
                 icon = Files.IconInfo.get_generic_icon (size, scale);
             }
         } else {


### PR DESCRIPTION
It's possible for `IconInfo.lookup` to return `null`, so we should fallback to the generic icon in this case.

This potentially f*xes #1862 