### PR TITLE
Add dialog to ask for overwrite

### DIFF
--- a/filechooser-portal/FileChooserDialog.vala
+++ b/filechooser-portal/FileChooserDialog.vala
@@ -489,7 +489,7 @@ public class Files.FileChooserDialog : Hdy.Window, Xdp.Request {
 
             if (GLib.FileUtils.test (filename, GLib.FileTest.EXISTS) && !GLib.FileUtils.test (filename, GLib.FileTest.IS_SYMLINK)) {
                 var display_filename = GLib.Filename.display_basename (filename);
-                var primary = _("Replace \"%s\"?".printf (display_filename));
+                var primary = _("Replace “%s”?".printf (display_filename));
                 var secondary = _("The file already exists. Replacing it will permanently overwrite its current contents.");
                 var replace_dialog = new Granite.MessageDialog.with_image_from_icon_name (primary, secondary, "dialog-warning", Gtk.ButtonsType.CANCEL) {
                     transient_for = this


### PR DESCRIPTION
Fixes #1955

Adds a new second-layer modal dialog that asks whether to overwrite a file when the name clashes with an existing file.

![Bildschirmfoto von 2022-01-21 16 14 05](https://user-images.githubusercontent.com/29022469/150650195-e325fb1f-2319-4c31-bba8-794c586ec447.png)

Known issues:

- [ ] When the selected file is renamed, deleted, or otherwise removed from the current directory, the dialog goes to the next selectable file and picks that. We need to preserve the user's filename choice in such cases, so the saved file remains consistent.
    - To demonstrate:
        1. Open a "Save As" dialog box
        2. Select an existing file to overwrite in a folder with multiple files (make sure you don't care about any of them).
        3. The conflict dialog will appear. Do not take action.
        4. In the file manager, delete the file that you selected.
        5. Back in the save dialog, the selection will move to a different file.
        6. Click the "Replace" button. The newly selected file, not the file that you originally picked or was displayed in the conflict dialog, will be overwritten.
    - Expected behavior: if the chosen file is removed, a new file should be saved with the name of the file originally chosen. (This may be up for debate, but that's what I expect.)
    - [ ] Related: if the file is deleted, is there any reason to change the behavior? I don't imagine we should dismiss the conflict dialog automatically, and I can't think of any other behavior change to make.
- [ ] When the dialog is closed by confirming and saving the file, the parent window remains dimmed.
- [ ] The save dialog is not dimmed when the overwrite dialog is presented.

Things to check:

- [ ] I'm not sure if the way I'm checking for existing files is preferable. The docs seem to suggest you don't use file tests for this functionality, but I'm not sure what else to do.
- [ ] Better wording could be nice. I did my best to explain (largely taken from Apple's built in wording), but there's always room for improvement.
- [ ] It does not handle filed URI→filename conversions. I'm not sure what situation would cause them, so I don't know what would be a sensible fallback.
- [ ] Do I need to handle different file types, like symlinks, differently? If you choose a symlink then the linked file would be overwritten, not the link file. I'm not sure if I should use different wording in that case.
- [ ] I'm not sure if it's possible to select multiple files in a replace dialog. If so, then that would almost certainly need special handling.
- [ ] Likewise, I have not checked the behavior with other FileActions, like creating a new folder. I assume no selection actions would be able to trigger an overwrite.

Any other testing, code, or design input would be hugely appreciated.