### PR TITLE
Reset pathbar on iconification

### DIFF
--- a/libcore/Widgets/BasicBreadcrumbsEntry.vala
+++ b/libcore/Widgets/BasicBreadcrumbsEntry.vala
@@ -327,18 +327,21 @@ namespace Files.View.Chrome {
                 return true;
             } else {
                 /* This the delayed propagated event */
-                focus_out_timeout_id = 0;
                 base.focus_out_event (event);
 
                 if (context_menu_showing) {
                     return true;
                 }
 
+                // Reset if window has top level focus or is iconified
                 // Do not lose entry text if another window is focused
-                if (((Gtk.Window)(get_toplevel ())).has_toplevel_focus) {
+                var top_level = (Gtk.Window)(get_toplevel ());
+                if (top_level.has_toplevel_focus ||
+                     (top_level.get_window ().get_state () & Gdk.WindowState.ICONIFIED) > 0) {
                     reset ();
                 }
 
+                focus_out_timeout_id = 0;
                 return false;
             }
         }


### PR DESCRIPTION
Fixes #2068 

This issue seems to be due to the pathbar receiving a `focus_out_event` when the window is iconified but, because it is no longer in a focused toplevel window it does not reset (to maintain entry focus while another window is focused).  However, it does not receive a `focus_in_event` when the window is uniconified.  This results in the entry having keyboard focus but the `is_focus` property returns false (maybe a Gtk bug?).

The simplest solution to this is to have the pathbar reset when the window is iconified.  In practice imo a user is unlikely to want to iconify the window in the middle of editing the pathbar without abandoning the edit so a more complex solution does not seem worthwhile.