### PR TITLE
Avoid crash on other Linux due to ref counting issues in Directory cache

### DIFF
--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -497,8 +497,8 @@ public class Files.Directory : Object {
             // Do not add toggle until cached
             lock (directory_cache) {
                 // Creation key will normally be the final location but check anyway.
-                if (creation_key != location) {
-                    warning ("creation key differs from final location");
+                if (!(creation_key.equal (location))) {
+                    warning ("creation key %s differs from final location %s", creation_key.get_uri (), location.get_uri ());
                     directory_cache.remove (creation_key);
                 }
 

--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -157,7 +157,9 @@ public class Files.Directory : Object {
             disconnect_volume_monitor_signals ();
         }
 
-        file.set_expanded (false); // Ensure any remaining folder icons are not displayed as expanded
+        if (file != null && file.is_directory) {
+            file.set_expanded (false); // Ensure any remaining folder icons are not displayed as expanded
+        }
     }
 
     /** Views call the following function with null parameter - file_loaded and done_loading

--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -20,11 +20,11 @@
 ***/
 
 public class Files.Directory : Object {
-    private static HashTable<GLib.File, unowned Files.Directory> directory_cache;
+    private static HashTable<unowned GLib.File, Files.Directory?> directory_cache;
     private static Mutex dir_cache_lock;
 
     static construct {
-        directory_cache = new HashTable<GLib.File, unowned Files.Directory> (GLib.File.hash, GLib.File.equal);
+        directory_cache = new HashTable<unowned GLib.File, Files.Directory?> (GLib.File.hash, GLib.File.equal);
         dir_cache_lock = GLib.Mutex ();
     }
 
@@ -110,6 +110,51 @@ public class Files.Directory : Object {
 
     public bool loaded_from_cache {get; private set; default = false;}
 
+    // New Directories can only be created via these two static methods
+    public static Directory from_gfile (GLib.File file) {
+        /* Ensure uri is correctly escaped and has scheme */
+        var escaped_uri = FileUtils.escape_uri (file.get_uri ());
+        var scheme = Uri.parse_scheme (escaped_uri);
+        if (scheme == null) {
+            scheme = Files.ROOT_FS_URI;
+            escaped_uri = scheme + escaped_uri;
+        }
+
+        var gfile = GLib.File.new_for_uri (escaped_uri);
+        var creation_key = gfile;
+        /* Avoid adding a new Directory that will be a duplicate of an existing one, when called
+         * with non-folder location. */
+        if (gfile.query_exists () && gfile.is_native () && gfile.has_parent (null)) {
+            var ftype = gfile.query_file_type (0, null);
+            if (ftype != FileType.DIRECTORY) {
+                creation_key = gfile.get_parent ();
+            }
+        }
+
+        /* Note: cache_lookup creates directory_cache if necessary */
+        var dir = cache_lookup (creation_key);
+        /* Both local and non-local files can be cached */
+        if (dir == null) {
+            dir = new Directory (creation_key);
+            // Cache immediately to avoid possible creation of duplicates
+            lock (directory_cache) {
+                directory_cache.insert (creation_key, dir);
+            }
+        }
+
+        /* If the original file was not a folder, ensure that it will be
+         * selected in the loaded view*/
+        if (!creation_key.equal (gfile)) {
+            dir.selected_file = file;
+        }
+
+        return dir;
+    }
+
+    public static Directory from_file (Files.File gof) {
+        return from_gfile (gof.get_target_location ());
+    }
+
     private Directory (GLib.File _file) {
         Object (
             creation_key: _file
@@ -151,7 +196,7 @@ public class Files.Directory : Object {
     }
 
     ~Directory () {
-        debug ("Directory destruct %s", file.uri);
+        warning ("Directory destruct %s", file.uri);
 
         if (is_trash) {
             disconnect_volume_monitor_signals ();
@@ -449,18 +494,21 @@ public class Files.Directory : Object {
         }
 
         if (!is_ready) {
-            /* This must only be run once for each Directory */
             is_ready = true;
 
-            /* Do not cache directory until it prepared and loadable to avoid an incorrect key being used in some
-             * in some cases. dir_cache will always have been created via call to public static
-             * functions from_file () or from_gfile (). Do not add toggle until cached. */
-
+            // Do not add toggle until cached
             lock (directory_cache) {
-                this.add_toggle_ref ((ToggleNotify) toggle_ref_notify);
+                // Creation key will normally be the final location but check anyway.
+                if (creation_key != location) {
+                    warning ("creation key differs from final location");
+                    directory_cache.remove (creation_key);
+                }
 
-                if (!creation_key.equal (location) || directory_cache.lookup (location) == null) {
+                if (directory_cache.lookup (location) == null) {
                     directory_cache.insert (location, this);
+                    // Replace the cache reference with a toggle ref
+                    this.add_toggle_ref ((ToggleNotify) toggle_ref_notify);
+                    this.unref ();
                 }
             }
         }
@@ -533,14 +581,13 @@ public class Files.Directory : Object {
 
     private static void toggle_ref_notify (void* data, Object object, bool is_last) {
         if (is_last) {
-            unowned Directory dir = (Directory) object;
-            debug ("Directory is last toggle_ref_notify %s", dir.file.uri);
-
+            var dir = (Directory) object;
+            // Replace the toggle ref with a normal ref before removing from cache
+            dir.ref ();
+            dir.remove_toggle_ref ((ToggleNotify) toggle_ref_notify);
             if (!dir.removed_from_cache) {
                 Directory.remove_dir_from_cache (dir);
             }
-
-            dir.remove_toggle_ref ((ToggleNotify) toggle_ref_notify);
         }
     }
 
@@ -1074,50 +1121,6 @@ public class Files.Directory : Object {
         notify_files_added (list_to);
     }
 
-    public static Directory from_gfile (GLib.File file) {
-        /* Ensure uri is correctly escaped and has scheme */
-        var escaped_uri = FileUtils.escape_uri (file.get_uri ());
-        var scheme = Uri.parse_scheme (escaped_uri);
-        if (scheme == null) {
-            scheme = Files.ROOT_FS_URI;
-            escaped_uri = scheme + escaped_uri;
-        }
-
-        var gfile = GLib.File.new_for_uri (escaped_uri);
-        var afile = gfile;
-        /* Avoid adding a new Directory that will be a duplicate of an existing one, when called
-         * with non-folder location. */
-        if (gfile.query_exists () && gfile.is_native () && gfile.has_parent (null)) {
-            var ftype = gfile.query_file_type (0, null);
-            if (ftype != FileType.DIRECTORY) {
-                afile = gfile.get_parent ();
-            }
-        }
-
-        /* Note: cache_lookup creates directory_cache if necessary */
-        Directory? dir = cache_lookup (afile);
-        /* Both local and non-local files can be cached */
-        if (dir == null) {
-            dir = new Directory (afile);
-            lock (directory_cache) {
-                directory_cache.insert (dir.creation_key, dir);
-            }
-        }
-
-
-        /* If the original file was not a folder, ensure that it will be
-         * selected in the loaded view*/
-        if (!afile.equal (gfile)) {
-            dir.selected_file = file;
-        }
-
-        return dir;
-    }
-
-    public static Directory from_file (Files.File gof) {
-        return from_gfile (gof.get_target_location ());
-    }
-
     private static void remove_file_from_cache (Files.File gof) {
         Directory? dir = cache_lookup (gof.directory);
         if (dir != null) {
@@ -1125,22 +1128,12 @@ public class Files.Directory : Object {
         }
     }
 
-    public static Directory? cache_lookup (GLib.File? file) {
-        Directory? cached_dir = null;
-
+    public static Directory? cache_lookup (GLib.File file) {
         if (directory_cache == null) { // Only happens once on startup.  Directory gets added on creation
             return null;
         }
 
-        if (file == null) {
-            critical ("Null file received in Directory cache_lookup");
-            return null;
-        }
-
-        lock (directory_cache) {
-            cached_dir = directory_cache.lookup (file);
-        }
-
+        var cached_dir = directory_cache.lookup (file);
         if (cached_dir != null) {
             if (cached_dir is Directory && cached_dir.file != null) {
                 debug ("found cached dir %s", cached_dir.file.uri);

--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -579,9 +579,8 @@ public class Files.Directory : Object {
 
     private static void toggle_ref_notify (void* data, Object object, bool is_last) {
         if (is_last) {
-            var dir = (Directory) object;
+            var dir = (Directory) object; // Adds a reference temporarily
             // Replace the toggle ref with a normal ref before removing from cache
-            dir.ref ();
             dir.remove_toggle_ref ((ToggleNotify) toggle_ref_notify);
             if (!dir.removed_from_cache) {
                 Directory.remove_dir_from_cache (dir);

--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -157,7 +157,7 @@ public class Files.File : GLib.Object {
         return null;
     }
 
-    public File (GLib.File location, GLib.File? dir = null) {
+    public File (GLib.File location, GLib.File dir) {
         Object (
             location: location,
             uri: location.get_uri (),

--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -42,10 +42,13 @@ public class Files.File : GLib.Object {
     public signal void destroy ();
 
     public bool is_gone;
+    // The location is guaranteed non-null, but the parent directory may be null
     public GLib.File location { get; construct; }
+    public GLib.File? directory { get; construct; } /* parent directory location */
+
     public GLib.File target_location = null;
     public Files.File target_gof = null;
-    public GLib.File directory { get; construct; } /* parent directory location */
+
     public GLib.Icon? icon = null;
     public GLib.List<string>? emblems_list = null;
     public uint n_emblems = 0;
@@ -157,7 +160,7 @@ public class Files.File : GLib.Object {
         return null;
     }
 
-    public File (GLib.File location, GLib.File dir) {
+    public File (GLib.File location, GLib.File? dir) {
         Object (
             location: location,
             uri: location.get_uri (),

--- a/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
+++ b/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
@@ -36,6 +36,15 @@ void add_gof_directory_async_tests () {
     Test.add_func ("/FilesDirectory/reload_populated_local", () => {
         run_load_folder_test (reload_populated_local_test);
     });
+    Test.add_func ("/FilesDirectory/dir_cache_lookup", () => {
+        run_load_folder_test (dir_cache_lookup_test);
+    });
+    Test.add_func ("/FilesDirectory/dir_cache_lookup2", () => {
+        run_load_folder_test (dir_cache_lookup2_test);
+    });
+    Test.add_func ("/FilesDirectory/empty_cache", () => {
+        empty_cache_test ();
+    });
 }
 
 delegate Directory LoadFolderTest (string path, MainLoop loop);
@@ -176,6 +185,54 @@ Directory reload_populated_local_test (string test_dir_path, MainLoop loop) {
 
             loop.quit ();
         }
+    });
+
+    return dir;
+}
+
+void empty_cache_test () {
+    Files.Directory.empty_dir_cache ();
+    assert (Files.Directory.cache_lookup (GLib.File.new_for_path (Path.DIR_SEPARATOR_S)) == null);
+}
+
+Directory dir_cache_lookup_test (string test_dir_path, MainLoop loop) {
+    // Test cache operations after creating from directory
+    var dir = setup_temp_async (test_dir_path, 50);
+    assert (Files.Directory.cache_lookup (dir.creation_key) != null);
+
+    dir.done_loading.connect (() => {
+        assert (dir.creation_key == dir.location);
+        assert (Files.Directory.cache_lookup (dir.location) != null);
+        Files.Directory.remove_dir_from_cache (dir);
+        assert (Files.Directory.cache_lookup (dir.location) == null);
+        loop.quit ();
+    });
+
+    return dir;
+}
+
+Directory dir_cache_lookup2_test (string test_dir_path, MainLoop loop) {
+    // Test cache operations after creating from regular file, not directory
+    Posix.system ("mkdir " + test_dir_path);
+    /* create empty files */
+    var pth = test_dir_path + Path.DIR_SEPARATOR_S + "test_file";
+    Posix.system ("touch " + pth);
+    GLib.File gfile = GLib.File.new_for_commandline_arg (pth);
+    assert (gfile.query_exists (null));
+
+    Directory dir = Directory.from_gfile (gfile);
+    assert (dir != null);
+    assert (Files.Directory.cache_lookup (dir.creation_key) != null);
+
+    dir.done_loading.connect (() => {
+        // We currently use the parent of regular files as creation key and
+        // this is expected to be the same as the location (to be tested)
+        // Previously the creation key could differ from the location.
+        assert (dir.creation_key == dir.location);
+        assert (Files.Directory.cache_lookup (dir.location) != null);
+        Files.Directory.remove_dir_from_cache (dir);
+        assert (Files.Directory.cache_lookup (dir.location) == null);
+        loop.quit ();
     });
 
     return dir;

--- a/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
+++ b/libcore/tests/GOFDirectoryAsyncTests/GOFDirectoryAsyncTests.vala
@@ -96,7 +96,7 @@ Directory load_populated_local_test (string test_dir_path, MainLoop loop) {
 
     var dir = setup_temp_async (test_dir_path, n_files);
 
-    assert (dir.ref_count == 1); //Extra ref from pending cache;
+    assert (dir.ref_count == 2); //Extra ref from pending cache;
 
     dir.file_loaded.connect (() => {
         file_loaded_signal_count++;


### PR DESCRIPTION
Fix #2148 (hopefully)

 - Directory cache now holds a toggle reference to the Directory 
 - Move Directory creation related methods together at top of file
 - Ensure  directories temporarily cached during creation are removed from cache if necessary
 - Amend test
 - Remove unnecessary null check (cache_lookup should never be called with a null parameter); Amend calling objects to comply
 - Add additional tests for directory_cache operations
 
A separate critical warning during Directory destruction is also fixed.

It was noticed that the `creation_key` property may no longer be required after https://github.com/elementary/files/commit/ef93c748789b0bcdd4b20565dff8e52a56993220.  The creation_key should be the same as the location now as it is always a folder and the location should no longer change during initialisation.

However, it was retained for now in case there is a corner case that needs it.
