### PR TITLE
Ensure directory is not unexpectedly cancelled

### DIFF
--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -488,7 +488,6 @@ public class Files.File : GLib.Object {
                 is_mounted = (mount != null);
             } catch (Error e) {
                 is_mounted = false;
-                debug (e.message);
             }
         }
 

--- a/libcore/ListModel.vala
+++ b/libcore/ListModel.vala
@@ -260,8 +260,6 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
         get (iter, ColumnID.FILE_COLUMN, out file);
         if (file != null) {
             var dir = Files.Directory.from_file (file);
-            dir.cancel ();
-
             subdirectory_unloaded (dir);
             return true;
         }

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -235,7 +235,7 @@ namespace Files {
             Files.Directory? dir = null;
             if (model.load_subdirectory (path, out dir)) { // Returns true if dir non null
                 connect_directory_handlers (dir);
-                dir.init ();
+                dir.init.begin ();
                 /* Maintain our own reference on dir, independent of the model */
                 /* Also needed for updating show hidden status */
                 loaded_subdirectories.prepend (dir);

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -260,7 +260,7 @@ namespace Files.View {
             }
             /* view and slot are unfrozen when done loading signal received */
             is_frozen = true;
-            directory.init ();
+            directory.init.begin ();
         }
 
         public override void reload (bool non_local_only = false) {
@@ -382,7 +382,6 @@ namespace Files.View {
             cancel_timeouts ();
 
             if (directory != null) {
-                directory.cancel ();
                 disconnect_dir_signals ();
             }
 

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -160,19 +160,16 @@ namespace Files.View.Chrome {
 
             if (current_completion_dir == null || !file.equal (current_completion_dir.location)) {
                 current_completion_dir = Directory.from_gfile (file);
-                current_completion_dir.init (on_file_loaded);
+                current_completion_dir.init.begin (on_file_loaded);
             } else if (current_completion_dir != null && current_completion_dir.can_load) {
                 clear_completion ();
                 /* Completion text set by on_file_loaded () */
-                current_completion_dir.init (on_file_loaded);
+                current_completion_dir.init.begin (on_file_loaded);
             }
         }
 
         private void cancel_completion_dir () {
-            if (current_completion_dir != null) {
-                current_completion_dir.cancel ();
-                current_completion_dir = null;
-            }
+            current_completion_dir = null;
         }
 
         protected void complete () {
@@ -432,7 +429,7 @@ namespace Files.View.Chrome {
             }
 
             if (files_menu_dir != null) {
-                files_menu_dir.init ();
+                files_menu_dir.init.begin ();
             }
         }
 
@@ -515,7 +512,6 @@ namespace Files.View.Chrome {
             }
             menu.show_all ();
             /* Release the Async directory as soon as possible */
-            dir.cancel ();
             dir = null;
         }
 


### PR DESCRIPTION
* Directory cannot be cancelled externally
* Remove unused public property of directory `is_cancelled`
* Reduce places where cancellable is created or cancelled
* Add some `requires` and `ensures` statements
* Make directory.init async and merge some functions
* Update and simplify directory tests
* Stress test reinitialising and reloading a directory