### PR TITLE
Do not use deprecated style property

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,8 @@ terminal_name = 'pantheon-terminal'
 add_project_arguments(
     ['-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
     '-DHANDY_USE_UNSTABLE_API',
+    '-DGDK_DISABLE_DEPRECATED',
+    '-DGTK_DISABLE_DEPRECATED',
     '-w'],
     language:'c'
 )
@@ -46,7 +48,7 @@ gio_dep = dependency('gio-2.0', version: '>='+min_glib_version)
 gio_unix_dep = dependency('gio-unix-2.0', version: '>='+min_glib_version)
 gmodule_dep = dependency('gmodule-2.0', version: '>='+min_glib_version)
 gee_dep = dependency('gee-0.8')
-gtk_dep = dependency('gtk+-3.0', version: '>=3.22.25')
+gtk_dep = dependency('gtk+-3.0', version: '>=3.24')
 granite_dep = dependency('granite', version: '>=6.1.0')
 handy_dep = dependency('libhandy-1', version: '>=0.83.0')
 

--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -83,11 +83,9 @@ public class Sidebar.SidebarWindow : Gtk.Grid, Files.SidebarInterface {
 
         var connect_server_button = new Gtk.Button.with_label (_("Connect Server…")) {
             always_show_image = true,
-            hexpand = true,
             image = new Gtk.Image.from_icon_name ("network-server-symbolic", Gtk.IconSize.MENU),
             no_show_all = Files.is_admin (),
-            tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>C"}),
-            xalign = 0
+            tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>C"})
         };
 
         var action_bar = new Gtk.ActionBar () {

--- a/src/View/Widgets/SearchResults.vala
+++ b/src/View/Widgets/SearchResults.vala
@@ -667,14 +667,11 @@ namespace Files.View.Chrome {
             x = (x + parent_alloc.x).clamp (workarea.x, workarea.x + workarea.width - width_request);
             y += parent_alloc.y + parent_alloc.height;
 
-            int separator_height;
             Gdk.Rectangle cell_area;
-            view.style_get ("vertical-separator", out separator_height);
             view.get_cell_area (new Gtk.TreePath.from_indices (0), null, out cell_area);
             var total = int.max ((items + headers), 2);
-            var height = total * (cell_area.height + separator_height);
+            var height = total * (cell_area.height * 11 / 10); // Allow for vertical space between cells
             height = height.clamp (0, workarea.y + workarea.height - y - 12);
-
             scroll.set_min_content_height (height);
             set_size_request (int.min (parent_alloc.width, workarea.width), height);
             move (x, y);


### PR DESCRIPTION
Based on #1945
The style property "vertical-separator" is deprecated.  It is not clear how to obtain the same information otherwise so it is estimated at 10% of the cell height, which visually gives the same result.