### PR TITLE
Fix compile warning from UndoManager.vala

### DIFF
--- a/libcore/UndoManager.vala
+++ b/libcore/UndoManager.vala
@@ -677,7 +677,7 @@ namespace Files {
             }
         }
 
-        public unowned string get_next_redo_description () {
+        public unowned string? get_next_redo_description () {
             var action = get_next_redo_action ();
             if (action != null) {
                 return action.action_type.to_redo_string ();

--- a/src/View/Widgets/HeaderBar.vala
+++ b/src/View/Widgets/HeaderBar.vala
@@ -285,7 +285,7 @@ public class Files.View.Chrome.HeaderBar : Hdy.HeaderBar {
 
         redo_button.tooltip_markup = Granite.markup_accel_tooltip (
             redo_accels,
-            redo_action_s != "" ?
+            redo_action_s != null ?
             redo_action_s :
             _("No operation to redo")
         );


### PR DESCRIPTION
`get_next_redo_description ()` was returning null contrary to its signature.  This PR fixes that.