### PR TITLE
Rewrite ViewSwitcher.vala without Granite.ModeButton

### DIFF
--- a/libcore/Widgets/ViewSwitcher.vala
+++ b/libcore/Widgets/ViewSwitcher.vala
@@ -22,56 +22,79 @@
 ***/
 
 namespace Files.View.Chrome {
-    public class ViewSwitcher : Granite.Widgets.ModeButton {
-        private const int SWITCH_DELAY_MSEC = 100;
-        public GLib.SimpleAction view_mode_action { get; construct; }
-        private uint mode_change_timeout_id = 0;
-        private ViewMode last_selected;
+    public class ViewSwitcher : Gtk.Grid {
+        public GLib.SimpleAction action { get; construct; }
 
-        construct {
-            /* Item 0 */
-            var icon = new Gtk.Image.from_icon_name ("view-grid-symbolic", Gtk.IconSize.BUTTON) {
-                tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>1"}, _("View as Grid"))
-            };
-
-            append (icon);
-
-            /* Item 1 */
-            var list = new Gtk.Image.from_icon_name ("view-list-symbolic", Gtk.IconSize.BUTTON) {
-                tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>2"}, _("View as List"))
-            };
-
-            append (list);
-
-            /* Item 2 */
-            var miller = new Gtk.Image.from_icon_name ("view-column-symbolic", Gtk.IconSize.BUTTON) {
-                tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>3"}, _("View in Columns"))
-            };
-
-            append (miller);
-
-            mode_changed.connect (() => {
-                last_selected = (ViewMode)selected;
-                if (mode_change_timeout_id > 0) {
-                    return;
-                }
-
-                mode_change_timeout_id = Timeout.add (SWITCH_DELAY_MSEC, () => {
-                    view_mode_action.activate (new GLib.Variant.uint32 (last_selected));
-                    mode_change_timeout_id = 0;
-                    return Source.REMOVE;
-                });
-            });
-
-            margin_top = 4;
-            margin_bottom = 4;
+        public ViewSwitcher (GLib.SimpleAction view_mode_action) {
+            Object (
+                action: view_mode_action,
+                orientation: Gtk.Orientation.HORIZONTAL,
+                margin_top: 4,
+                margin_bottom: 4,
+                column_homogeneous: true
+            );
         }
 
-        public ViewSwitcher (GLib.SimpleAction _view_mode_action) {
-            Object (
-                orientation: Gtk.Orientation.HORIZONTAL,
-                view_mode_action: _view_mode_action
-            );
+        construct {
+            get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+
+            /* Grid View item */
+            var id = (uint32)ViewMode.ICON;
+            var grid_view_btn = new Gtk.RadioButton (null) {
+                image = new Gtk.Image.from_icon_name ("view-grid-symbolic", Gtk.IconSize.BUTTON),
+                tooltip_markup = get_tooltip_for_id (id, _("View as Grid"))
+            };
+            grid_view_btn.set_mode (false);
+            grid_view_btn.toggled.connect (on_mode_changed);
+            grid_view_btn.set_data<uint32> ("id", id);
+
+            /* List View */
+            id = (uint32)ViewMode.LIST;
+            var list_view_btn = new Gtk.RadioButton.from_widget (grid_view_btn) {
+                image = new Gtk.Image.from_icon_name ("view-list-symbolic", Gtk.IconSize.BUTTON),
+                tooltip_markup = get_tooltip_for_id (id, _("View as List"))
+            };
+            list_view_btn.set_mode (false);
+            list_view_btn.toggled.connect (on_mode_changed);
+            list_view_btn.set_data<uint32> ("id", id);
+
+
+            /* Item 2 */
+            id = (uint32)ViewMode.MILLER_COLUMNS;
+            var column_view_btn = new Gtk.RadioButton.from_widget (grid_view_btn) {
+                image = new Gtk.Image.from_icon_name ("view-column-symbolic", Gtk.IconSize.BUTTON),
+                tooltip_markup = get_tooltip_for_id (id, _("View in Columns"))
+            };
+            column_view_btn.set_mode (false);
+            column_view_btn.toggled.connect (on_mode_changed);
+            column_view_btn.set_data<ViewMode> ("id", ViewMode.MILLER_COLUMNS);
+
+            attach (grid_view_btn, 0, 0);
+            attach (list_view_btn, 1, 0);
+            attach (column_view_btn, 2, 0);
+        }
+
+        private string get_tooltip_for_id (uint32 id, string description) {
+            var app = (Gtk.Application)Application.get_default ();
+            var detailed_name = Action.print_detailed_name ("win." + action.name, new Variant.uint32 (id));
+            var accels = app.get_accels_for_action (detailed_name);
+            return Granite.markup_accel_tooltip (accels, description);
+        }
+
+        private void on_mode_changed (Gtk.ToggleButton source) {
+            if (!source.active) {
+                return;
+            }
+
+            action.activate (source.get_data<uint32> ("id"));
+        }
+
+        public void set_mode (uint32 mode) {
+            this.@foreach ((child) => {
+                if (child.get_data<uint32> ("id") == mode) {
+                    ((Gtk.RadioButton)child).active = true;
+                }
+            });
         }
     }
 }

--- a/libcore/Widgets/ViewSwitcher.vala
+++ b/libcore/Widgets/ViewSwitcher.vala
@@ -22,17 +22,11 @@
 ***/
 
 namespace Files.View.Chrome {
-    public class ViewSwitcher : Gtk.Grid {
+    public class ViewSwitcher : Gtk.Box {
         public GLib.SimpleAction action { get; construct; }
 
         public ViewSwitcher (GLib.SimpleAction view_mode_action) {
-            Object (
-                action: view_mode_action,
-                orientation: Gtk.Orientation.HORIZONTAL,
-                margin_top: 4,
-                margin_bottom: 4,
-                column_homogeneous: true
-            );
+            Object (action: view_mode_action);
         }
 
         construct {
@@ -69,9 +63,10 @@ namespace Files.View.Chrome {
             column_view_btn.toggled.connect (on_mode_changed);
             column_view_btn.set_data<ViewMode> ("id", ViewMode.MILLER_COLUMNS);
 
-            attach (grid_view_btn, 0, 0);
-            attach (list_view_btn, 1, 0);
-            attach (column_view_btn, 2, 0);
+            valign = Gtk.Align.CENTER;
+            add (grid_view_btn);
+            add (list_view_btn);
+            add (column_view_btn);
         }
 
         private string get_tooltip_for_id (uint32 id, string description) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -80,10 +80,6 @@ namespace Files.View {
                 width_request: 500,
                 window_number: application.window_count
             );
-
-            if (is_first_window) {
-                set_accelerators ();
-            }
         }
 
         static construct {
@@ -92,18 +88,55 @@ namespace Files.View {
 
         construct {
             add_action_entries (WIN_ENTRIES, this);
-
             undo_actions_set_insensitive ();
 
             undo_manager = UndoManager.instance ();
 
-            build_window ();
+            // Setting accels on `application` does not work in construct clause
+            // Must set before building window so ViewSwitcher can lookup the accels for tooltips
+            if (is_first_window) {
+                marlin_app.set_accels_for_action ("win.quit", {"<Ctrl>Q"});
+                marlin_app.set_accels_for_action ("win.new-window", {"<Ctrl>N"});
+                marlin_app.set_accels_for_action ("win.undo", {"<Ctrl>Z"});
+                marlin_app.set_accels_for_action ("win.redo", {"<Ctrl><Shift>Z"});
+                marlin_app.set_accels_for_action ("win.bookmark", {"<Ctrl>D"});
+                marlin_app.set_accels_for_action ("win.find::", {"<Ctrl>F"});
+                marlin_app.set_accels_for_action ("win.edit-path", {"<Ctrl>L"});
+                marlin_app.set_accels_for_action ("win.tab::NEW", {"<Ctrl>T"});
+                marlin_app.set_accels_for_action ("win.tab::CLOSE", {"<Ctrl>W"});
+                marlin_app.set_accels_for_action ("win.tab::NEXT", {"<Ctrl>Page_Down", "<Ctrl>Tab"});
+                marlin_app.set_accels_for_action ("win.tab::PREVIOUS", {"<Ctrl>Page_Up", "<Shift><Ctrl>Tab"});
+                marlin_app.set_accels_for_action (
+                    GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (0)), {"<Ctrl>1"}
+                );
+                marlin_app.set_accels_for_action (
+                    GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (1)), {"<Ctrl>2"}
+                );
+                marlin_app.set_accels_for_action (
+                    GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (2)), {"<Ctrl>3"}
+                );
+                marlin_app.set_accels_for_action ("win.zoom::ZOOM_IN", {"<Ctrl>plus", "<Ctrl>equal"});
+                marlin_app.set_accels_for_action ("win.zoom::ZOOM_OUT", {"<Ctrl>minus"});
+                marlin_app.set_accels_for_action ("win.zoom::ZOOM_NORMAL", {"<Ctrl>0"});
+                marlin_app.set_accels_for_action ("win.show-hidden", {"<Ctrl>H"});
+                marlin_app.set_accels_for_action ("win.refresh", {"<Ctrl>R", "F5"});
+                marlin_app.set_accels_for_action ("win.go-to::HOME", {"<Alt>Home"});
+                marlin_app.set_accels_for_action ("win.go-to::RECENT", {"<Alt>R"});
+                marlin_app.set_accels_for_action ("win.go-to::TRASH", {"<Alt>T"});
+                marlin_app.set_accels_for_action ("win.go-to::ROOT", {"<Alt>slash"});
+                marlin_app.set_accels_for_action ("win.go-to::NETWORK", {"<Alt>N"});
+                marlin_app.set_accels_for_action ("win.go-to::SERVER", {"<Alt>C"});
+                marlin_app.set_accels_for_action ("win.go-to::UP", {"<Alt>Up"});
+                marlin_app.set_accels_for_action ("win.go-to::FORWARD", {"<Alt>Right", "XF86Forward"});
+                marlin_app.set_accels_for_action ("win.go-to::BACK", {"<Alt>Left", "XF86Back"});
+                marlin_app.set_accels_for_action ("win.info::HELP", {"F1"});
+            }
 
+            build_window ();
             connect_signals ();
 
             int width, height;
             Files.app_settings.get ("window-size", "(ii)", out width, out height);
-
             default_width = width;
             default_height = height;
 
@@ -124,6 +157,7 @@ namespace Files.View {
                         if (default_x != -1 && default_y != -1) {
                             move (default_x, default_y);
                         }
+
                         break;
                 }
             }
@@ -133,9 +167,8 @@ namespace Files.View {
         }
 
         private void build_window () {
-            view_switcher = new Chrome.ViewSwitcher ((SimpleAction)lookup_action ("view-mode")) {
-                selected = Files.app_settings.get_enum ("default-viewmode")
-            };
+            view_switcher = new Chrome.ViewSwitcher ((SimpleAction)lookup_action ("view-mode"));
+            view_switcher.set_mode (Files.app_settings.get_enum ("default-viewmode"));
 
             top_menu = new Chrome.HeaderBar (view_switcher) {
                 show_close_button = true,
@@ -894,7 +927,7 @@ namespace Files.View {
             });
         }
 
-        private GLib.SimpleAction? get_action (string action_name) {
+        public GLib.SimpleAction? get_action (string action_name) {
             return (GLib.SimpleAction?)(lookup_action (action_name));
         }
 
@@ -1116,7 +1149,7 @@ namespace Files.View {
 
             /* Update viewmode switch, action state and settings */
             var mode = current_tab.view_mode;
-            view_switcher.selected = mode;
+            view_switcher.set_mode (mode);
             view_switcher.sensitive = current_tab.can_show_folder;
             get_action ("view-mode").change_state (new Variant.uint32 (mode));
             Files.app_settings.set_enum ("default-viewmode", mode);
@@ -1186,44 +1219,6 @@ namespace Files.View {
 
         public new void grab_focus () {
             current_tab.grab_focus ();
-        }
-
-        private void set_accelerators () {
-            marlin_app.set_accels_for_action ("win.quit", {"<Ctrl>Q"});
-            application.set_accels_for_action ("win.new-window", {"<Ctrl>N"});
-            application.set_accels_for_action ("win.undo", {"<Ctrl>Z"});
-            application.set_accels_for_action ("win.redo", {"<Ctrl><Shift>Z"});
-            application.set_accels_for_action ("win.bookmark", {"<Ctrl>D"});
-            application.set_accels_for_action ("win.find::", {"<Ctrl>F"});
-            application.set_accels_for_action ("win.edit-path", {"<Ctrl>L"});
-            application.set_accels_for_action ("win.tab::NEW", {"<Ctrl>T"});
-            application.set_accels_for_action ("win.tab::CLOSE", {"<Ctrl>W"});
-            application.set_accels_for_action ("win.tab::NEXT", {"<Ctrl>Page_Down", "<Ctrl>Tab"});
-            application.set_accels_for_action ("win.tab::PREVIOUS", {"<Ctrl>Page_Up", "<Shift><Ctrl>Tab"});
-            application.set_accels_for_action (
-                GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (0)), {"<Ctrl>1"}
-            );
-            application.set_accels_for_action (
-                GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (1)), {"<Ctrl>2"}
-            );
-            application.set_accels_for_action (
-                GLib.Action.print_detailed_name ("win.view-mode", new Variant.uint32 (2)), {"<Ctrl>3"}
-            );
-            application.set_accels_for_action ("win.zoom::ZOOM_IN", {"<Ctrl>plus", "<Ctrl>equal"});
-            application.set_accels_for_action ("win.zoom::ZOOM_OUT", {"<Ctrl>minus"});
-            application.set_accels_for_action ("win.zoom::ZOOM_NORMAL", {"<Ctrl>0"});
-            application.set_accels_for_action ("win.show-hidden", {"<Ctrl>H"});
-            application.set_accels_for_action ("win.refresh", {"<Ctrl>R", "F5"});
-            application.set_accels_for_action ("win.go-to::HOME", {"<Alt>Home"});
-            application.set_accels_for_action ("win.go-to::RECENT", {"<Alt>R"});
-            application.set_accels_for_action ("win.go-to::TRASH", {"<Alt>T"});
-            application.set_accels_for_action ("win.go-to::ROOT", {"<Alt>slash"});
-            application.set_accels_for_action ("win.go-to::NETWORK", {"<Alt>N"});
-            application.set_accels_for_action ("win.go-to::SERVER", {"<Alt>C"});
-            application.set_accels_for_action ("win.go-to::UP", {"<Alt>Up"});
-            application.set_accels_for_action ("win.go-to::FORWARD", {"<Alt>Right", "XF86Forward"});
-            application.set_accels_for_action ("win.go-to::BACK", {"<Alt>Left", "XF86Back"});
-            application.set_accels_for_action ("win.info::HELP", {"F1"});
         }
     }
 }


### PR DESCRIPTION
Suggested by https://github.com/elementary/granite/pull/558

Some simplifications were made, including removing the ability to switch by scrolling on the buttons.
Scrolling caused a bug requiring over-rapid switching to be suppressed, removing it enabled removal of throttling as it seems unlikely that operation by clicking could trigger the bug.  If necessary throttling can be restored.  It is still possible to crash Files by rapidly pressing the view mode accelerator keys but that bug pre-exists in Files so will be dealt with in another PR.