### PR TITLE
Avoid event properties

### DIFF
--- a/libcore/EventUtils.vala
+++ b/libcore/EventUtils.vala
@@ -17,7 +17,7 @@
 ***/
 
 namespace Files.EventUtils {
-    public static Gdk.ModifierType get_event_modifiers (Gdk.Event event, Gdk.ModifierType consumed = 0) {
+    public static Gdk.ModifierType get_modifier_state (Gdk.Event event, Gdk.ModifierType consumed = 0) {
         Gdk.ModifierType mods;
         if (event.get_state (out mods)) {
             return (mods & ~consumed) & Gtk.accelerator_get_default_mod_mask ();
@@ -26,7 +26,7 @@ namespace Files.EventUtils {
         }
     }
 
-    public static void get_event_coords (Gdk.Event event, out int ix, out int iy) {
+    public static void get_coords (Gdk.Event event, out int ix, out int iy) {
         double dx, dy;
         if (event.get_coords (out dx, out dy)) {
             ix = (int)dx;
@@ -40,10 +40,19 @@ namespace Files.EventUtils {
         return;
     }
 
-    public static uint get_event_button (Gdk.Event event) {
+    public static uint get_button (Gdk.Event event) {
         uint button;
-        if (event.get_state (out button)) {
+        if (event.get_button (out button)) {
             return button;
+        } else {
+            return -1;
+        }
+    }
+
+    public static uint get_keyval (Gdk.Event event) {
+        uint keyval;
+        if (event.get_keyval (out keyval)) {
+            return keyval;
         } else {
             return -1;
         }

--- a/libcore/EventUtils.vala
+++ b/libcore/EventUtils.vala
@@ -1,0 +1,51 @@
+/***
+    Copyright (c) 2021 elementary Inc <https://elementary.io>
+
+    This program is free software: you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License version 3, as published
+    by the Free Software Foundation, Inc.,.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranties of
+    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+    PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program. If not, see <http://www.gnu.org/licenses/>.
+
+    Authors : Jeremy Wootten <jeremy@elementaryos.org>
+***/
+
+namespace Files.EventUtils {
+    public static Gdk.ModifierType get_event_modifiers (Gdk.Event event, Gdk.ModifierType consumed = 0) {
+        Gdk.ModifierType mods;
+        if (event.get_state (out mods)) {
+            return (mods & ~consumed) & Gtk.accelerator_get_default_mod_mask ();
+        } else {
+            return 0;
+        }
+    }
+
+    public static void get_event_coords (Gdk.Event event, out int ix, out int iy) {
+        double dx, dy;
+        if (event.get_coords (out dx, out dy)) {
+            ix = (int)dx;
+            iy = (int)dy;
+            return;
+        } else {
+            ix = -1;
+            iy = -1;
+        }
+
+        return;
+    }
+
+    public static uint get_event_button (Gdk.Event event) {
+        uint button;
+        if (event.get_state (out button)) {
+            return button;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/libcore/Widgets/BasicBreadcrumbsEntry.vala
+++ b/libcore/Widgets/BasicBreadcrumbsEntry.vala
@@ -185,7 +185,7 @@ namespace Files.View.Chrome {
                 return true;
             }
 
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            var mods = Files.EventUtils.get_event_modifiers (event);
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
 
             switch (event.keyval) {

--- a/libcore/Widgets/BasicBreadcrumbsEntry.vala
+++ b/libcore/Widgets/BasicBreadcrumbsEntry.vala
@@ -185,10 +185,10 @@ namespace Files.View.Chrome {
                 return true;
             }
 
-            var mods = Files.EventUtils.get_event_modifiers (event);
+            var mods = Files.EventUtils.get_modifier_state (event);
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
 
-            switch (event.keyval) {
+            switch (Files.EventUtils.get_keyval (event)) {
                 /* Do not trap unmodified Down and Up keys - used by some input methods */
                 case Gdk.Key.KP_Down:
                 case Gdk.Key.Down:

--- a/libcore/meson.build
+++ b/libcore/meson.build
@@ -20,6 +20,7 @@ pantheon_files_core_vala_files = files(
     'Directory.vala',
     'DndHandler.vala',
     'Enums.vala',
+    'EventUtils.vala',
     'File.vala',
     'FileChanges.vala',
     'FileConflictDialog.vala',

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -411,35 +411,36 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
 
             int y0 = (get_allocated_height () - color_button_width) / 2;
             int x0 = COLORBOX_SPACING + color_button_width;
-
-            if (event.y < y0 || event.y > y0 + color_button_width) {
+            int x, y;
+            EventUtils.get_event_coords (event, out x, out y);
+            if (y < y0 || y > y0 + color_button_width) {
                 return true;
             }
 
             if (Gtk.StateFlags.DIR_RTL in get_style_context ().get_state ()) {
                 var width = get_allocated_width ();
-                int x = width - 27;
+                int x1 = width - 27;
                 for (int i = 0; i < Files.Preferences.TAGS_COLORS.length; i++) {
-                    if (event.x <= x && event.x >= x - color_button_width) {
+                    if (x <= x1 && x >= x1 - color_button_width) {
                         color_changed (i);
                         clear_checks ();
                         check_color (i);
                         break;
                     }
 
-                    x -= x0;
+                    x1 -= x0;
                 }
             } else {
-                int x = 27;
+                int x1 = 27;
                 for (int i = 0; i < Files.Preferences.TAGS_COLORS.length; i++) {
-                    if (event.x >= x && event.x <= x + color_button_width) {
+                    if (x >= x1 && x <= x1 + color_button_width) {
                         color_changed (i);
                         clear_checks ();
                         check_color (i);
                         break;
                     }
 
-                    x += x0;
+                    x1 += x0;
                 }
             }
 

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -412,7 +412,7 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
             int y0 = (get_allocated_height () - color_button_width) / 2;
             int x0 = COLORBOX_SPACING + color_button_width;
             int x, y;
-            EventUtils.get_event_coords (event, out x, out y);
+            EventUtils.get_coords (event, out x, out y);
             if (y < y0 || y > y0 + color_button_width) {
                 return true;
             }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -737,7 +737,7 @@ namespace Files {
                 return true;
             }
 
-            var mods = EventUtils.get_event_modifiers (event);
+            var mods = EventUtils.get_modifier_state (event);
             if (mods > 0) {
                 Gdk.ScrollDirection event_direction;
                 double delta_x, delta_y;
@@ -1468,7 +1468,7 @@ namespace Files {
             Gdk.DragContext context;
             var widget = get_child ();
             int x, y;
-            EventUtils.get_event_coords (event, out x, out y);
+            EventUtils.get_coords (event, out x, out y);
 
             if (Gtk.drag_check_threshold (widget, drag_x, drag_y, x, y)) {
                 cancel_drag_timer ();
@@ -1844,7 +1844,7 @@ namespace Files {
 
         protected void start_drag_timer (Gdk.Event event) {
             connect_drag_timeout_motion_and_release_events ();
-            drag_button = (int)(EventUtils.get_event_button (event));
+            drag_button = (int)(EventUtils.get_button (event));
 
             drag_timer_id = GLib.Timeout.add_full (GLib.Priority.LOW,
                                                    300,
@@ -2898,9 +2898,10 @@ namespace Files {
 
             cancel_hover ();
 
-            uint keyval = event.keyval;
+            var keyval = EventUtils.get_keyval (event);
+;
             Gdk.ModifierType consumed_mods = 0;
-            Gdk.ModifierType mods = EventUtils.get_event_modifiers (event);
+            Gdk.ModifierType mods = EventUtils.get_modifier_state (event);
 
             /* Leave standard ASCII alone, else try to get Latin hotkey from keyboard state */
             /* This means that Latin hot keys for Latin Dvorak keyboards (e.g. Spanish Dvorak)
@@ -3446,13 +3447,12 @@ namespace Files {
             Gtk.TreePath? path = null;
             /* Remember position of click for detecting drag motion*/
 
-            int x, y;
-            EventUtils.get_event_coords (event, out x, out y);
-            var event_button = EventUtils.get_event_button (event);
+            EventUtils.get_coords (event, out drag_x, out drag_y);
+            var event_button = EventUtils.get_button (event);
             click_zone = get_event_position_info (event, out path, event_button == Gdk.BUTTON_PRIMARY); //Only rubberband with primary button
             click_path = path;
 
-            var mods = EventUtils.get_event_modifiers (event);
+            var mods = EventUtils.get_modifier_state (event);
             bool no_mods = (mods == 0);
             bool control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
             bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
@@ -3617,12 +3617,13 @@ namespace Files {
 
             Gtk.Widget widget = get_child ();
             int x, y;
-            EventUtils.get_event_coords (event, out x, out y);
+            EventUtils.get_coords (event, out x, out y);
             if (x >= 0 && y >= 0) {
                 update_selected_files_and_menu ();
                 /* Only take action if pointer has not moved */
                 if (!Gtk.drag_check_threshold (widget, drag_x, drag_y, x, y)) {
-                    var event_button = EventUtils.get_event_button (event);
+
+                    var event_button = EventUtils.get_button (event);
                     if (should_activate) {
                         /* Need Idle else can crash with rapid clicking (avoid nested signals) */
                         Idle.add (() => {

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -215,7 +215,7 @@ namespace Files {
             }
 
             int x, y;
-            EventUtils.get_event_coords (event, out x, out y);
+            EventUtils.get_coords (event, out x, out y);
 
             /* Determine whether there whitespace at this point.  Note: this function returns false when the
              * position is on the edge of the cell, even though this appears to be blank. We
@@ -365,7 +365,7 @@ namespace Files {
         /* Override base class in order to disable the Gtk.TreeView local search functionality */
         public override bool key_press_event (Gdk.EventKey event) {
             /* We still need the base class to handle cursor keys first */
-            switch (event.keyval) {
+            switch (EventUtils.get_keyval (event)) {
                 case Gdk.Key.Up:
                 case Gdk.Key.Down:
                 case Gdk.Key.KP_Up:

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -207,22 +207,22 @@ namespace Files {
             Gtk.TreePath? p = null;
             unowned Gtk.TreeViewColumn? c = null;
             uint zone;
-            int x, y, cx, cy, depth;
+            int cx, cy, depth;
             path = null;
 
             if (event.window != tree.get_bin_window ()) {
                 return ClickZone.INVALID;
             }
 
-            x = (int)event.x;
-            y = (int)event.y;
+            int x, y;
+            EventUtils.get_event_coords (event, out x, out y);
 
             /* Determine whether there whitespace at this point.  Note: this function returns false when the
              * position is on the edge of the cell, even though this appears to be blank. We
              * deal with this below. */
-            var is_blank = tree.is_blank_at_pos ((int)event.x, (int)event.y, null, null, null, null);
+            var is_blank = tree.is_blank_at_pos (x, y, null, null, null, null);
 
-            tree.get_path_at_pos ((int)event.x, (int)event.y, out p, out c, out cx, out cy);
+            tree.get_path_at_pos (x, y, out p, out c, out cx, out cy);
             path = p;
             depth = p != null ? p.get_depth () : 0;
 

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -95,15 +95,10 @@ namespace Files {
         }
 
         protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            var mods = EventUtils.get_event_modifiers (event);
+            var mods = EventUtils.get_modifier_state (event);
             bool no_mods = (mods == 0);
 
-            uint event_keyval;
-            if (!event.get_keyval (out event_keyval)) {
-                return false;
-            }
-
-            switch (event_keyval) {
+            switch (EventUtils.get_keyval (event)) {
                 /* Do not emit alert sound on left and right cursor keys in Miller View */
                 case Gdk.Key.Left:
                 case Gdk.Key.Right:

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -95,10 +95,15 @@ namespace Files {
         }
 
         protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            var mods = EventUtils.get_event_modifiers (event);
             bool no_mods = (mods == 0);
 
-            switch (event.keyval) {
+            uint event_keyval;
+            if (!event.get_keyval (out event_keyval)) {
+                return false;
+            }
+
+            switch (event_keyval) {
                 /* Do not emit alert sound on left and right cursor keys in Miller View */
                 case Gdk.Key.Left:
                 case Gdk.Key.Right:

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -215,7 +215,7 @@ namespace Files {
             path = null;
 
             int x, y;
-            EventUtils.get_event_coords (event, out x, out y);
+            EventUtils.get_coords (event, out x, out y);
 
             tree.get_item_at_pos (x, y, out p, out cell_renderer);
             path = p;

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -212,11 +212,10 @@ namespace Files {
             Gtk.TreePath? p = null;
             Gtk.CellRenderer? cell_renderer;
             uint zone;
-            int x, y;
             path = null;
 
-            x = (int)event.x;
-            y = (int)event.y;
+            int x, y;
+            EventUtils.get_event_coords (event, out x, out y);
 
             tree.get_item_at_pos (x, y, out p, out cell_renderer);
             path = p;
@@ -247,6 +246,7 @@ namespace Files {
                         zone = ClickZone.NAME;
                     } else if (rubberband) {
                         /* Fake location outside centre bottom of item for rubberbanding */
+                        //FIXME This will not work in Gtk4!
                         event.x = rect.x + rect.width / 2;
                         event.y = rect.y + rect.height + 10 + (int)(get_vadjustment ().value);
                         zone = ClickZone.BLANK_NO_PATH;

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -155,17 +155,12 @@ namespace Files {
         }
 
         protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            var mods = EventUtils.get_event_modifiers (event);
+            var mods = EventUtils.get_modifier_state (event);
             bool control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
             bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
 
             if (!control_pressed && !shift_pressed) {
-                uint event_keyval;
-                if (!event.get_keyval (out event_keyval)) {
-                    return false;
-                }
-
-                switch (event_keyval) {
+                switch (EventUtils.get_keyval (event)) {
                     case Gdk.Key.Right:
                         Gtk.TreePath? path = null;
                         tree.get_cursor (out path, null);

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -155,11 +155,17 @@ namespace Files {
         }
 
         protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            bool control_pressed = ((event.state & Gdk.ModifierType.CONTROL_MASK) != 0);
-            bool shift_pressed = ((event.state & Gdk.ModifierType.SHIFT_MASK) != 0);
+            var mods = EventUtils.get_event_modifiers (event);
+            bool control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
+            bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
 
             if (!control_pressed && !shift_pressed) {
-                switch (event.keyval) {
+                uint event_keyval;
+                if (!event.get_keyval (out event_keyval)) {
+                    return false;
+                }
+
+                switch (event_keyval) {
                     case Gdk.Key.Right:
                         Gtk.TreePath? path = null;
                         tree.get_cursor (out path, null);

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -356,7 +356,7 @@ namespace Files.View {
 
         private bool on_key_pressed (Gtk.Widget box, Gdk.EventKey event) {
             /* Only handle unmodified keys */
-            var mods = EventUtils.get_event_modifiers (event);
+            var mods = EventUtils.get_modifier_state (event);
             if (mods > 0) {
                 return false;
             }
@@ -368,11 +368,7 @@ namespace Files.View {
             }
 
             View.Slot to_activate = null;
-            uint event_keyval;
-            if (!event.get_keyval (out event_keyval)) {
-                return false;
-            }
-            switch (event_keyval) {
+            switch (EventUtils.get_keyval (event)) {
                 case Gdk.Key.Left:
                     if (current_position > 0) {
                         to_activate = slot_list.nth_data (current_position - 1);

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -356,7 +356,8 @@ namespace Files.View {
 
         private bool on_key_pressed (Gtk.Widget box, Gdk.EventKey event) {
             /* Only handle unmodified keys */
-            if ((event.state & Gtk.accelerator_get_default_mod_mask ()) > 0) {
+            var mods = EventUtils.get_event_modifiers (event);
+            if (mods > 0) {
                 return false;
             }
 
@@ -367,8 +368,11 @@ namespace Files.View {
             }
 
             View.Slot to_activate = null;
-
-            switch (event.keyval) {
+            uint event_keyval;
+            if (!event.get_keyval (out event_keyval)) {
+                return false;
+            }
+            switch (event_keyval) {
                 case Gdk.Key.Left:
                     if (current_position > 0) {
                         to_activate = slot_list.nth_data (current_position - 1);

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -215,7 +215,7 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
     }
 
     protected virtual bool on_key_press_event (Gdk.EventKey event) {
-        switch (event.keyval) {
+        switch (Files.EventUtils.get_keyval (event)) {
             case Gdk.Key.F2:
                 rename ();
                 return true;
@@ -239,8 +239,8 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
             return false;
         }
 
-        uint event_button = Files.EventUtils.get_event_button (event);
-        var mods = Files.EventUtils.get_event_modifiers (event);
+        uint event_button = Files.EventUtils.get_button (event);
+        var mods = Files.EventUtils.get_modifier_state (event);
         var control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
         var other_mod_pressed = (((mods & ~Gdk.ModifierType.SHIFT_MASK) & ~Gdk.ModifierType.CONTROL_MASK) != 0);
         var only_control_pressed = control_pressed && !other_mod_pressed; /* Shift can be pressed */

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -239,12 +239,13 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
             return false;
         }
 
-        var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+        uint event_button = Files.EventUtils.get_event_button (event);
+        var mods = Files.EventUtils.get_event_modifiers (event);
         var control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
         var other_mod_pressed = (((mods & ~Gdk.ModifierType.SHIFT_MASK) & ~Gdk.ModifierType.CONTROL_MASK) != 0);
         var only_control_pressed = control_pressed && !other_mod_pressed; /* Shift can be pressed */
 
-        switch (event.button) {
+        switch (event_button) {
             case Gdk.BUTTON_PRIMARY:
                 if (only_control_pressed) {
                     activated (Files.OpenFlag.NEW_TAB);
@@ -262,8 +263,10 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
                 return true;
 
             default:
-                return false;
+                break;
         }
+
+        return false;
     }
 
     protected virtual void popup_context_menu (Gdk.EventButton event) {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -581,9 +581,10 @@ namespace Files.View {
         }
 
         private bool on_button_press_event (Gdk.EventButton event) {
-            Gdk.ModifierType mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            var mods = EventUtils.get_event_modifiers (event);
+            var event_button = EventUtils.get_event_button (event);
             bool result = false;
-            switch (event.button) {
+            switch (event_button) {
                 /* Extra mouse button actions */
                 case 6:
                 case 8:

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -581,8 +581,8 @@ namespace Files.View {
         }
 
         private bool on_button_press_event (Gdk.EventButton event) {
-            var mods = EventUtils.get_event_modifiers (event);
-            var event_button = EventUtils.get_event_button (event);
+            var mods = EventUtils.get_modifier_state (event);
+            var event_button = EventUtils.get_button (event);
             bool result = false;
             switch (event_button) {
                 /* Extra mouse button actions */

--- a/src/View/Widgets/AbstractEditableLabel.vala
+++ b/src/View/Widgets/AbstractEditableLabel.vala
@@ -36,7 +36,7 @@ namespace Files {
         }
 
         public virtual bool on_key_press_event (Gdk.EventKey event) {
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            var mods = EventUtils.get_event_modifiers (event);
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
 
             switch (event.keyval) {

--- a/src/View/Widgets/AbstractEditableLabel.vala
+++ b/src/View/Widgets/AbstractEditableLabel.vala
@@ -36,10 +36,10 @@ namespace Files {
         }
 
         public virtual bool on_key_press_event (Gdk.EventKey event) {
-            var mods = EventUtils.get_event_modifiers (event);
+            var mods = EventUtils.get_modifier_state (event);
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
 
-            switch (event.keyval) {
+            switch (EventUtils.get_keyval (event)) {
                 case Gdk.Key.Return:
                 case Gdk.Key.KP_Enter:
                     /*  Only end rename with unmodified Enter. This is to allow use of Ctrl-Enter

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -74,7 +74,7 @@ namespace Files.View.Chrome {
             autocompleted = false;
             multiple_completions = false;
 
-            switch (event.keyval) {
+            switch (EventUtils.get_keyval (event)) {
                 case Gdk.Key.Return:
                 case Gdk.Key.KP_Enter:
                 case Gdk.Key.ISO_Enter:
@@ -517,7 +517,7 @@ namespace Files.View.Chrome {
             if (is_icon_event (event) || has_focus || hide_breadcrumbs) {
                 return base.on_button_press_event (event);
             } else {
-                var event_button = EventUtils.get_event_button (event);
+                var event_button = EventUtils.get_button (event);
                 var el = mark_pressed_element (event);
                 if (el != null) {
                     switch (event_button) {
@@ -541,7 +541,7 @@ namespace Files.View.Chrome {
         private BreadcrumbElement? mark_pressed_element (Gdk.EventButton event) {
             reset_elements_states ();
             int x, y;
-            EventUtils.get_event_coords (event, out x, out y);
+            EventUtils.get_coords (event, out x, out y);
             BreadcrumbElement? el = get_element_from_coordinates (x, y);
             if (el != null) {
                 el.pressed = true;

--- a/src/View/Widgets/SearchResults.vala
+++ b/src/View/Widgets/SearchResults.vala
@@ -465,16 +465,17 @@ namespace Files.View.Chrome {
                 return true;
             }
 
-            var mods = EventUtils.get_event_modifiers (event);
+            var mods = EventUtils.get_modifier_state (event);
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
             bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
             bool alt_pressed = ((mods & Gdk.ModifierType.MOD1_MASK) != 0);
             bool only_shift_pressed = shift_pressed && ((mods & ~Gdk.ModifierType.SHIFT_MASK) == 0);
             bool only_alt_pressed = alt_pressed && ((mods & ~Gdk.ModifierType.MOD1_MASK) == 0);
 
+            var event_keyval = EventUtils.get_keyval (event);
             if (mods != 0 && !only_shift_pressed) {
                 if (only_control_pressed) {
-                    if (event.keyval == Gdk.Key.l) {
+                    if (event_keyval == Gdk.Key.l) {
                         cancel (); /* release any grab */
                         exit (false); /* Do not exit navigate mode */
                         return true;
@@ -482,9 +483,9 @@ namespace Files.View.Chrome {
                         return parent.key_press_event (event);
                     }
                 } else if (only_alt_pressed &&
-                           event.keyval == Gdk.Key.Return ||
-                           event.keyval == Gdk.Key.KP_Enter ||
-                           event.keyval == Gdk.Key.ISO_Enter) {
+                           event_keyval == Gdk.Key.Return ||
+                           event_keyval == Gdk.Key.KP_Enter ||
+                           event_keyval == Gdk.Key.ISO_Enter) {
 
                     accept (null, true); // Open the selected file in default app
                 } else {
@@ -492,7 +493,7 @@ namespace Files.View.Chrome {
                 }
             }
 
-            switch (event.keyval) {
+            switch (event_keyval) {
                 case Gdk.Key.Return:
                 case Gdk.Key.KP_Enter:
                 case Gdk.Key.ISO_Enter:
@@ -507,8 +508,8 @@ namespace Files.View.Chrome {
                         return true;
                     }
 
-                    var up = (event.keyval == Gdk.Key.Up) ||
-                             (event.keyval == Gdk.Key.ISO_Left_Tab);
+                    var up = (event_keyval == Gdk.Key.Up) ||
+                             (event_keyval == Gdk.Key.ISO_Left_Tab);
 
                     if (view.get_selection ().count_selected_rows () < 1) {
                         if (up) {

--- a/src/View/Widgets/SearchResults.vala
+++ b/src/View/Widgets/SearchResults.vala
@@ -464,7 +464,8 @@ namespace Files.View.Chrome {
             if (event.is_modifier == 1) {
                 return true;
             }
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+
+            var mods = EventUtils.get_event_modifiers (event);
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
             bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
             bool alt_pressed = ((mods & Gdk.ModifierType.MOD1_MASK) != 0);

--- a/src/View/Widgets/Welcome.vala
+++ b/src/View/Widgets/Welcome.vala
@@ -30,16 +30,19 @@ namespace Files.View {
         }
 
         public bool on_button_press_event (Gdk.EventButton event) {
+            var event_button = EventUtils.get_event_button (event);
             /* Pass Back and Forward button events to toplevel window */
-            switch (event.button) {
+            switch (event_button) {
                 case 6:
                 case 7:
                 case 8:
                 case 9:
                     return get_toplevel ().button_press_event (event);
                 default:
-                    return base.button_press_event (event);
+                    break;
             }
+
+            return base.button_press_event (event);
         }
     }
 }

--- a/src/View/Widgets/Welcome.vala
+++ b/src/View/Widgets/Welcome.vala
@@ -30,7 +30,7 @@ namespace Files.View {
         }
 
         public bool on_button_press_event (Gdk.EventButton event) {
-            var event_button = EventUtils.get_event_button (event);
+            var event_button = EventUtils.get_button (event);
             /* Pass Back and Forward button events to toplevel window */
             switch (event_button) {
                 case 6:

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -211,7 +211,7 @@ namespace Files.View {
             undo_manager.request_menu_update.connect (update_undo_actions);
 
             key_press_event.connect ((event) => {
-                var mods = EventUtils.get_event_modifiers (event);
+                var mods = EventUtils.get_modifier_state (event);
                 bool no_mods = (mods == 0);
                 bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
                 bool only_shift_pressed = shift_pressed && ((mods & ~Gdk.ModifierType.SHIFT_MASK) == 0);
@@ -221,12 +221,7 @@ namespace Files.View {
                  * There are other hotkeys for operating/focusing other widgets.
                  * Using modified Arrow keys no longer works due to recent changes.  */
 
-                uint event_keyval;
-                if (!event.get_keyval (out event_keyval)) {
-                    return false;
-                }
-
-                switch (event_keyval) {
+                switch (EventUtils.get_keyval (event)) {
                     case Gdk.Key.Tab:
                         if (top_menu.locked_focus) {
                             return false;
@@ -249,11 +244,11 @@ namespace Files.View {
             });
 
             key_press_event.connect_after ((event) => {
-                var mods = EventUtils.get_event_modifiers (event);
+                var mods = EventUtils.get_modifier_state (event);
                 /* Use find function instead of view interactive search */
                 if (mods == 0 || mods == Gdk.ModifierType.SHIFT_MASK) {
                     /* Use printable characters to initiate search */
-                    var uc = ((unichar)(Gdk.keyval_to_unicode (event.keyval)));
+                    var uc = (unichar)(Gdk.keyval_to_unicode (EventUtils.get_keyval (event)));
                     if (uc.isprint ()) {
                         activate_action ("find", uc.to_string ());
                         return true;

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -211,7 +211,7 @@ namespace Files.View {
             undo_manager.request_menu_update.connect (update_undo_actions);
 
             key_press_event.connect ((event) => {
-                var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+                var mods = EventUtils.get_event_modifiers (event);
                 bool no_mods = (mods == 0);
                 bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
                 bool only_shift_pressed = shift_pressed && ((mods & ~Gdk.ModifierType.SHIFT_MASK) == 0);
@@ -220,7 +220,13 @@ namespace Files.View {
                  * because cannot tab out of location bar and also unwanted items tend to get focused.
                  * There are other hotkeys for operating/focusing other widgets.
                  * Using modified Arrow keys no longer works due to recent changes.  */
-                switch (event.keyval) {
+
+                uint event_keyval;
+                if (!event.get_keyval (out event_keyval)) {
+                    return false;
+                }
+
+                switch (event_keyval) {
                     case Gdk.Key.Tab:
                         if (top_menu.locked_focus) {
                             return false;
@@ -243,8 +249,9 @@ namespace Files.View {
             });
 
             key_press_event.connect_after ((event) => {
+                var mods = EventUtils.get_event_modifiers (event);
                 /* Use find function instead of view interactive search */
-                if (event.state == 0 || event.state == Gdk.ModifierType.SHIFT_MASK) {
+                if (mods == 0 || mods == Gdk.ModifierType.SHIFT_MASK) {
                     /* Use printable characters to initiate search */
                     var uc = ((unichar)(Gdk.keyval_to_unicode (event.keyval)));
                     if (uc.isprint ()) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,9 +26,9 @@ pantheon_files_exec = executable (
     'Dialogs/PropertiesWindow.vala',
     'Dialogs/VolumePropertiesWindow.vala',
 
+    'Utils/AppUtils.vala',
     'Utils/MimeActions.vala',
     'Utils/Permissions.vala',
-    'Utils/AppUtils.vala',
 
     'View/AbstractDirectoryView.vala',
     'View/AbstractTreeView.vala',


### PR DESCRIPTION
Reduce work required for Gtk4 migration by by providing and using similar functions in EventUtils instead of using event properties.  For convenience the `get_coords` function returns `int` not `double` values.

TODO:  Find a way of not modifying event properties in IconView in order for rubberbanding to work more easily (larger target area).  This will not be possible in Gtk4.