### PR TITLE
Remove faulty check blocking pre-selection

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3308,10 +3308,6 @@ namespace Files {
 
     /** name renderer signals */
         protected void on_name_editing_started (Gtk.CellEditable? editable, string path_string) {
-            if (renaming) { /* Ignore duplicate editing-started signal*/
-                return;
-            }
-
             var editable_widget = editable as AbstractEditableLabel?;
             if (editable_widget != null) {
                 original_name = editable_widget.get_chars (0, -1);


### PR DESCRIPTION
Fix #2029 

A recent commit concerning renaming has resulted in this regression due to the `renaming` flag being set earlier so that the function doing the selection always returned early due to a re-entry check.

This PR just removes the check, which, afaicr was put in place due to duplicate signals calling the function twice when renaming.  This no longer seems to happen so the check is not required.