### PR TITLE
Fix duplicate files and other recent regressions

### DIFF
--- a/libcore/ListModel.vala
+++ b/libcore/ListModel.vala
@@ -410,6 +410,11 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
         return false;
     }
 
+    public new void clear () {
+        file_treerow_map.clear ();
+        base.clear ();
+    }
+
     private int file_entry_compare_func (Gtk.TreeIter a, Gtk.TreeIter b) {
         Files.File? file_a = null;
         Files.File? file_b = null;

--- a/libcore/ListModel.vala
+++ b/libcore/ListModel.vala
@@ -321,17 +321,12 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
             // Faster than checking for duplicates
             set_sorting_off ();
             if (iter_children (out child_iter, parent_iter)) {
-                get (child_iter, ColumnID.FILE_COLUMN, out child_file);
-                if (child_file != null) {
-                    file_treerow_map.unset (child_file.uri);
-                }
-
-                while (remove (ref child_iter)) {
+                do {
                     get (child_iter, ColumnID.FILE_COLUMN, out child_file);
                     if (child_file != null) {
                         file_treerow_map.unset (child_file.uri);
                     }
-                };
+                } while (remove (ref child_iter));
             }
 
             // Insert dummy;

--- a/libcore/ListModel.vala
+++ b/libcore/ListModel.vala
@@ -88,26 +88,22 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
             typeof (bool)
         });
 
-        // We do not want a default sort order - one of the visible columns must always be sorted
-        for (int i = 0; i < ColumnID.NUM_COLUMNS; i++) {
-            set_sort_func (i, (Gtk.TreeIterCompareFunc) file_entry_compare_func);
-        }
-
         set_sort_column_id (
             ColumnID.FILENAME,
             Gtk.SortType.ASCENDING
         );
+        set_sorting_off ();
     }
 
     // Turn off sorting while files are being added
-    public void prepare_to_load () {
+    public void set_sorting_off () {
         for (int i = 0; i < ColumnID.NUM_COLUMNS; i++) {
             set_sort_func (i, () => {return 0;});
         }
     }
 
     // Turn on sorting after model stops loading.
-    public void after_loading () {
+    public void set_sorting_on () {
         for (int i = 0; i < ColumnID.NUM_COLUMNS; i++) {
             set_sort_func (i, (Gtk.TreeIterCompareFunc) file_entry_compare_func);
         }
@@ -286,6 +282,7 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
                 return;
             }
 
+            set_sorting_off ();
             foreach (var file in files) {
                 if (!show_hidden_files && file.is_hidden) {
                     continue;
@@ -307,6 +304,8 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
                     insert_with_values (out child_iter, child_iter, -1, PrivColumnID.DUMMY, true);
                 }
             }
+
+            set_sorting_on ();
         }
     }
 
@@ -320,6 +319,7 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
             Files.File child_file;
             // Remove all child nodes so they are refreshed if subdirectory reloaded
             // Faster than checking for duplicates
+            set_sorting_off ();
             if (iter_children (out child_iter, parent_iter)) {
                 get (child_iter, ColumnID.FILE_COLUMN, out child_file);
                 if (child_file != null) {
@@ -337,6 +337,7 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
             // Insert dummy;
             insert_with_values (out child_iter, parent_iter, -1, PrivColumnID.DUMMY, true);
             subdirectory_unloaded (dir);
+            set_sorting_on ();
             return true;
         }
 

--- a/libcore/ListModel.vala
+++ b/libcore/ListModel.vala
@@ -316,7 +316,7 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
             var dir = Files.Directory.from_file (file);
             dir.cancel ();
             Gtk.TreeIter? child_iter = null;
-            Files.File child_file;
+            Files.File? child_file = null;
             // Remove all child nodes so they are refreshed if subdirectory reloaded
             // Faster than checking for duplicates
             set_sorting_off ();

--- a/libcore/ListModel.vala
+++ b/libcore/ListModel.vala
@@ -357,6 +357,7 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
         if (!change_dummy) {
             // There was no dummy row to replace so create a new entry for this file
             insert_with_values (out file_iter, parent_iter, 0, ColumnID.FILE_COLUMN, file, PrivColumnID.DUMMY, false);
+            file_treerow_map.@set (file.uri, new Gtk.TreeRowReference (this, get_path (file_iter)));
         }
 
         if (file.is_folder ()) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -637,13 +637,13 @@ namespace Files {
         }
 
         protected void connect_directory_loading_handlers (Directory dir) {
-            model.prepare_to_load ();
+            model.set_sorting_off ();
             dir.file_loaded.connect (on_directory_file_loaded);
             dir.done_loading.connect (on_directory_done_loading);
         }
 
         protected void disconnect_directory_loading_handlers (Directory dir) {
-            model.after_loading ();
+            model.set_sorting_on ();
             dir.file_loaded.disconnect (on_directory_file_loaded);
             dir.done_loading.disconnect (on_directory_done_loading);
         }


### PR DESCRIPTION
Fixes #2190
Fixes #2189 
Fixes #2188 

This PR "completes" the faulty commit responsible.  The file-rowreference map was not being updated in all relevant places .

The map must be updated whenever a file is added or removed from the model, not just on loading.

NOTE: This PR and the previous one only speed up construction/destruction of the model.  The most dramatic speed increase is seen when the Directory is cached and does not have to be reloaded from disk.  Loading/sorting a large directory for the first time can still take several seconds (exponent >1 and <2) and there is a noticeable lag when navigating away.

On a modestly powered machine folders containing several thousand item are acceptably responsive, but tens of thousand items still result in significant delays (with no user feedback).  

The GTK4 port is already much faster so probably not worth spending too much time improving the Gtk3 version?

