### PR TITLE
Remove deprecation: button.xalign; bump min gtk, disable deprecated

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,8 @@ terminal_name = 'pantheon-terminal'
 add_project_arguments(
     ['-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
     '-DHANDY_USE_UNSTABLE_API',
+    '-DGDK_DISABLE_DEPRECATED',
+    '-DGTK_DISABLE_DEPRECATED',
     '-w'],
     language:'c'
 )
@@ -46,7 +48,7 @@ gio_dep = dependency('gio-2.0', version: '>='+min_glib_version)
 gio_unix_dep = dependency('gio-unix-2.0', version: '>='+min_glib_version)
 gmodule_dep = dependency('gmodule-2.0', version: '>='+min_glib_version)
 gee_dep = dependency('gee-0.8')
-gtk_dep = dependency('gtk+-3.0', version: '>=3.22.25')
+gtk_dep = dependency('gtk+-3.0', version: '>=3.24')
 granite_dep = dependency('granite', version: '>=6.1.0')
 handy_dep = dependency('libhandy-1', version: '>=0.83.0')
 

--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -83,11 +83,9 @@ public class Sidebar.SidebarWindow : Gtk.Grid, Files.SidebarInterface {
 
         var connect_server_button = new Gtk.Button.with_label (_("Connect Server…")) {
             always_show_image = true,
-            hexpand = true,
             image = new Gtk.Image.from_icon_name ("network-server-symbolic", Gtk.IconSize.MENU),
             no_show_all = Files.is_admin (),
-            tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>C"}),
-            xalign = 0
+            tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>C"})
         };
 
         var action_bar = new Gtk.ActionBar () {

--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -81,12 +81,21 @@ public class Sidebar.SidebarWindow : Gtk.Grid, Files.SidebarInterface {
         };
         scrolled_window.add (bookmarklists_grid);
 
-        var connect_server_button = new Gtk.Button.with_label (_("Connect Server…")) {
+        var connect_server_button = new Gtk.Button () {
+            hexpand = true,
             always_show_image = true,
             image = new Gtk.Image.from_icon_name ("network-server-symbolic", Gtk.IconSize.MENU),
             no_show_all = Files.is_admin (),
             tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>C"})
         };
+        var connect_server_label = new Gtk.Label (_("Connect Server…")) {
+            halign = Gtk.Align.START
+        };
+        var label_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+
+        label_box.add (connect_server_label);
+        connect_server_button.remove (connect_server_button.get_child ());
+        connect_server_button.add (label_box);
 
         var action_bar = new Gtk.ActionBar () {
             //For now hide action bar when admin. This might need revisiting if other actions are added


### PR DESCRIPTION
First step towards GTK4 - remove remaining GTK3  deprecations.  Note that needs https://github.com/elementary/granite/pull/545 to suppress warning about a deprecation in DynamicNotebook