### PR TITLE
Sort, margins, seps, use checkboxes for includes

### DIFF
--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -122,12 +122,11 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
 
         var undo_redo_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
             homogeneous = true,
-            hexpand = true,
-            margin_top = 12,
             margin_end = 12,
-            margin_bottom = 6,
+            margin_bottom = 12,
             margin_start = 12
         };
+        undo_redo_box.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
 
         var undo_button = new Gtk.Button.from_icon_name ("edit-undo-symbolic", Gtk.IconSize.MENU) {
             action_name = "win.undo"
@@ -148,18 +147,17 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
         undo_redo_box.add (undo_button);
         undo_redo_box.add (redo_button);
 
-        //Global Options
-        var options_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
-            margin_end = 12,
-            margin_start = 12,
-            margin_bottom = 12,
-            homogeneous = true
-        };
         // Double-click option
         var double_click_button = new Granite.SwitchModelButton (_("Double-click to Navigate")) {
             description = _("Double-click on a folder opens it, single-click selects it"),
             action_name = "win.singleclick-select"
         };
+
+        //Sort folders before files
+        var foldes_before_files = new Granite.SwitchModelButton (_("Sort Folders before Files")) {
+            action_name = "win.folders-before-files"
+        };
+
         // Show hidden files
         var show_hidden_button = new Granite.SwitchModelButton (_("Show Hidden Files")) {
             action_name = "win.show-hidden"
@@ -172,26 +170,20 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
         var hide_local_thumbnails = new Granite.SwitchModelButton (_("Hide Local Thumbnails")) {
             action_name = "win.hide-local-thumbnails"
         };
-        //Sort folders before files
-        var foldes_before_files = new Granite.SwitchModelButton (_("Sort Folders before Files")) {
-            action_name = "win.folders-before-files"
-        };
-
-        options_box.add (double_click_button);
-        options_box.add (show_hidden_button);
-        options_box.add (show_remote_thumbnails);
-        options_box.add (hide_local_thumbnails);
-        options_box.add (foldes_before_files);
 
         // Popover menu
         var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
-            margin_bottom = 3
+            margin_bottom = 6
         };
         menu_box.add (icon_size_box);
-        menu_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
         menu_box.add (undo_redo_box);
-        menu_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-        menu_box.add (options_box);
+        menu_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL) { margin_bottom = 3 });
+        menu_box.add (double_click_button);
+        menu_box.add (foldes_before_files);
+        menu_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL) { margin_top = 3, margin_bottom = 3 });
+        menu_box.add (show_hidden_button);
+        menu_box.add (show_remote_thumbnails);
+        menu_box.add (hide_local_thumbnails);
         menu_box.show_all ();
 
         var menu = new Gtk.Popover (null);

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -158,18 +158,26 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
             action_name = "win.folders-before-files"
         };
 
-        // Show hidden files
-        var show_hidden_button = new Granite.SwitchModelButton (_("Show Hidden Files")) {
+        var show_header = new Granite.HeaderLabel (_("Show in View"));
+
+        var show_hidden_button = new Gtk.CheckButton () {
             action_name = "win.show-hidden"
         };
-        // Show remote thumbnails
-        var show_remote_thumbnails = new Granite.SwitchModelButton (_("Show Remote Thumbnails")) {
-            action_name = "win.show-remote-thumbnails"
-        };
-        //Hide local thumbnails
-        var hide_local_thumbnails = new Granite.SwitchModelButton (_("Hide Local Thumbnails")) {
+        show_hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
+        show_hidden_button.add (new Granite.AccelLabel (
+            _("Hidden Files"),
+            "<Ctrl>h"
+        ));
+
+        var hide_local_thumbnails = new Gtk.CheckButton.with_label (_("Local Thumbnails")) {
             action_name = "win.hide-local-thumbnails"
         };
+        hide_local_thumbnails.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
+
+        var show_remote_thumbnails = new Gtk.CheckButton.with_label (_("Remote Thumbnails")) {
+            action_name = "win.show-remote-thumbnails"
+        };
+        show_remote_thumbnails.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
 
         // Popover menu
         var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
@@ -181,9 +189,10 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
         menu_box.add (double_click_button);
         menu_box.add (foldes_before_files);
         menu_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL) { margin_top = 3, margin_bottom = 3 });
+        menu_box.add (show_header);
         menu_box.add (show_hidden_button);
-        menu_box.add (show_remote_thumbnails);
         menu_box.add (hide_local_thumbnails);
+        menu_box.add (show_remote_thumbnails);
         menu_box.show_all ();
 
         var menu = new Gtk.Popover (null);


### PR DESCRIPTION
I'm including two screenshots here, one for each commit!

## First Commit

* Use linked buttons for undo/redo. This is more inline with how we show action buttons in Code or how they're presented in Web
* Separate behavior changes from things we're including in the view

![Screenshot from 2023-02-09 09 17 48](https://user-images.githubusercontent.com/7277719/217891640-85d9b6c0-a0d4-490c-9c0a-27c4c9e22cbc.png)

# Second Commit

This is going to need to invert the logic of the "Local thumbnails" action, which I didn't touch here yet. But, the idea is that these are a list of things we want to include/exclude from the view and not completely separate features that we're enabling/disabling. So we use checkboxes here since they're related parts of the same list. I also feel like this breaks up the menu a bit to be less overwhelming with switches and it lets us bring back that accel label that we had in the context menu

![Screenshot from 2023-02-09 09 27 47](https://user-images.githubusercontent.com/7277719/217891636-de9809d0-7a9a-461e-b250-fbc0da78426f.png)