### PR TITLE
Ensure overlay appears after rubberband selection in ListView

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3644,7 +3644,6 @@ namespace Files {
             uint button;
             event.get_coords (out x, out y);
             event.get_button (out button);
-            update_selected_files_and_menu ();
             /* Only take action if pointer has not moved */
             if (!Gtk.drag_check_threshold (get_child (), (int)drag_x, (int)drag_y, (int)x, (int)y)) {
                 if (should_activate) {
@@ -3656,22 +3655,19 @@ namespace Files {
                     });
                 } else if (should_deselect && click_path != null) {
                     unselect_path (click_path);
-                    /* Only need to update selected files if changed by this handler */
-                    Idle.add (() => {
-                        update_selected_files_and_menu ();
-                        return GLib.Source.REMOVE;
-                    });
                 } else if (should_select && click_path != null) {
                     select_path (click_path);
-                    /* Only need to update selected files if changed by this handler */
-                    Idle.add (() => {
-                        update_selected_files_and_menu ();
-                        return GLib.Source.REMOVE;
-                    });
                 } else if (button == Gdk.BUTTON_SECONDARY) {
                     show_context_menu (event);
                 }
             }
+
+            // Selection may have been changed *but not signalled* by rubberbanding
+            // in Gtk.TreeView (IconView does signal during rubberbanding)
+            Idle.add (() => {
+                update_selected_files_and_menu ();
+                return GLib.Source.REMOVE;
+            });
 
             should_activate = false;
             should_deselect = false;


### PR DESCRIPTION
Fixes #2151 
Fixes #2152 

This issue was caused by a subtle difference in Gtk.TreeView and Gtk.IconView.  The former does *not* signal selection changes caused by pointer movement during rubberbanding whereas the latter does.  So if the rubberband starts outside the list the selection change never gets signalled.

So we have to ensure AbstractDirectoryView updates and signals the selection change in the button release handler.