### PR TITLE
Fix Public Share symbolic icon missing in breadcrumb

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -8,10 +8,10 @@ msgstr ""
 "Project-Id-Version: marlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-12-30 16:30+0000\n"
-"PO-Revision-Date: 2021-12-22 17:55+0000\n"
+"PO-Revision-Date: 2022-01-06 00:12+0000\n"
 "Last-Translator: DartDeaDia <dartdeadia@protonmail.com>\n"
-"Language-Team: Russian <https://l10n.elementary.io/projects/files/files/ru/"
-">\n"
+"Language-Team: Russian <https://l10n.elementary.io/projects/files/files/ru/>"
+"\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -643,8 +643,6 @@ msgstr ""
 "дополнительной информации."
 
 #: libcore/marlin-file-operations.c:842
-#, fuzzy
-#| msgid "Cannot move file to trash.  Try to delete it?"
 msgid "Cannot move file to trash. Try to delete it?"
 msgstr "Не удаётся переместить файл в корзину. Попытаться удалить его?"
 


### PR DESCRIPTION
Public Share is the only default User Directory to not have its symbolic icon displayed in the breadcrumb. This fixes that issue.