### PR TITLE
Move key translation to a utility

### DIFF
--- a/src/Utils/KeyUtils.vala
+++ b/src/Utils/KeyUtils.vala
@@ -1,0 +1,80 @@
+/***
+    Copyright (c) 2022 elementary Inc <https://elementary.io>
+
+    This program is free software: you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License version 3, as published
+    by the Free Software Foundation, Inc.,.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranties of
+    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+    PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program. If not, see <http://www.gnu.org/licenses/>.
+
+    Authors : Jeremy Wootten <jeremy@elementaryos.org>
+***/
+
+namespace KeyUtils {
+    /* Leave standard ASCII alone, else try to get Latin hotkey from keyboard state */
+    /* This means that Latin hot keys for Latin Dvorak keyboards (e.g. Spanish Dvorak)
+     * will be in their Dvorak position, not their QWERTY position.
+     * For non-Latin (e.g. Cyrillic) keyboards however, the Latin hotkeys are mapped
+     * to the same position as on a Latin QWERTY keyboard. If the conversion fails, the unprocessed
+     * event.keyval is used. */
+    //TODO Needs complete rewrite for Gtk4 so leaving some direct access of event struct
+    public static uint map_key (Gdk.EventKey event, out Gdk.ModifierType consumed_mods) {
+        uint original_keyval, keyval;
+        event.get_keyval (out original_keyval);
+        keyval = original_keyval;
+        consumed_mods = 0;
+
+        if (keyval > 127) {
+            int eff_grp, level;
+            var display = event.get_device ().get_display ();
+            var keymap = Gdk.Keymap.get_for_display (display);
+            if (!keymap.translate_keyboard_state (
+                    event.hardware_keycode,
+                    event.state, event.group,
+                    out keyval, out eff_grp,
+                    out level, out consumed_mods)) {
+
+                warning ("translate keyboard state failed");
+                keyval = original_keyval;
+                consumed_mods = 0;
+            } else {
+                keyval = 0;
+                for (uint key = 32; key < 128; key++) {
+                    if (match_keycode (keymap, key, event.hardware_keycode, level)) {
+                        keyval = key;
+                        break;
+                    }
+                }
+
+                if (keyval == 0) {
+                    debug ("Could not match hardware code to ASCII hotkey");
+                    keyval = original_keyval;
+                    consumed_mods = 0;
+                }
+            }
+        }
+
+        return keyval;
+    }
+
+    /** Returns true if the code parameter matches the keycode of the keyval parameter for
+      * any keyboard group or level (in order to allow for non-QWERTY keyboards) **/
+    private static bool match_keycode (Gdk.Keymap keymap, uint keyval, uint code, int level) {
+        Gdk.KeymapKey [] keys;
+        if (keymap.get_entries_for_keyval (keyval, out keys)) {
+            foreach (var key in keys) {
+                if (code == key.keycode && level == key.level) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2902,24 +2902,6 @@ namespace Files {
         }
 
 /** Keyboard event handling **/
-        //NOTE This will need complete rewrite for Gtk4 so not worth removing direct access to event struct (where possible) now.
-
-        /** Returns true if the code parameter matches the keycode of the keyval parameter for
-          * any keyboard group or level (in order to allow for non-QWERTY keyboards) **/
-        protected bool match_keycode (uint keyval, uint code, int level) {
-            Gdk.KeymapKey [] keys;
-            Gdk.Keymap keymap = Gdk.Keymap.get_for_display (get_display ());
-            if (keymap.get_entries_for_keyval (keyval, out keys)) {
-                foreach (var key in keys) {
-                    if (code == key.keycode && level == key.level) {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
         protected virtual bool on_view_key_press_event (Gdk.EventKey event) {
             if (is_frozen) {
                 return true;
@@ -2931,47 +2913,9 @@ namespace Files {
 
             cancel_hover ();
 
-            uint original_keyval;
-            event.get_keyval (out original_keyval);
-            var keyval = original_keyval;
-            Gdk.ModifierType state;
+            Gdk.ModifierType consumed_mods, state;
+            var keyval = KeyUtils.map_key (event, out consumed_mods);
             event.get_state (out state);
-            Gdk.ModifierType consumed_mods = 0;
-
-            /* Leave standard ASCII alone, else try to get Latin hotkey from keyboard state */
-            /* This means that Latin hot keys for Latin Dvorak keyboards (e.g. Spanish Dvorak)
-             * will be in their Dvorak position, not their QWERTY position.
-             * For non-Latin (e.g. Cyrillic) keyboards however, the Latin hotkeys are mapped
-             * to the same position as on a Latin QWERTY keyboard. If the conversion fails, the unprocessed
-             * event.keyval is used. TODO: Complete rewrite for Gtk4 */
-
-            if (keyval > 127) {
-                int eff_grp, level;
-                if (!Gdk.Keymap.get_for_display (get_display ()).translate_keyboard_state (
-                        event.hardware_keycode,
-                        event.state, event.group,
-                        out keyval, out eff_grp,
-                        out level, out consumed_mods)) {
-
-                    warning ("translate keyboard state failed");
-                    keyval = original_keyval;
-                    consumed_mods = 0;
-                } else {
-                    keyval = 0;
-                    for (uint key = 32; key < 128; key++) {
-                        if (match_keycode (key, event.hardware_keycode, level)) {
-                            keyval = key;
-                            break;
-                        }
-                    }
-
-                    if (keyval == 0) {
-                        debug ("Could not match hardware code to ASCII hotkey");
-                        keyval = original_keyval;
-                        consumed_mods = 0;
-                    }
-                }
-            }
 
             var mods = (state & ~consumed_mods) & Gtk.accelerator_get_default_mod_mask ();
             bool no_mods = (mods == 0);

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,6 +29,7 @@ pantheon_files_exec = executable (
     'Utils/MimeActions.vala',
     'Utils/Permissions.vala',
     'Utils/AppUtils.vala',
+    'Utils/KeyUtils.vala',
 
     'View/AbstractDirectoryView.vala',
     'View/AbstractTreeView.vala',


### PR DESCRIPTION
Extracted from #1999. Will reduce conflict with master if merged.

Moves some code, without material change, out of AbstractDirectoryView and into a separate utility file.