### PR TITLE
Fix crash creating new empty file (#2098)

### DIFF
--- a/libcore/FileOperations/CreateJob.vala
+++ b/libcore/FileOperations/CreateJob.vala
@@ -42,7 +42,7 @@ public class Files.FileOperations.CreateJob : CommonJob {
         this.src = src;
     }
 
-    public CreateJob.file (Gtk.Window? parent_window, GLib.File dest_dir, string target_filename, [CCode (array_length_cname = "length")] uint8[] src_data) {
+    public CreateJob.file (Gtk.Window? parent_window, GLib.File dest_dir, string? target_filename, [CCode (array_length_cname = "length")] uint8[] src_data) {
         base (parent_window);
         this.dest_dir = dest_dir;
         this.filename = target_filename;

--- a/libcore/marlin-file-operations.c
+++ b/libcore/marlin-file-operations.c
@@ -4394,7 +4394,7 @@ retry:
             }
             // End UNDO-REDO
         } else {
-            data[0] = '\0';
+            data = "";
             length = 0;
             if (job->src_data) {
                 data = job->src_data;


### PR DESCRIPTION
Creating a new empty file (Right click -> New -> Empty File) crashes Files.

There were 2 issues causing the crash:

 - `CreateJob.file` didn't allow to set an empty `target_filename`.
 - `create_job ()` accessed uninitialized memory.

This commit fixes both issues.

Fix: https://github.com/elementary/files/issues/2098
Fixes: 53983bde62c4 ("More work towards the Vala port (#2092)")