### PR TITLE
Prevent unexpected file activation after navigation with double-click

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -686,6 +686,8 @@ namespace Files {
             block_model ();
             model.clear ();
             all_selected = false;
+            /* Prevent unexpected file activation after navigation with double-click in mixed mode */
+            on_directory = false;
             unblock_model ();
         }
 
@@ -3509,7 +3511,6 @@ namespace Files {
              * dragging on blank areas
              */
             block_drag_and_drop ();
-
             /* Handle un-modified clicks or control-clicks here else pass on. */
             if (!will_handle_button_press (no_mods, only_control_pressed, only_shift_pressed)) {
                 return false;


### PR DESCRIPTION
Fixes #2088 

Simplest fix since button handling will need to be rewritten for Gtk4 anyway.  The fix assumes non-directory files always need a double-click to activate.  This fixes the stated issue but note that the stray click on the new folder will *select* a non-directory file instead of activating it.  Users who want to double-click on folders should switch to the reinstated double-click mode anyway.