### PR TITLE
Close slot early before mode change; cancel another timeout

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3843,6 +3843,7 @@ namespace Files {
             cancel_timeout (ref drag_scroll_timer_id);
             cancel_timeout (ref add_remove_file_timeout_id);
             cancel_timeout (ref set_cursor_timeout_id);
+            cancel_timeout (ref draw_timeout_id);
             /* List View will take care of unloading subdirectories */
         }
 

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -280,6 +280,7 @@ namespace Files.View {
             }
 
             if (mode != view_mode) {
+                aslot.close ();
                 view_mode = mode;
                 loading (false);
                 store_selection ();


### PR DESCRIPTION
Fixes #2075 
Fixes #1983 

Close the current slot (which cancels various view timeouts) before proceeding with mode change.