### PR TITLE
Use the elementary platform and sdk for portal tester

### DIFF
--- a/filechooser-portal/tests/io.elementary.Files.PortalTester.yml
+++ b/filechooser-portal/tests/io.elementary.Files.PortalTester.yml
@@ -1,7 +1,7 @@
 app-id: io.elementary.Files.PortalTester
-runtime: org.gnome.Platform
-runtime-version: '3.38'
-sdk: org.gnome.Sdk
+runtime: io.elementary.Platform
+runtime-version: '6'
+sdk: io.elementary.Sdk
 command: io.elementary.Files.PortalTester
 finish-args:
   # X11 + XShm access


### PR DESCRIPTION
Not sure how long we need to support a separate portal tester here but might as well use the elementary platform and sdk.