### PR TITLE
Fix terminal critical warnings and possible crash when removing bookmark

### DIFF
--- a/src/View/Sidebar/BookmarkListBox.vala
+++ b/src/View/Sidebar/BookmarkListBox.vala
@@ -211,26 +211,19 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
     }
 
     public override bool remove_item_by_id (uint32 id) {
-        SidebarItemInterface? row_to_destroy = null;
-        foreach (unowned Gtk.Widget child in get_children ()) {
+        bool removed = false;
+        this.@foreach ((child) => {
             if (child is SidebarItemInterface) {
                 unowned var row = (SidebarItemInterface)child;
-                if (row.permanent) {
-                    continue;
-                } else if (row.id == id) {
-                    row_to_destroy = row;
+               if (!row.permanent && row.id == id) {
                     remove (row);
                     bookmark_list.delete_items_with_uri (row.uri); //Assumes no duplicates
+                    removed = true;
                 }
             }
-        }
+        });
 
-        if (row_to_destroy != null) {
-            row_to_destroy.destroy_bookmark ();
-            return true;
-        }
-
-        return false;
+        return removed;
     }
 
     public SidebarItemInterface? get_item_at_index (int index) {

--- a/src/View/Sidebar/BookmarkListBox.vala
+++ b/src/View/Sidebar/BookmarkListBox.vala
@@ -211,18 +211,23 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
     }
 
     public override bool remove_item_by_id (uint32 id) {
+        SidebarItemInterface? row_to_destroy = null;
         foreach (unowned Gtk.Widget child in get_children ()) {
             if (child is SidebarItemInterface) {
                 unowned var row = (SidebarItemInterface)child;
                 if (row.permanent) {
                     continue;
                 } else if (row.id == id) {
+                    row_to_destroy = row;
                     remove (row);
                     bookmark_list.delete_items_with_uri (row.uri); //Assumes no duplicates
-                    row.destroy_bookmark ();
-                    return true;
                 }
             }
+        }
+
+        if (row_to_destroy != null) {
+            row_to_destroy.destroy_bookmark ();
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Fixes #2061 (confirmed by issue reporter)

Use `Container.@foreach ()` instead of `foreach (child in Container) {}`  to allow destruction of child within loop.

This silences the terminal warnings but as I could not reproduce the reported crash needs the reporter to confirm it also fixes that problem