### PR TITLE
Avoid short-lived temporary files appearing in view

### DIFF
--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -326,6 +326,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
     }
 
     public virtual void update_free_space () {
+        debug ("update free space");
         add_mountable_tooltip.begin ();
     }
 

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -50,6 +50,10 @@ public class Sidebar.DeviceListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
         });
 
         set_sort_func (device_sort_func);
+
+        this.enter_notify_event.connect (() => {
+            refresh_info ();
+        });
     }
 
     private int device_sort_func (Gtk.ListBoxRow? row1, Gtk.ListBoxRow? row2) {


### PR DESCRIPTION
Fixes #2216 

The issue is caused by adding a file to the model occurring asynchronously after query the fileinfo whereas files are removed immediately.  This causes very short-lived files being deleted before they are created.

This PR fixes the problem by adding the file to the model before querying the file info.  In order to do this it is necessary to use the fallback method of determining whether the file is hidden but this should make little practical difference.


