### PR TITLE
Update appdata and meson.build for next release

### DIFF
--- a/data/io.elementary.files.appdata.xml.in.in
+++ b/data/io.elementary.files.appdata.xml.in.in
@@ -28,6 +28,20 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="6.2.2" date="2023-02-03" urgency="medium">
+      <description>
+        <p>Minor updates:</p>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/files/pull/2122">Avoid crashes when disconnecting the provider</issue>
+        <issue url="https://github.com/elementary/files/issues/2115">Paste into folder menu item doesn't work</issue>
+        <issue url="https://github.com/elementary/files/pull/2107">Improve double-click setting label</issue>
+        <issue url="https://github.com/elementary/files/issues/2105">Sidebar icons sometimes change</issue>
+      </issues>
+    </release>
     <release version="6.2.1" date="2022-11-15" urgency="medium">
       <description>
         <p>Minor updates:</p>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'io.elementary.files',
     'vala', 'c',
-    version: '6.2.1',
+    version: '6.2.2',
     meson_version: '>= 0.50.0'
 )
 


### PR DESCRIPTION
Updates the appdata and version number for next release.

Other house keeping could be done here or (better) later:
 - [ ] Change name to `...metainfo.xml`
 - [ ] Reduce number of releases retained