### PR TITLE
Fix filechooser portal compile warnings

### DIFF
--- a/filechooser-portal/ExternalWindow.vala
+++ b/filechooser-portal/ExternalWindow.vala
@@ -78,7 +78,7 @@ public class ExternalWindowX11 : ExternalWindow, GLib.Object {
 
         Gdk.set_allowed_backends ("x11");
         x11_display = Gdk.Display.open (null);
-        Gdk.set_allowed_backends (null);
+        Gdk.set_allowed_backends ("*");
 
         if (x11_display == null) {
             warning ("Failed to open X11 display");
@@ -113,7 +113,7 @@ public class ExternalWindowWayland : ExternalWindow, GLib.Object {
 
         Gdk.set_allowed_backends ("wayland");
         wayland_display = Gdk.Display.open (null);
-        Gdk.set_allowed_backends (null);
+        Gdk.set_allowed_backends ("*");
 
         if (wayland_display == null) {
             warning ("Failed to open Wayland display");

--- a/filechooser-portal/Main.vala
+++ b/filechooser-portal/Main.vala
@@ -511,7 +511,7 @@ public class Files.FileChooserPortal : Object {
 
         var loop = new MainLoop (null, false);
         try {
-            var session_bus = Bus.get_sync (BusType.SESSION);
+            Bus.get_sync (BusType.SESSION);
             var owner_id = Bus.own_name (
                 BusType.SESSION,
                 "org.freedesktop.impl.portal.desktop.elementary.files",


### PR DESCRIPTION
Silence some compiler criticals coming from the filechooser portal.

 - [x] Lose an unused var
 - [x] Do not set Gdk.allowed_backends to null contrary to its (Vala) signature.  Gdk source code indicates that when allowed_backends is null, then "*" will be used.
 - [ ] Do not use null as parameter to Gdk.Display.open_display contrary to its (Gtk3) signature.  NOTE: In Gtk4, the signature allows a null.  It is not clear what should be used instead of null in Gtk3 - I could not determine what will be returned with a null parameter.  