### PR TITLE
Update freespace when device list box entered

### DIFF
--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -326,6 +326,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
     }
 
     public virtual void update_free_space () {
+        debug ("update free space");
         add_mountable_tooltip.begin ();
     }
 

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -50,6 +50,10 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
         });
 
         set_sort_func (device_sort_func);
+
+        this.enter_notify_event.connect (() => {
+            refresh_info ();
+        });
     }
 
     private int device_sort_func (Gtk.ListBoxRow? row1, Gtk.ListBoxRow? row2) {


### PR DESCRIPTION
Closes #2035 

Rather than polling the filesystem and in the absence of a signal emitted when a tooltip is shown, the freespace is updated when the pointer enters the device list box so that the tooltip will be accurate if an external file operation takes place that is not reflected in any of the open views.