### PR TITLE
Update Undo/Redo button tooltips with operation type

### DIFF
--- a/libcore/UndoManager.vala
+++ b/libcore/UndoManager.vala
@@ -16,7 +16,7 @@ namespace Files {
         CHANGEOWNER,
         CHANGEGROUP;
 
-        public string to_string () {
+        public unowned string to_action_string () {
             switch (this) {
                 case COPY:
                     return _("Copy");

--- a/libcore/UndoManager.vala
+++ b/libcore/UndoManager.vala
@@ -14,7 +14,42 @@ namespace Files {
         SETPERMISSIONS,
         RECURSIVESETPERMISSIONS,
         CHANGEOWNER,
-        CHANGEGROUP
+        CHANGEGROUP;
+
+        public string to_string () {
+            switch (this) {
+                case COPY:
+                    return _("Copy");
+                case DUPLICATE:
+                    return _("Duplicate");
+                case MOVE:
+                    return _("Move");
+                case RENAME:
+                    return _("Rename");
+                case CREATEEMPTYFILE:
+                    return _("Create Empty File");
+                case CREATEFILEFROMTEMPLATE:
+                    return _("Create File from Template");
+                case CREATEFOLDER:
+                    return _("Create Folder");
+                case MOVETOTRASH:
+                    return _("Move to Trash");
+                case CREATELINK:
+                    return _("Create Link");
+                case RESTOREFROMTRASH:
+                    return _("Restore from Trash");
+                case SETPERMISSIONS:
+                    return _("Set Permissions");
+                case RECURSIVESETPERMISSIONS:
+                    return _("Set Permissions Recursively");
+                case CHANGEOWNER:
+                    return _("Change Owner");
+                case CHANGEGROUP:
+                    return _("Change Group");
+                default:
+                    assert_not_reached ();
+            }
+        }
     }
 
     public class UndoActionData {
@@ -595,6 +630,23 @@ namespace Files {
                 return null;
             } else {
                 return action;
+            }
+        }
+
+        public string get_next_undo_description () {
+            var action = get_next_undo_action ();
+            if (action != null) {
+                return action.action_type.to_string ();
+            } else {
+                return "";
+            }
+        }
+        public string get_next_redo_description () {
+            var action = get_next_redo_action ();
+            if (action != null) {
+                return action.action_type.to_string ();
+            } else {
+                return "";
             }
         }
 

--- a/libcore/UndoManager.vala
+++ b/libcore/UndoManager.vala
@@ -633,12 +633,12 @@ namespace Files {
             }
         }
 
-        public string get_next_undo_description () {
-            var action = get_next_undo_action ();
+        public unowned string? get_next_undo_description () {
+            unowned var action = get_next_undo_action ();
             if (action != null) {
-                return action.action_type.to_string ();
+                return action.action_type.to_action_string ();
             } else {
-                return "";
+                return null;
             }
         }
         public string get_next_redo_description () {

--- a/libcore/UndoManager.vala
+++ b/libcore/UndoManager.vala
@@ -16,36 +16,71 @@ namespace Files {
         CHANGEOWNER,
         CHANGEGROUP;
 
-        public unowned string to_action_string () {
+        public unowned string to_undo_string () {
             switch (this) {
                 case COPY:
-                    return _("Copy");
+                    return _("Undo Copy");
                 case DUPLICATE:
-                    return _("Duplicate");
+                    return _("Undo Duplicate");
                 case MOVE:
-                    return _("Move");
+                    return _("Undo Move");
                 case RENAME:
-                    return _("Rename");
+                    return _("Undo Rename");
                 case CREATEEMPTYFILE:
-                    return _("Create Empty File");
+                    return _("Undo Create Empty File");
                 case CREATEFILEFROMTEMPLATE:
-                    return _("Create File from Template");
+                    return _("Undo Create File from Template");
                 case CREATEFOLDER:
-                    return _("Create Folder");
+                    return _("Undo Create Folder");
                 case MOVETOTRASH:
-                    return _("Move to Trash");
+                    return _("Undo Move to Trash");
                 case CREATELINK:
-                    return _("Create Link");
+                    return _("Undo Create Link");
                 case RESTOREFROMTRASH:
-                    return _("Restore from Trash");
+                    return _("Undo Restore from Trash");
                 case SETPERMISSIONS:
-                    return _("Set Permissions");
+                    return _("Undo Set Permissions");
                 case RECURSIVESETPERMISSIONS:
-                    return _("Set Permissions Recursively");
+                    return _("Undo Set Permissions Recursively");
                 case CHANGEOWNER:
-                    return _("Change Owner");
+                    return _("Undo Change Owner");
                 case CHANGEGROUP:
-                    return _("Change Group");
+                    return _("Undo Change Group");
+                default:
+                    assert_not_reached ();
+            }
+        }
+
+        public unowned string to_redo_string () {
+            switch (this) {
+                case COPY:
+                    return _("Redo Copy");
+                case DUPLICATE:
+                    return _("Redo Duplicate");
+                case MOVE:
+                    return _("Redo Move");
+                case RENAME:
+                    return _("Redo Rename");
+                case CREATEEMPTYFILE:
+                    return _("Redo Create Empty File");
+                case CREATEFILEFROMTEMPLATE:
+                    return _("Redo Create File from Template");
+                case CREATEFOLDER:
+                    return _("Redo Create Folder");
+                case MOVETOTRASH:
+                    return _("Redo Move to Trash");
+                case CREATELINK:
+                    return _("Redo Create Link");
+                case RESTOREFROMTRASH:
+                    return _("Redo Restore from Trash");
+                case SETPERMISSIONS:
+                    return _("Redo Set Permissions");
+                case RECURSIVESETPERMISSIONS:
+                    return _("Redo Set Permissions Recursively");
+                case CHANGEOWNER:
+                    return _("Redo Change Owner");
+                case CHANGEGROUP:
+                    return _("Redo Change Group");
                 default:
                     assert_not_reached ();
             }
@@ -636,17 +671,18 @@ namespace Files {
         public unowned string? get_next_undo_description () {
             unowned var action = get_next_undo_action ();
             if (action != null) {
-                return action.action_type.to_action_string ();
+                return action.action_type.to_undo_string ();
             } else {
                 return null;
             }
         }
-        public string get_next_redo_description () {
+
+        public unowned string get_next_redo_description () {
             var action = get_next_redo_action ();
             if (action != null) {
-                return action.action_type.to_string ();
+                return action.action_type.to_redo_string ();
             } else {
-                return "";
+                return null;
             }
         }
 

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -273,8 +273,8 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
     }
 
     private void set_undo_redo_tooltips () {
-        var undo_action_s = undo_manager.get_next_undo_description ();
-        var redo_action_s = undo_manager.get_next_redo_description ();
+        unowned var undo_action_s = undo_manager.get_next_undo_description ();
+        unowned var redo_action_s = undo_manager.get_next_redo_description ();
 
         undo_button.tooltip_markup = Granite.markup_accel_tooltip (
             undo_accels,

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -279,6 +279,7 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
         undo_button.tooltip_markup = Granite.markup_accel_tooltip (
             undo_accels,
             undo_action_s != "" ?
+            ///TRANSLATORS %s is a placeholder for a file operation type such as "Move"
             _("Undo %s").printf (undo_action_s) :
             _("No operation to undo")
         );
@@ -286,6 +287,7 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
         redo_button.tooltip_markup = Granite.markup_accel_tooltip (
             redo_accels,
             redo_action_s != "" ?
+            ///TRANSLATORS %s is a placeholder for a file operation type such as "Move"
             _("Redo %s").printf (redo_action_s) :
             _("No operation to redo")
         );

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -275,23 +275,20 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
     private void set_undo_redo_tooltips () {
         var undo_action_s = undo_manager.get_next_undo_description ();
         var redo_action_s = undo_manager.get_next_redo_description ();
-        if (undo_action_s != "") {
-            undo_button.tooltip_markup = Granite.markup_accel_tooltip (
-                undo_accels,
-                _("Undo %s").printf (undo_action_s)
-            );
-        } else {
-            undo_button.tooltip_text = _("No operation to undo");
-        }
 
-        if (redo_action_s != "") {
-            redo_button.tooltip_markup = Granite.markup_accel_tooltip (
-                redo_accels,
-                _("Redo %s").printf (redo_action_s)
-            );
-        } else {
-            redo_button.tooltip_text = _("No operation to redo");
-        }
+        undo_button.tooltip_markup = Granite.markup_accel_tooltip (
+            undo_accels,
+            undo_action_s != "" ?
+            _("Undo %s").printf (undo_action_s) :
+            _("No operation to undo")
+        );
+
+        redo_button.tooltip_markup = Granite.markup_accel_tooltip (
+            redo_accels,
+            redo_action_s != "" ?
+            _("Redo %s").printf (redo_action_s) :
+            _("No operation to redo")
+        );
     }
 
     private void on_zoom_setting_changed (Settings settings, string key) {

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -56,6 +56,11 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
     private Gtk.Button zoom_default_button;
     private Gtk.Button zoom_in_button;
     private Gtk.Button zoom_out_button;
+    private Gtk.Button undo_button;
+    private Gtk.Button redo_button;
+    private string[] undo_accels;
+    private string[] redo_accels;
+    private unowned UndoManager undo_manager;
 
     public HeaderBar (ViewSwitcher switcher) {
         Object (view_switcher: switcher);
@@ -131,24 +136,19 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
         };
         undo_redo_box.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
 
-        var undo_button = new Gtk.Button.from_icon_name ("edit-undo-symbolic", Gtk.IconSize.MENU) {
+        undo_button = new Gtk.Button.from_icon_name ("edit-undo-symbolic", Gtk.IconSize.MENU) {
             action_name = "win.undo"
         };
-        undo_button.tooltip_markup = Granite.markup_accel_tooltip (
-            app_instance.get_accels_for_action ("win.undo"),
-            _("Undo Last File Operation")
-        );
 
-        var redo_button = new Gtk.Button.from_icon_name ("edit-redo-symbolic", Gtk.IconSize.MENU) {
+        redo_button = new Gtk.Button.from_icon_name ("edit-redo-symbolic", Gtk.IconSize.MENU) {
             action_name = "win.redo"
         };
-        redo_button.tooltip_markup = Granite.markup_accel_tooltip (
-            app_instance.get_accels_for_action ("win.redo"),
-            _("Redo Last Undone File Operation")
-        );
 
         undo_redo_box.add (undo_button);
         undo_redo_box.add (redo_button);
+
+        undo_accels = app_instance.get_accels_for_action ("win.undo");
+        redo_accels = app_instance.get_accels_for_action ("win.redo");
 
         // Double-click option
         var double_click_button = new Granite.SwitchModelButton (_("Double-click to Navigate")) {
@@ -266,6 +266,32 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
         });
 
         location_bar.escape.connect (() => {escape ();});
+
+        undo_manager = UndoManager.instance ();
+        undo_manager.request_menu_update.connect (set_undo_redo_tooltips);
+        set_undo_redo_tooltips ();
+    }
+
+    private void set_undo_redo_tooltips () {
+        var undo_action_s = undo_manager.get_next_undo_description ();
+        var redo_action_s = undo_manager.get_next_redo_description ();
+        if (undo_action_s != "") {
+            undo_button.tooltip_markup = Granite.markup_accel_tooltip (
+                undo_accels,
+                _("Undo %s").printf (undo_action_s)
+            );
+        } else {
+            undo_button.tooltip_text = _("No operation to undo");
+        }
+
+        if (redo_action_s != "") {
+            redo_button.tooltip_markup = Granite.markup_accel_tooltip (
+                redo_accels,
+                _("Redo %s").printf (redo_action_s)
+            );
+        } else {
+            redo_button.tooltip_text = _("No operation to redo");
+        }
     }
 
     private void on_zoom_setting_changed (Settings settings, string key) {

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -278,7 +278,7 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
 
         undo_button.tooltip_markup = Granite.markup_accel_tooltip (
             undo_accels,
-            undo_action_s != "" ?
+            undo_action_s != null ?
             ///TRANSLATORS %s is a placeholder for a file operation type such as "Move"
             _("Undo %s").printf (undo_action_s) :
             _("No operation to undo")

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -280,7 +280,7 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
             undo_accels,
             undo_action_s != null ?
             ///TRANSLATORS %s is a placeholder for a file operation type such as "Move"
-            _("Undo %s").printf (undo_action_s) :
+            undo_action_s :
             _("No operation to undo")
         );
 
@@ -288,7 +288,7 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
             redo_accels,
             redo_action_s != "" ?
             ///TRANSLATORS %s is a placeholder for a file operation type such as "Move"
-            _("Redo %s").printf (redo_action_s) :
+            redo_action_s :
             _("No operation to redo")
         );
     }


### PR DESCRIPTION
Fixes #2136 

Simple solution using only the operation type.  Further details regarding the source and target could be added but the tooltip may get long.
