### PR TITLE
Cancel current selection on button press to block dragging text

### DIFF
--- a/src/View/Widgets/MultiLineEditableLabel.vala
+++ b/src/View/Widgets/MultiLineEditableLabel.vala
@@ -26,9 +26,16 @@ namespace Files {
 
         public override Gtk.Widget create_editable_widget () {
             textview = new Gtk.TextView ();
+            /* Cancel selection under cursor to avoid dragging selected text */
+            textview.button_press_event.connect (() => {
+                var start_pos = textview.buffer.cursor_position;
+                select_region (start_pos - 1, start_pos);
+                return false;
+            });
             /* Block propagation of button press event to view as this would cause renaming to end */
-            textview.button_press_event.connect_after (() => {return true;});
-
+            textview.button_press_event.connect_after (() => {
+                return true;
+            });
             scrolled_window = new Gtk.ScrolledWindow (null, null);
             scrolled_window.add (textview);
             return scrolled_window as Gtk.Widget;

--- a/src/View/Widgets/SingleLineEditableLabel.vala
+++ b/src/View/Widgets/SingleLineEditableLabel.vala
@@ -27,6 +27,12 @@ namespace Files {
 
         public override Gtk.Widget create_editable_widget () {
             textview = new Gtk.Entry ();
+            textview.button_press_event.connect (() => {
+                var cursor_position = textview.get_position ();
+                textview.select_region (cursor_position - 1, cursor_position);
+                return Gdk.EVENT_PROPAGATE;
+            });
+
             return textview as Gtk.Widget;
         }
 


### PR DESCRIPTION
Fixes #1957 

This overrides the native behaviour of the widgets used for renaming so that instead of dragging selected text, a new selection is started.  This emulates the behaviour of the Nemo filemanager (and contrasts with Nautilus and Dolphin)