### PR TITLE
Show New Tab and New Window accelerators

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1867,7 +1867,7 @@ namespace Files {
 
             if (common_actions.get_action_enabled ("open-in")) {
                 var new_tab_menuitem = new Gtk.MenuItem ();
-                if (selected_file != null) {
+                if (selected_files != null) {
                     new_tab_menuitem.add (new Granite.AccelLabel (
                         _("New Tab"),
                         "<Shift>Return"
@@ -1876,15 +1876,15 @@ namespace Files {
                 } else {
                     new_tab_menuitem.add (new Granite.AccelLabel.from_action_name (
                         _("New Tab"),
-                        "win.action-tab::TAB"
+                        "win.tab::TAB"
                     ));
-                    new_tab_menuitem.action_name = "win.action-tab";
+                    new_tab_menuitem.action_name = "win.tab";
                 }
 
                 new_tab_menuitem.action_target = "TAB";
 
                 var new_window_menuitem = new Gtk.MenuItem ();
-                if (selected_file != null) {
+                if (selected_files != null) {
                     new_window_menuitem.add (new Granite.AccelLabel (
                         _("New Window"),
                         "<Shift><Ctrl>Return"
@@ -1893,9 +1893,9 @@ namespace Files {
                 } else {
                     new_window_menuitem.add (new Granite.AccelLabel.from_action_name (
                         _("New Window"),
-                        "win.action-tab::WINDOW"
+                        "win.tab::WINDOW"
                     ));
-                    new_window_menuitem.action_name = "win.action-tab";
+                    new_window_menuitem.action_name = "win.tab";
                 }
                 new_window_menuitem.action_target = "WINDOW";
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1867,15 +1867,36 @@ namespace Files {
 
             if (common_actions.get_action_enabled ("open-in")) {
                 var new_tab_menuitem = new Gtk.MenuItem ();
-                new_tab_menuitem.add (new Granite.AccelLabel (
-                    _("New Tab"),
-                    "<Shift>Return"
-                ));
-                new_tab_menuitem.action_name = "common.open-in";
+                if (selected_file != null) {
+                    new_tab_menuitem.add (new Granite.AccelLabel (
+                        _("New Tab"),
+                        "<Shift>Return"
+                    ));
+                    new_tab_menuitem.action_name = "common.open-in";
+                } else {
+                    new_tab_menuitem.add (new Granite.AccelLabel.from_action_name (
+                        _("New Tab"),
+                        "win.action-tab::TAB"
+                    ));
+                    new_tab_menuitem.action_name = "win.action-tab";
+                }
+
                 new_tab_menuitem.action_target = "TAB";
 
-                var new_window_menuitem = new Gtk.MenuItem.with_label (_("New Window"));
-                new_window_menuitem.action_name = "common.open-in";
+                var new_window_menuitem = new Gtk.MenuItem ();
+                if (selected_file != null) {
+                    new_window_menuitem.add (new Granite.AccelLabel (
+                        _("New Window"),
+                        "<Shift><Ctrl>Return"
+                    ));
+                    new_window_menuitem.action_name = "common.open-in";
+                } else {
+                    new_window_menuitem.add (new Granite.AccelLabel.from_action_name (
+                        _("New Window"),
+                        "win.action-tab::WINDOW"
+                    ));
+                    new_window_menuitem.action_name = "win.action-tab";
+                }
                 new_window_menuitem.action_target = "WINDOW";
 
                 open_submenu.add (new_tab_menuitem);
@@ -2994,6 +3015,8 @@ namespace Files {
                         activate_selected_items (Files.OpenFlag.DEFAULT);
                     } else if (only_shift_pressed) {
                         activate_selected_items (Files.OpenFlag.NEW_TAB);
+                    } else if (shift_pressed && control_pressed && !alt_pressed) {
+                        activate_selected_items (Files.OpenFlag.NEW_WINDOW);
                     } else if (only_alt_pressed) {
                         common_actions.activate_action ("properties", null);
                     } else if (no_mods) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -453,7 +453,9 @@ namespace Files.View {
                 "",
                 null,
                 content,
-                new Granite.AccelLabel (_("Close Tab"), "<Ctrl>w")
+                new Granite.AccelLabel (_("Close Tab"), "<Ctrl>w"),
+                new Granite.AccelLabel (_("Duplicate Tab"), "<Ctrl><Alt>t"),
+                new Granite.AccelLabel (_("Open in New Window"), "<Ctrl><Alt>n")
             ) {
                 ellipsize_mode = Pango.EllipsizeMode.MIDDLE
             };
@@ -790,6 +792,14 @@ namespace Files.View {
 
                 case "PREVIOUS":
                     tabs.previous_page ();
+                    break;
+
+                case "TAB":
+                    add_tab (current_tab.location, current_tab.view_mode);
+                    break;
+
+                case "WINDOW":
+                    tabs.tab_moved (tabs.current, 0, 0);
                     break;
 
                 default:
@@ -1224,6 +1234,8 @@ namespace Files.View {
             application.set_accels_for_action ("win.go-to::FORWARD", {"<Alt>Right", "XF86Forward"});
             application.set_accels_for_action ("win.go-to::BACK", {"<Alt>Left", "XF86Back"});
             application.set_accels_for_action ("win.info::HELP", {"F1"});
+            application.set_accels_for_action ("win.tab::TAB", {"<Ctrl><Alt>T"});
+            application.set_accels_for_action ("win.tab::WINDOW", {"<Ctrl><Alt>N"});
         }
     }
 }


### PR DESCRIPTION
Suggested by #1956 

 * Add new tab and new window window actions with accelerators
 * Show accelerators in tab menu
 * Also amend view context menu to show accels and use window actions
 * Add view accelerator for open selected in new window

Also fixes an issue where the "Open in New Tab" view context menu for the background folder showed an inactive accelerator.