### PR TITLE
Invert show local logic

### DIFF
--- a/data/schemas/io.elementary.files.gschema.xml
+++ b/data/schemas/io.elementary.files.gschema.xml
@@ -34,10 +34,10 @@
       <summary>Thumbnail remote files</summary>
       <description>Show thumbnails for files on remote filesystems</description>
     </key>
-    <key type="b" name="hide-local-thumbnails">
-      <default>false</default>
-      <summary>Do not thumbnail local files</summary>
-      <description>Do not thumbnail files on the local filesystem</description>
+    <key type="b" name="show-local-thumbnails">
+      <default>true</default>
+      <summary>Thumbnail local files</summary>
+      <description>Show thumbnail files on the local filesystem</description>
     </key>
     <key type="b" name="show-sidebar">
       <default>true</default>

--- a/libcore/Preferences.vala
+++ b/libcore/Preferences.vala
@@ -27,7 +27,7 @@ namespace Files {
 
         public bool show_hidden_files {get; set; default = false;}
         public bool show_remote_thumbnails {set; get; default = true;}
-        public bool hide_local_thumbnails {set; get; default = false;}
+        public bool show_local_thumbnails {set; get; default = false;}
         public bool singleclick_select {set; get; default = false;}
         public bool confirm_trash {set; get; default = true;}
         public bool force_icon_size {set; get; default = true;}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -285,8 +285,8 @@ public class Files.Application : Gtk.Application {
 
         Files.app_settings.bind ("show-remote-thumbnails",
                                    prefs, "show-remote-thumbnails", GLib.SettingsBindFlags.DEFAULT);
-        Files.app_settings.bind ("hide-local-thumbnails",
-                                   prefs, "hide-local-thumbnails", GLib.SettingsBindFlags.DEFAULT);
+        Files.app_settings.bind ("show-local-thumbnails",
+                                   prefs, "show-local-thumbnails", GLib.SettingsBindFlags.DEFAULT);
 
         Files.app_settings.bind ("date-format", prefs, "date-format", GLib.SettingsBindFlags.DEFAULT);
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1342,7 +1342,7 @@ namespace Files {
                 model.file_changed (file, dir);
                 /* 2nd parameter is for returned request id if required - we do not use it? */
                 /* This is required if we need to dequeue the request */
-                if ((!slot.directory.is_network && !show_local_thumbnails) ||
+                if ((!slot.directory.is_network && show_local_thumbnails) ||
                     (show_remote_thumbnails && slot.directory.can_open_files)) {
 
                     thumbnailer.queue_file (file, null, large_thumbnails);

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -169,10 +169,10 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
             "<Ctrl>h"
         ));
 
-        var hide_local_thumbnails = new Gtk.CheckButton.with_label (_("Local Thumbnails")) {
-            action_name = "win.hide-local-thumbnails"
+        var show_local_thumbnails = new Gtk.CheckButton.with_label (_("Local Thumbnails")) {
+            action_name = "win.show-local-thumbnails"
         };
-        hide_local_thumbnails.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
+        show_local_thumbnails.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
 
         var show_remote_thumbnails = new Gtk.CheckButton.with_label (_("Remote Thumbnails")) {
             action_name = "win.show-remote-thumbnails"
@@ -191,7 +191,7 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
         menu_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL) { margin_top = 3, margin_bottom = 3 });
         menu_box.add (show_header);
         menu_box.add (show_hidden_button);
-        menu_box.add (hide_local_thumbnails);
+        menu_box.add (show_local_thumbnails);
         menu_box.add (show_remote_thumbnails);
         menu_box.show_all ();
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -41,7 +41,7 @@ namespace Files.View {
             {"show-hidden", null, null, "false", change_state_show_hidden},
             {"singleclick-select", null, null, "false", change_state_single_click_select},
             {"show-remote-thumbnails", null, null, "true", change_state_show_remote_thumbnails},
-            {"hide-local-thumbnails", null, null, "false", change_state_hide_local_thumbnails},
+            {"show-local-thumbnails", null, null, "false", change_state_show_local_thumbnails},
             {"folders-before-files", null, null, "true", change_state_folders_before_files}
         };
 
@@ -923,10 +923,10 @@ namespace Files.View {
             Files.app_settings.set_boolean ("show-remote-thumbnails", state);
         }
 
-        public void change_state_hide_local_thumbnails (GLib.SimpleAction action) {
+        public void change_state_show_local_thumbnails (GLib.SimpleAction action) {
             bool state = !action.state.get_boolean ();
             action.set_state (new GLib.Variant.boolean (state));
-            Files.app_settings.set_boolean ("hide-local-thumbnails", state);
+            Files.app_settings.set_boolean ("show-local-thumbnails", state);
         }
 
         public void change_state_folders_before_files (GLib.SimpleAction action) {


### PR DESCRIPTION
Inverts the logic of `show-local-thumbnails` and removes duplicates from the context menu