### PR TITLE
AppData: Use "grid" instead of "icon" for consistency with UI

### DIFF
--- a/data/io.elementary.files.appdata.xml.in.in
+++ b/data/io.elementary.files.appdata.xml.in.in
@@ -157,7 +157,7 @@
           <li>Dark style support</li>
           <li>Mint and Bubblegum color tags</li>
           <li>Do not restore locations that have become inaccessible</li>
-          <li>Clicking between thumbnail and text now activates/selects in Icon view</li>
+          <li>Clicking between thumbnail and text now activates/selects in Grid view</li>
           <li>AFC protocol support</li>
           <li>Add a smaller minimum icon size in list view</li>
           <li>Show emblems inline in list views</li>
@@ -332,7 +332,7 @@
     <release version="4.1.8" date="2019-05-02" urgency="medium">
       <description>
         <ul>
-          <li>Keyboard navigation fix for cherry picking select files in icon view</li>
+          <li>Keyboard navigation fix for cherry picking select files in Grid view</li>
           <li>Don't hardcode search placeholder text style, fixes dark theme issue</li>
           <li>Updated translations</li>
         </ul>


### PR DESCRIPTION
Sorry for nitpicking, but we call the default view as "Grid View":

https://github.com/elementary/files/blob/a63819feb25f661e0bdba0aa880f04e3e9e9743b/libcore/Widgets/ViewSwitcher.vala#L34

Maybe we may want to use the same notation in the release notes too for consistency with the UI? Although these strings don't appear since these are for older releases, this change would help translators to use their translated word of "Grid View".
