### PR TITLE
Small code cleanups

### DIFF
--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -273,7 +273,9 @@ namespace Files.View {
         **/
         public void change_view_mode (ViewMode mode, GLib.File? loc = null) {
             var aslot = get_current_slot ();
-            assert (aslot != null);
+            if (aslot == null) {
+                return;
+            }
 
             if (mode != view_mode) {
                 view_mode = mode;

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -390,14 +390,6 @@ namespace Files.View {
             save_tabs ();
         }
 
-        public Files.AbstractSlot? get_active_slot () {
-            if (current_tab != null) {
-                return current_tab.get_current_slot ();
-            } else {
-                return null;
-            }
-        }
-
         public new void set_title (string title) {
             this.title = title;
         }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -750,6 +750,10 @@ namespace Files.View {
         }
 
         private void action_view_mode (GLib.SimpleAction action, GLib.Variant? param) {
+            if (current_tab == null) { // can occur during startup
+                return;
+            }
+
             ViewMode mode = real_mode ((ViewMode)(param.get_uint32 ()));
             current_tab.change_view_mode (mode);
             /* ViewContainer takes care of changing appearance */


### PR DESCRIPTION
Cherrypicked from #2018 as not directly addressing the issue, in order to reduce diff once merged.

* Check for null slot and tab to suppress terminal warning
* Replace assert with if clause
* Remove unnecessary function.