### PR TITLE
filechooser-portal: Check for flatpak-builder before providing a build target

### DIFF
--- a/filechooser-portal/meson.build
+++ b/filechooser-portal/meson.build
@@ -51,16 +51,19 @@ configure_file(
     install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'dbus-1', 'services')
 )
 
-custom_target(
-    'portal-tester',
-    command: [
-        'flatpak-builder',
-        '--user',
-        '--install',
-        meson.current_build_dir() / 'tests' / 'builddir',
-        meson.current_source_dir() / 'tests' / 'io.elementary.Files.PortalTester.yml',
-        '--force-clean'
-    ],
-    capture: true,
-    output: 'io.elementary.Files.PortalTester'
-)
+flatpak_builder = find_program('flatpak-builder', required: false)
+if (flatpak_builder.found())
+    custom_target(
+        'portal-tester',
+        command: [
+            flatpak_builder,
+            '--user',
+            '--install',
+            meson.current_build_dir() / 'tests' / 'builddir',
+            meson.current_source_dir() / 'tests' / 'io.elementary.Files.PortalTester.yml',
+            '--force-clean'
+        ],
+        capture: true,
+        output: 'io.elementary.Files.PortalTester'
+    )
+endif


### PR DESCRIPTION
This allows to build without flatpak-builder in newer meson version as the command
line arguments were actually checked.