### PR TITLE
Drop unnecessary Config.TERMINAL_NAME check

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -7,7 +7,6 @@
 #define TESTDATA_DIR "@testdata_dir@"
 #define LOCALE_DIR "@locale_dir@"
 #define APP_NAME "@app_name@"
-#define TERMINAL_NAME "@terminal_name@"
 
 #define HAVE_DBUS
 #endif

--- a/libcore/pantheon-files-core-C.vapi
+++ b/libcore/pantheon-files-core-C.vapi
@@ -9,7 +9,6 @@ namespace Config {
     public const string TESTDATA_DIR;
     public const string LOCALE_DIR;
     public const string APP_NAME;
-    public const string TERMINAL_NAME;
 }
 
 namespace Files {

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,6 @@ i18n = import('i18n')
 # Define the global directories and variables
 #
 plugin_dir = join_paths(get_option('prefix'), get_option('libdir'), meson.project_name(), 'plugins')
-terminal_name = 'pantheon-terminal'
 
 add_project_arguments(
     ['-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
@@ -91,7 +90,6 @@ config_data.set('plugin_dir', plugin_dir)
 config_data.set('version', meson.project_version())
 config_data.set('testdata_dir', join_paths(meson.source_root(), 'data', 'tests'))
 config_data.set('app_name', meson.project_name())
-config_data.set('terminal_name', terminal_name)
 config_data.set('gettext_package', meson.project_name())
 config_data.set('locale_dir', join_paths(get_option('prefix'), get_option('localedir')))
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2592,7 +2592,7 @@ namespace Files {
         private bool app_is_this_app (AppInfo ai) {
             string exec_name = ai.get_executable ();
 
-            return (exec_name == Config.APP_NAME || exec_name == Config.TERMINAL_NAME);
+            return (exec_name == Config.APP_NAME);
         }
 
         private void filter_default_app_from_open_with_apps () {


### PR DESCRIPTION
`Config.TERMINAL_NAME` is set as `pantheon-terminal` so the check will never be true. :thinking:

This is previously dropped in https://github.com/elementary/files/commit/38df48790df3f8a833f2430891e074392256394d ("Respect open with default app from context menu even for folders") but re-added in https://github.com/elementary/files/commit/049b5af08a603e1fdcaecb7b7dd7bc266de14feb ("Meson build"), maybe this is by accident?

`Config.TERMINAL_NAME` likely has no more users after the change so I am dropping it completely.