### PR TITLE
No access event struct

### DIFF
--- a/filechooser-portal/FileChooserDialog.vala
+++ b/filechooser-portal/FileChooserDialog.vala
@@ -403,7 +403,9 @@ public class Files.FileChooserDialog : Hdy.Window, Xdp.Request {
     }
 
     protected override bool key_release_event (Gdk.EventKey event) {
-        if (event.keyval == Gdk.Key.Escape) {
+        uint keyval;
+        event.get_keyval (out keyval);
+        if (keyval == Gdk.Key.Escape) {
             response (Gtk.ResponseType.DELETE_EVENT);
             return Gdk.EVENT_STOP;
         }

--- a/libcore/Widgets/BasicBreadcrumbsEntry.vala
+++ b/libcore/Widgets/BasicBreadcrumbsEntry.vala
@@ -297,7 +297,9 @@ namespace Files.View.Chrome {
 
 
             set_tooltip_markup ("");
-            var el = get_element_from_coordinates ((int)event.x, (int)event.y);
+            double x, y;
+            event.get_coords (out x, out y);
+            var el = get_element_from_coordinates ((int)x, (int)y);
             if (el != null && !hide_breadcrumbs) {
                 set_tooltip_markup (_("Go to %s").printf (el.text_for_display));
                 set_entry_cursor ("default");

--- a/libcore/Widgets/BasicBreadcrumbsEntry.vala
+++ b/libcore/Widgets/BasicBreadcrumbsEntry.vala
@@ -185,10 +185,14 @@ namespace Files.View.Chrome {
                 return true;
             }
 
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            var mods = state & Gtk.accelerator_get_default_mod_mask ();
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
 
-            switch (event.keyval) {
+            uint keyval;
+            event.get_keyval (out keyval);
+            switch (keyval) {
                 /* Do not trap unmodified Down and Up keys - used by some input methods */
                 case Gdk.Key.KP_Down:
                 case Gdk.Key.Down:
@@ -228,7 +232,9 @@ namespace Files.View.Chrome {
         }
 
         protected virtual bool on_button_press_event (Gdk.EventButton event) {
-            context_menu_showing = has_focus && event.button == Gdk.BUTTON_SECONDARY;
+            uint button;
+            event.get_button (out button);
+            context_menu_showing = has_focus && button == Gdk.BUTTON_SECONDARY;
             return !has_focus;  // Only pass to default Gtk handler when focused and Entry showing.
         }
 
@@ -236,9 +242,13 @@ namespace Files.View.Chrome {
             /* Only activate breadcrumbs with primary click when pathbar does not have focus and breadcrumbs showing.
              * Note that in home directory, the breadcrumbs are hidden and a placeholder shown even when pathbar does
              * not have focus. */
-            if (event.button == Gdk.BUTTON_PRIMARY && !has_focus && !hide_breadcrumbs && !is_icon_event (event)) {
+            uint button;
+            event.get_button (out button);
+            if (button == Gdk.BUTTON_PRIMARY && !has_focus && !hide_breadcrumbs && !is_icon_event (event)) {
                 reset_elements_states ();
-                var el = get_element_from_coordinates ((int) event.x, (int) event.y);
+                double x, y;
+                event.get_coords (out x, out y);
+                var el = get_element_from_coordinates ((int)x, (int)y);
                 if (el != null) {
                     activate_path (get_path_from_element (el));
                     return true;
@@ -255,7 +265,7 @@ namespace Files.View.Chrome {
         protected bool is_icon_event (Gdk.EventButton event) {
             /* We need to distinguish whether the event comes from one of the icons.
              * There doesn't seem to be a way of doing this directly so we check the window width */
-            return (event.window.get_width () <= ICON_WIDTH);
+            return (event.get_window ().get_width () <= ICON_WIDTH);
         }
 
         void on_icon_press (Gtk.EntryIconPosition pos) {

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -412,7 +412,9 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
             int y0 = (get_allocated_height () - color_button_width) / 2;
             int x0 = COLORBOX_SPACING + color_button_width;
 
-            if (event.y < y0 || event.y > y0 + color_button_width) {
+            double ex, ey;
+            event.get_coords (out ex, out ey);
+            if (ey < y0 || ey > y0 + color_button_width) {
                 return true;
             }
 
@@ -420,7 +422,7 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
                 var width = get_allocated_width ();
                 int x = width - 27;
                 for (int i = 0; i < Files.Preferences.TAGS_COLORS.length; i++) {
-                    if (event.x <= x && event.x >= x - color_button_width) {
+                    if (ex <= x && ex >= x - color_button_width) {
                         color_changed (i);
                         clear_checks ();
                         check_color (i);
@@ -432,7 +434,7 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
             } else {
                 int x = 27;
                 for (int i = 0; i < Files.Preferences.TAGS_COLORS.length; i++) {
-                    if (event.x >= x && event.x <= x + color_button_width) {
+                    if (x >= x && x <= x + color_button_width) {
                         color_changed (i);
                         clear_checks ();
                         check_color (i);

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -434,7 +434,7 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
             } else {
                 int x = 27;
                 for (int i = 0; i < Files.Preferences.TAGS_COLORS.length; i++) {
-                    if (x >= x && x <= x + color_button_width) {
+                    if (ex >= x && ex <= x + color_button_width) {
                         color_changed (i);
                         clear_checks ();
                         check_color (i);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2923,12 +2923,16 @@ namespace Files {
                 return true;
             }
 
+            if (event.is_modifier == 1) {
+                return true;
+            }
+
             cancel_hover ();
 
             uint original_keyval;
-            Gdk.ModifierType state;
             event.get_keyval (out original_keyval);
             var keyval = original_keyval;
+            Gdk.ModifierType state;
             event.get_state (out state);
             Gdk.ModifierType consumed_mods = 0;
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -125,8 +125,8 @@ namespace Files {
         protected bool large_thumbnails = false;
 
         /* Used only when acting as drag source */
-        int drag_x = 0;
-        int drag_y = 0;
+        double drag_x = 0;
+        double drag_y = 0;
         int drag_button;
         uint drag_timer_id = 0;
         protected GLib.List<Files.File> source_drag_file_list = null;
@@ -738,8 +738,12 @@ namespace Files {
                 return true;
             }
 
-            if ((event.state & Gdk.ModifierType.CONTROL_MASK) > 0) {
-                switch (event.direction) {
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            Gdk.ScrollDirection direction;
+            event.get_scroll_direction (out direction);
+            if ((state & Gdk.ModifierType.CONTROL_MASK) > 0) {
+                switch (direction) {
                     case Gdk.ScrollDirection.UP:
                         zoom_in ();
                         return true;
@@ -1469,7 +1473,7 @@ namespace Files {
             int x = (int)event.x;
             int y = (int)event.y;
 
-            if (Gtk.drag_check_threshold (widget, drag_x, drag_y, x, y)) {
+            if (Gtk.drag_check_threshold (widget, (int)drag_x, (int)drag_y, x, y)) {
                 cancel_drag_timer ();
                 should_activate = false;
                 var target_list = new Gtk.TargetList (DRAG_TARGETS);
@@ -2896,6 +2900,7 @@ namespace Files {
         }
 
 /** Keyboard event handling **/
+        //NOTE This will need complete rewrite for Gtk4 so not worth removing direct access to event struct (where possible) now.
 
         /** Returns true if the code parameter matches the keycode of the keyval parameter for
           * any keyboard group or level (in order to allow for non-QWERTY keyboards) **/
@@ -2914,13 +2919,17 @@ namespace Files {
         }
 
         protected virtual bool on_view_key_press_event (Gdk.EventKey event) {
-            if (is_frozen || event.is_modifier == 1) {
+            if (is_frozen) {
                 return true;
             }
 
             cancel_hover ();
 
-            uint keyval = event.keyval;
+            uint original_keyval;
+            Gdk.ModifierType state;
+            event.get_keyval (out original_keyval);
+            var keyval = original_keyval;
+            event.get_state (out state);
             Gdk.ModifierType consumed_mods = 0;
 
             /* Leave standard ASCII alone, else try to get Latin hotkey from keyboard state */
@@ -2928,10 +2937,10 @@ namespace Files {
              * will be in their Dvorak position, not their QWERTY position.
              * For non-Latin (e.g. Cyrillic) keyboards however, the Latin hotkeys are mapped
              * to the same position as on a Latin QWERTY keyboard. If the conversion fails, the unprocessed
-             * event.keyval is used. */
+             * event.keyval is used. TODO: Complete rewrite for Gtk4 */
+
             if (keyval > 127) {
                 int eff_grp, level;
-
                 if (!Gdk.Keymap.get_for_display (get_display ()).translate_keyboard_state (
                         event.hardware_keycode,
                         event.state, event.group,
@@ -2939,7 +2948,7 @@ namespace Files {
                         out level, out consumed_mods)) {
 
                     warning ("translate keyboard state failed");
-                    keyval = event.keyval;
+                    keyval = original_keyval;
                     consumed_mods = 0;
                 } else {
                     keyval = 0;
@@ -2952,13 +2961,13 @@ namespace Files {
 
                     if (keyval == 0) {
                         debug ("Could not match hardware code to ASCII hotkey");
-                        keyval = event.keyval;
+                        keyval = original_keyval;
                         consumed_mods = 0;
                     }
                 }
             }
 
-            var mods = (event.state & ~consumed_mods) & Gtk.accelerator_get_default_mod_mask ();
+            var mods = (state & ~consumed_mods) & Gtk.accelerator_get_default_mod_mask ();
             bool no_mods = (mods == 0);
             bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
             bool only_shift_pressed = shift_pressed && ((mods & ~Gdk.ModifierType.SHIFT_MASK) == 0);
@@ -3261,10 +3270,14 @@ namespace Files {
         }
 
         protected virtual bool on_scroll_event (Gdk.EventScroll event) {
-            if ((event.state & Gdk.ModifierType.CONTROL_MASK) == 0) {
+            Gdk.ScrollDirection direction;
+            event.get_scroll_direction (out direction);
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            if ((state & Gdk.ModifierType.CONTROL_MASK) == 0) {
                 double increment = 0.0;
 
-                switch (event.direction) {
+                switch (direction) {
                     case Gdk.ScrollDirection.LEFT:
                         increment = 5.0;
                         break;
@@ -3283,6 +3296,7 @@ namespace Files {
                         break;
                 }
             }
+
             return handle_scroll_event (event);
         }
 
@@ -3457,7 +3471,8 @@ namespace Files {
             /* Ignore if second button pressed before first released - not permitted during rubberbanding.
              * Multiple click produces an event without corresponding release event so do not block that.
              */
-            if (dnd_disabled && event.type == Gdk.EventType.BUTTON_PRESS) {
+            var type = event.get_event_type ();
+            if (dnd_disabled && type == Gdk.EventType.BUTTON_PRESS) {
                 return true;
             }
 
@@ -3465,13 +3480,16 @@ namespace Files {
 
             Gtk.TreePath? path = null;
             /* Remember position of click for detecting drag motion*/
-            drag_x = (int)(event.x);
-            drag_y = (int)(event.y);
+            event.get_coords (out drag_x, out drag_y);
+            uint button;
+            event.get_button (out button);
             //Only rubberband with primary button
-            click_zone = get_event_position_info (event, out path, event.button == Gdk.BUTTON_PRIMARY);
+            click_zone = get_event_position_info (event, out path, button == Gdk.BUTTON_PRIMARY);
             click_path = path;
 
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            var mods = state & Gtk.accelerator_get_default_mod_mask ();
             bool no_mods = (mods == 0);
             bool control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
             bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
@@ -3480,7 +3498,7 @@ namespace Files {
             bool only_shift_pressed = shift_pressed && !control_pressed && !other_mod_pressed;
             bool path_selected = (path != null ? path_is_selected (path) : false);
             bool on_blank = (click_zone == ClickZone.BLANK_NO_PATH || click_zone == ClickZone.BLANK_PATH);
-            bool double_click_event = (event.type == Gdk.EventType.@2BUTTON_PRESS);
+            bool double_click_event = (type == Gdk.EventType.@2BUTTON_PRESS);
             /* Block drag and drop to allow rubberbanding and prevent unwanted effects of
              * dragging on blank areas
              */
@@ -3498,7 +3516,7 @@ namespace Files {
             should_scroll = true;
 
             /* Handle all selection and deselection explicitly in the following switch statement */
-            switch (event.button) {
+            switch (button) {
                 case Gdk.BUTTON_PRIMARY: // button 1
                     switch (click_zone) {
                         case ClickZone.BLANK_NO_PATH:
@@ -3640,18 +3658,18 @@ namespace Files {
 
             slot.active (should_scroll);
 
-            Gtk.Widget widget = get_child ();
-            int x = (int)event.x;
-            int y = (int)event.y;
+            // Gtk.Widget widget = ;
+            double x, y;
+            uint button;
+            event.get_coords (out x, out y);
+            event.get_button (out button);
             update_selected_files_and_menu ();
             /* Only take action if pointer has not moved */
-            if (!Gtk.drag_check_threshold (widget, drag_x, drag_y, x, y)) {
+            if (!Gtk.drag_check_threshold (get_child (), (int)drag_x, (int)drag_y, (int)x, (int)y)) {
                 if (should_activate) {
                     /* Need Idle else can crash with rapid clicking (avoid nested signals) */
                     Idle.add (() => {
-                        var flag = event.button == Gdk.BUTTON_MIDDLE ? Files.OpenFlag.NEW_TAB :
-                                                                       Files.OpenFlag.DEFAULT;
-
+                        var flag = button == Gdk.BUTTON_MIDDLE ? Files.OpenFlag.NEW_TAB : Files.OpenFlag.DEFAULT;
                         activate_selected_items (flag);
                         return GLib.Source.REMOVE;
                     });
@@ -3669,7 +3687,7 @@ namespace Files {
                         update_selected_files_and_menu ();
                         return GLib.Source.REMOVE;
                     });
-                } else if (event.button == Gdk.BUTTON_SECONDARY) {
+                } else if (button == Gdk.BUTTON_SECONDARY) {
                     show_context_menu (event);
                 }
             }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1847,15 +1847,17 @@ namespace Files {
 
         protected void start_drag_timer (Gdk.Event event) {
             connect_drag_timeout_motion_and_release_events ();
-            var button_event = (Gdk.EventButton)event;
-            drag_button = (int)(button_event.button);
+            uint button;
+            if (event.get_button (out button)) {
+                drag_button = (int)button;
 
-            drag_timer_id = GLib.Timeout.add_full (GLib.Priority.LOW,
-                                                   300,
-                                                   () => {
-                on_drag_timeout_button_release ((Gdk.EventButton)event);
-                return GLib.Source.REMOVE;
-            });
+                drag_timer_id = GLib.Timeout.add_full (GLib.Priority.LOW,
+                                                       300,
+                                                       () => {
+                    on_drag_timeout_button_release ((Gdk.EventButton)event);
+                    return GLib.Source.REMOVE;
+                });
+            }
         }
 
         protected void show_context_menu (Gdk.Event event) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1470,10 +1470,10 @@ namespace Files {
             /* Only active during drag timeout */
             Gdk.DragContext context;
             var widget = get_child ();
-            int x = (int)event.x;
-            int y = (int)event.y;
+            double x, y;
+            event.get_coords (out x, out y);
 
-            if (Gtk.drag_check_threshold (widget, (int)drag_x, (int)drag_y, x, y)) {
+            if (Gtk.drag_check_threshold (widget, (int)drag_x, (int)drag_y, (int)x, (int)y)) {
                 cancel_drag_timer ();
                 should_activate = false;
                 var target_list = new Gtk.TargetList (DRAG_TARGETS);
@@ -1488,7 +1488,7 @@ namespace Files {
                                                            actions,
                                                            drag_button,
                                                            (Gdk.Event) event,
-                                                            x, y);
+                                                            (int)x, (int)y);
                 return true;
             } else {
                 return false;

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -210,7 +210,8 @@ namespace Files {
             int cx, cy, depth;
             path = null;
 
-            if (event.window != tree.get_bin_window ()) {
+            var ewindow = event.get_window ();
+            if (ewindow != tree.get_bin_window ()) {
                 return ClickZone.INVALID;
             }
 

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -207,22 +207,22 @@ namespace Files {
             Gtk.TreePath? p = null;
             unowned Gtk.TreeViewColumn? c = null;
             uint zone;
-            int x, y, cx, cy, depth;
+            int cx, cy, depth;
             path = null;
 
             if (event.window != tree.get_bin_window ()) {
                 return ClickZone.INVALID;
             }
 
-            x = (int)event.x;
-            y = (int)event.y;
+            double x, y;
+            event.get_coords (out x, out y);
 
             /* Determine whether there whitespace at this point.  Note: this function returns false when the
              * position is on the edge of the cell, even though this appears to be blank. We
              * deal with this below. */
-            var is_blank = tree.is_blank_at_pos ((int)event.x, (int)event.y, null, null, null, null);
+            var is_blank = tree.is_blank_at_pos ((int)x, (int)y, null, null, null, null);
 
-            tree.get_path_at_pos ((int)event.x, (int)event.y, out p, out c, out cx, out cy);
+            tree.get_path_at_pos ((int)x, (int)y, out p, out c, out cx, out cy);
             path = p;
             depth = p != null ? p.get_depth () : 0;
 
@@ -246,7 +246,7 @@ namespace Files {
                     if (rtl ? (x > rect.x + rect.width - icon_size) : (x < rect.x + icon_size)) {
                         /* cannot be on name */
                         bool on_helper = false;
-                        bool on_icon = is_on_icon (x, y, ref on_helper);
+                        bool on_icon = is_on_icon ((int)x, (int)y, ref on_helper);
 
                         if (on_helper) {
                             zone = ClickZone.HELPER;

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -364,7 +364,9 @@ namespace Files {
         /* Override base class in order to disable the Gtk.TreeView local search functionality */
         public override bool key_press_event (Gdk.EventKey event) {
             /* We still need the base class to handle cursor keys first */
-            switch (event.keyval) {
+            uint keyval;
+            event.get_keyval (out keyval);
+            switch (keyval) {
                 case Gdk.Key.Up:
                 case Gdk.Key.Down:
                 case Gdk.Key.KP_Up:

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -95,10 +95,14 @@ namespace Files {
         }
 
         protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            uint keyval;
+            event.get_keyval (out keyval);
+            var mods = state & Gtk.accelerator_get_default_mod_mask ();
             bool no_mods = (mods == 0);
 
-            switch (event.keyval) {
+            switch (keyval) {
                 /* Do not emit alert sound on left and right cursor keys in Miller View */
                 case Gdk.Key.Left:
                 case Gdk.Key.Right:
@@ -137,7 +141,8 @@ namespace Files {
             selected_folder = file;
             bool result = true;
 
-            if (event.type == Gdk.EventType.BUTTON_PRESS) {
+            var type = event.get_event_type ();
+            if (type == Gdk.EventType.BUTTON_PRESS) {
                 /* Ignore second GDK_BUTTON_PRESS event of double-click */
                 if (awaiting_double_click) {
                     result = true;
@@ -150,7 +155,7 @@ namespace Files {
                         return GLib.Source.REMOVE;
                     });
                 }
-            } else if (event.type == Gdk.EventType.@2BUTTON_PRESS) {
+            } else if (type == Gdk.EventType.@2BUTTON_PRESS) {
                 should_activate = false;
                 cancel_await_double_click ();
 

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -211,13 +211,12 @@ namespace Files {
                                                          bool rubberband = false) {
             Gtk.CellRenderer? cell_renderer;
             uint zone;
-            int x, y;
             path = null;
 
-            x = (int)event.x;
-            y = (int)event.y;
+            double x, y;
+            event.get_coords (out x, out y);
 
-            tree.get_item_at_pos (x, y, out path, out cell_renderer);
+            tree.get_item_at_pos ((int)x, (int)y, out path, out cell_renderer);
             zone = (path != null ? ClickZone.BLANK_PATH : ClickZone.BLANK_NO_PATH);
 
             if (cell_renderer != null) {
@@ -256,7 +255,7 @@ namespace Files {
                     bool on_helper = false;
                     Files.File? file = model.file_for_path (path);
                     if (file != null) {
-                        bool on_icon = is_on_icon (x, y, ref on_helper);
+                        bool on_icon = is_on_icon ((int)x, (int)y, ref on_helper);
 
                         if (on_helper) {
                             zone = ClickZone.HELPER;

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -248,6 +248,7 @@ namespace Files {
                     if (is_on_blank && rubberband) {
                         /* Fake location outside centre bottom of item for rubberbanding because IconView
                          * unlike TreeView will not rubberband if clicked on an item. */
+                         //TODO Rewrite needed for Gtk4 where events are immutable
                         event.x = rect.x + rect.width / 2;
                         event.y = rect.y + rect.height + 10 + (int)(get_vadjustment ().value);
                     }

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -155,11 +155,15 @@ namespace Files {
         }
 
         protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            bool control_pressed = ((event.state & Gdk.ModifierType.CONTROL_MASK) != 0);
-            bool shift_pressed = ((event.state & Gdk.ModifierType.SHIFT_MASK) != 0);
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            bool control_pressed = ((state & Gdk.ModifierType.CONTROL_MASK) != 0);
+            bool shift_pressed = ((state & Gdk.ModifierType.SHIFT_MASK) != 0);
 
             if (!control_pressed && !shift_pressed) {
-                switch (event.keyval) {
+                uint keyval;
+                event.get_keyval (out keyval);
+                switch (keyval) {
                     case Gdk.Key.Right:
                         Gtk.TreePath? path = null;
                         tree.get_cursor (out path, null);

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -356,7 +356,9 @@ namespace Files.View {
 
         private bool on_key_pressed (Gtk.Widget box, Gdk.EventKey event) {
             /* Only handle unmodified keys */
-            if ((event.state & Gtk.accelerator_get_default_mod_mask ()) > 0) {
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            if ((state & Gtk.accelerator_get_default_mod_mask ()) > 0) {
                 return false;
             }
 
@@ -368,7 +370,9 @@ namespace Files.View {
 
             View.Slot to_activate = null;
 
-            switch (event.keyval) {
+            uint keyval;
+            event.get_keyval (out keyval);
+            switch (keyval) {
                 case Gdk.Key.Left:
                     if (current_position > 0) {
                         to_activate = slot_list.nth_data (current_position - 1);

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -215,7 +215,9 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
     }
 
     protected virtual bool on_key_press_event (Gdk.EventKey event) {
-        switch (event.keyval) {
+        uint keyval;
+        event.get_keyval (out keyval);
+        switch (keyval) {
             case Gdk.Key.F2:
                 rename ();
                 return true;
@@ -239,12 +241,16 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
             return false;
         }
 
-        var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+        Gdk.ModifierType state;
+        event.get_state (out state);
+        var mods = state & Gtk.accelerator_get_default_mod_mask ();
         var control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
         var other_mod_pressed = (((mods & ~Gdk.ModifierType.SHIFT_MASK) & ~Gdk.ModifierType.CONTROL_MASK) != 0);
         var only_control_pressed = control_pressed && !other_mod_pressed; /* Shift can be pressed */
 
-        switch (event.button) {
+        uint button;
+        event.get_button (out button);
+        switch (button) {
             case Gdk.BUTTON_PRIMARY:
                 if (only_control_pressed) {
                     activated (Files.OpenFlag.NEW_TAB);

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -581,9 +581,13 @@ namespace Files.View {
         }
 
         private bool on_button_press_event (Gdk.EventButton event) {
-            Gdk.ModifierType mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            uint button;
+            event.get_button (out button);
+            var mods = state & Gtk.accelerator_get_default_mod_mask ();
             bool result = false;
-            switch (event.button) {
+            switch (button) {
                 /* Extra mouse button actions */
                 case 6:
                 case 8:

--- a/src/View/Widgets/AbstractEditableLabel.vala
+++ b/src/View/Widgets/AbstractEditableLabel.vala
@@ -36,10 +36,14 @@ namespace Files {
         }
 
         public virtual bool on_key_press_event (Gdk.EventKey event) {
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            uint keyval;
+            event.get_keyval (out keyval);
+            var mods = state & Gtk.accelerator_get_default_mod_mask ();
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
 
-            switch (event.keyval) {
+            switch (keyval) {
                 case Gdk.Key.Return:
                 case Gdk.Key.KP_Enter:
                     /*  Only end rename with unmodified Enter. This is to allow use of Ctrl-Enter

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -77,8 +77,9 @@ namespace Files.View.Chrome {
         public override bool on_key_press_event (Gdk.EventKey event) {
             autocompleted = false;
             multiple_completions = false;
-
-            switch (event.keyval) {
+            uint keyval;
+            event.get_keyval (out keyval);
+            switch (keyval) {
                 case Gdk.Key.Return:
                 case Gdk.Key.KP_Enter:
                 case Gdk.Key.ISO_Enter:
@@ -402,13 +403,16 @@ namespace Files.View.Chrome {
 
             var style_context = get_style_context ();
             var padding = style_context.get_padding (style_context.get_state ());
+            double x, y, x_root, y_root;
+            event.get_coords (out x, out y);
+            event.get_root_coords (out x_root, out y_root);
             if (clicked_element.x - BREAD_SPACING < 0) {
-                menu_x_root = event.x_root - event.x + clicked_element.x;
+                menu_x_root = x_root - x + clicked_element.x;
             } else {
-                menu_x_root = event.x_root - event.x + clicked_element.x - BREAD_SPACING;
+                menu_x_root = x_root - x + clicked_element.x - BREAD_SPACING;
             }
 
-            menu_y_root = event.y_root - event.y + get_allocated_height () - padding.bottom - padding.top;
+            menu_y_root = y_root - y + get_allocated_height () - padding.bottom - padding.top;
 
             menu = new Gtk.Menu ();
             menu.cancel.connect (() => {reset_elements_states ();});
@@ -538,7 +542,9 @@ namespace Files.View.Chrome {
             } else {
                 var el = mark_pressed_element (event);
                 if (el != null) {
-                    switch (event.button) {
+                    uint button;
+                    event.get_button (out button);
+                    switch (button) {
                         case 1:
                             break; // Long press support discontinued as provided by system settings
                         case 2:
@@ -558,7 +564,9 @@ namespace Files.View.Chrome {
 
         private BreadcrumbElement? mark_pressed_element (Gdk.EventButton event) {
             reset_elements_states ();
-            BreadcrumbElement? el = get_element_from_coordinates ((int) event.x, (int) event.y);
+            double x, y;
+            event.get_coords (out x, out y);
+            BreadcrumbElement? el = get_element_from_coordinates ((int)x, (int)y);
             if (el != null) {
                 el.pressed = true;
                 queue_draw ();

--- a/src/View/Widgets/SearchResults.vala
+++ b/src/View/Widgets/SearchResults.vala
@@ -464,7 +464,12 @@ namespace Files.View.Chrome {
             if (event.is_modifier == 1) {
                 return true;
             }
-            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+
+            uint keyval;
+            event.get_keyval (out keyval);
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            var mods = state & Gtk.accelerator_get_default_mod_mask ();
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
             bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
             bool alt_pressed = ((mods & Gdk.ModifierType.MOD1_MASK) != 0);
@@ -473,7 +478,7 @@ namespace Files.View.Chrome {
 
             if (mods != 0 && !only_shift_pressed) {
                 if (only_control_pressed) {
-                    if (event.keyval == Gdk.Key.l) {
+                    if (keyval == Gdk.Key.l) {
                         cancel (); /* release any grab */
                         exit (false); /* Do not exit navigate mode */
                         return true;
@@ -481,9 +486,9 @@ namespace Files.View.Chrome {
                         return parent.key_press_event (event);
                     }
                 } else if (only_alt_pressed &&
-                           event.keyval == Gdk.Key.Return ||
-                           event.keyval == Gdk.Key.KP_Enter ||
-                           event.keyval == Gdk.Key.ISO_Enter) {
+                           keyval == Gdk.Key.Return ||
+                           keyval == Gdk.Key.KP_Enter ||
+                           keyval == Gdk.Key.ISO_Enter) {
 
                     accept (null, true); // Open the selected file in default app
                 } else {
@@ -491,7 +496,7 @@ namespace Files.View.Chrome {
                 }
             }
 
-            switch (event.keyval) {
+            switch (keyval) {
                 case Gdk.Key.Return:
                 case Gdk.Key.KP_Enter:
                 case Gdk.Key.ISO_Enter:
@@ -506,8 +511,8 @@ namespace Files.View.Chrome {
                         return true;
                     }
 
-                    var up = (event.keyval == Gdk.Key.Up) ||
-                             (event.keyval == Gdk.Key.ISO_Left_Tab);
+                    var up = (keyval == Gdk.Key.Up) ||
+                             (keyval == Gdk.Key.ISO_Left_Tab);
 
                     if (view.get_selection ().count_selected_rows () < 1) {
                         if (up) {

--- a/src/View/Widgets/SingleLineEditableLabel.vala
+++ b/src/View/Widgets/SingleLineEditableLabel.vala
@@ -68,7 +68,9 @@ namespace Files {
 
         public override bool on_key_press_event (Gdk.EventKey event) {
             /* Ensure rename cancelled on cursor Up/Down */
-            switch (event.keyval) {
+            uint keyval;
+            event.get_keyval (out keyval);
+            switch (keyval) {
                 case Gdk.Key.Up:
                 case Gdk.Key.Down:
                     end_editing (true);

--- a/src/View/Widgets/Welcome.vala
+++ b/src/View/Widgets/Welcome.vala
@@ -31,7 +31,9 @@ namespace Files.View {
 
         public bool on_button_press_event (Gdk.EventButton event) {
             /* Pass Back and Forward button events to toplevel window */
-            switch (event.button) {
+            uint button;
+            event.get_button (out button);
+            switch (button) {
                 case 6:
                 case 7:
                 case 8:

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -246,7 +246,11 @@ namespace Files.View {
             undo_manager.request_menu_update.connect (update_undo_actions);
 
             key_press_event.connect ((event) => {
-                var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+                Gdk.ModifierType state;
+                event.get_state (out state);
+                uint keyval;
+                event.get_keyval (out keyval);
+                var mods = state & Gtk.accelerator_get_default_mod_mask ();
                 bool no_mods = (mods == 0);
                 bool shift_pressed = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
                 bool only_shift_pressed = shift_pressed && ((mods & ~Gdk.ModifierType.SHIFT_MASK) == 0);
@@ -255,7 +259,7 @@ namespace Files.View {
                  * because cannot tab out of location bar and also unwanted items tend to get focused.
                  * There are other hotkeys for operating/focusing other widgets.
                  * Using modified Arrow keys no longer works due to recent changes.  */
-                switch (event.keyval) {
+                switch (keyval) {
                     case Gdk.Key.Tab:
                         if (top_menu.locked_focus) {
                             return false;
@@ -278,10 +282,14 @@ namespace Files.View {
             });
 
             key_press_event.connect_after ((event) => {
+                Gdk.ModifierType state;
+                event.get_state (out state);
+                uint keyval;
+                event.get_keyval (out keyval);
                 /* Use find function instead of view interactive search */
-                if (event.state == 0 || event.state == Gdk.ModifierType.SHIFT_MASK) {
+                if (state == 0 || state == Gdk.ModifierType.SHIFT_MASK) {
                     /* Use printable characters to initiate search */
-                    var uc = ((unichar)(Gdk.keyval_to_unicode (event.keyval)));
+                    var uc = (unichar)(Gdk.keyval_to_unicode (keyval));
                     if (uc.isprint ()) {
                         activate_action ("find", uc.to_string ());
                         return true;
@@ -292,6 +300,7 @@ namespace Files.View {
             });
 
 
+            //TODO Rewrite for Gtk4
             window_state_event.connect ((event) => {
                 if (Gdk.WindowState.ICONIFIED in event.changed_mask) {
                     top_menu.cancel (); /* Cancel any ongoing search query else interface may freeze on uniconifying */


### PR DESCRIPTION
As mentioned in the Gtk migration guide, direct access of the Gdk.Event struct should be replaced with getters prior to migration to Gtk4 and this PR does that where possible.  There are a few places where no simple substition is possible as getters do not exist in Gtk3 or for other reasons and these have been commented.