### PR TITLE
Inactivate browser button if dragged.

### DIFF
--- a/libwidgets/Chrome/ButtonWithMenu.vala
+++ b/libwidgets/Chrome/ButtonWithMenu.vala
@@ -136,10 +136,20 @@ namespace Files.View.Chrome {
             mnemonic_activate.connect (on_mnemonic_activate);
 
             events |= Gdk.EventMask.BUTTON_PRESS_MASK |
-                      Gdk.EventMask.BUTTON_RELEASE_MASK;
+                      Gdk.EventMask.BUTTON_RELEASE_MASK |
+                      Gdk.EventMask.BUTTON_MOTION_MASK;
 
             button_press_event.connect (on_button_press_event);
             button_release_event.connect (on_button_release_event);
+            motion_notify_event.connect (() => {
+                if (timeout > 0) {
+                    Source.remove (timeout);
+                    timeout = 0;
+                    active = false;
+                }
+
+                return false;
+            });
         }
 
         public override void show_all () {

--- a/libwidgets/Chrome/ButtonWithMenu.vala
+++ b/libwidgets/Chrome/ButtonWithMenu.vala
@@ -148,7 +148,7 @@ namespace Files.View.Chrome {
                     active = false;
                 }
 
-                return false;
+                return Gdk.EVENT_PROPAGATE;
             });
         }
 


### PR DESCRIPTION
Fixes #1898 

If the button is dragged it does not receive any button-release event and so does not go back to an inactive state.

As a conservative solution to the issue, the button becomes inactive as soon as the pointer moves with the button pressed.

Other solutions include not activating the button at all on button press (since it is a custom signal that actually causes navigation on button release) but this changes the UI.