### PR TITLE
Improve speed of loading and display of large  folders

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -637,11 +637,13 @@ namespace Files {
         }
 
         protected void connect_directory_loading_handlers (Directory dir) {
+            model.prepare_to_load ();
             dir.file_loaded.connect (on_directory_file_loaded);
             dir.done_loading.connect (on_directory_done_loading);
         }
 
         protected void disconnect_directory_loading_handlers (Directory dir) {
+            model.after_loading ();
             dir.file_loaded.disconnect (on_directory_file_loaded);
             dir.done_loading.disconnect (on_directory_done_loading);
         }
@@ -1408,7 +1410,11 @@ namespace Files {
                 is_writable = false;
             }
 
-            thaw_tree ();
+            Idle.add (() => {
+                thaw_tree ();
+                return Source.REMOVE;
+            });
+
 
             schedule_thumbnail_color_tag_timeout ();
         }
@@ -1468,7 +1474,7 @@ namespace Files {
 
         private void directory_hidden_changed (Directory dir, bool show) {
             /* May not be slot.directory - could be subdirectory */
-            dir.file_loaded.connect (on_directory_file_loaded); /* disconnected by on_done_loading callback.*/
+            connect_directory_loading_handlers (dir);
             dir.load_hiddens ();
         }
 

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -349,8 +349,10 @@ namespace Files {
         /* These two functions accelerate the loading of Views especially for large folders
          * Views are not displayed until fully loaded */
         protected override void freeze_tree () {
-            tree.freeze_child_notify ();
-            tree_frozen = true;
+            if (!tree_frozen) {
+                tree.freeze_child_notify ();
+                tree_frozen = true;
+            }
         }
 
         protected override void thaw_tree () {
@@ -360,12 +362,17 @@ namespace Files {
             }
         }
 
+        // For scrolling
         protected override void freeze_child_notify () {
             tree.freeze_child_notify ();
         }
 
         protected override void thaw_child_notify () {
-            tree.thaw_child_notify ();
+            // Do not prematurely thaw tree when loading
+            if (!tree_frozen) {
+                tree.thaw_child_notify ();
+            }
+
         }
     }
 

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -392,12 +392,16 @@ namespace Files {
             }
         }
 
+        // For scrolling
         protected override void freeze_child_notify () {
             tree.freeze_child_notify ();
         }
 
         protected override void thaw_child_notify () {
-            tree.thaw_child_notify ();
+            //Do not prematurely thaw tree while loading
+            if (!tree_frozen) {
+                tree.thaw_child_notify ();
+            }
         }
 
         protected void linear_select_path (Gtk.TreePath path) {


### PR DESCRIPTION
Fixes #2172 

* Keep map of row references
* Do not sort while loading

Time to load a folder containing 20,000 empty files, sort on filename, and unfreeze interface:
MASTER: 260 seconds
PR: approx 2 seconds

