### PR TITLE
Prep gtk4 1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,6 @@
-Copyright (c) 2015-2018 elementary LLC <https://elementary.io>
+ * Copyright 2015 - 2023 elementary, Inc. <https://elementary.io>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+
 
 ammonkey <am.monkeyd@gmail.com>
 Mathijs Henquet <mathijs.henquet@gmail.com>
@@ -7,3 +9,4 @@ Vadim Rutkovsky
 Rico Tzschichholz
 Mario Guerriero <mario@elementaryos.org>
 Jeremy Wootten <jeremy@elementaryos.org>
+John Sullivan <sullivan@eazel.com>

--- a/libcore/Bookmark.vala
+++ b/libcore/Bookmark.vala
@@ -1,32 +1,17 @@
 /***
-    Copyright (c)  1999, 2000 Eazel, Inc.
-                   2015-2018 elementary LLC <https://elementary.io>
-
-    This program is free software: you can redistribute it and/or modify it
-    under the terms of the GNU Lesser General Public License version 3, as published
-    by the Free Software Foundation, Inc.,.
-
-    This program is distributed in the hope that it will be useful, but
-    WITHOUT ANY WARRANTY; without even the implied warranties of
-    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
-    PURPOSE. See the GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program. If not, see <http://www.gnu.org/licenses/>.
-
-    Authors : John Sullivan <sullivan@eazel.com>
-              Jeremy Wootten <jeremy@elementaryos.org>
+ * Copyright (c)  1999, 2000 Eazel, Inc.
+ * Copyright 2015 - 2023 elementary, Inc. <https://elementary.io>
+ * SPDX-License-Identifier: GPL-3.0-or-later
 ***/
 
 namespace Files {
-    public class Bookmark {
-
+    public class Bookmark : Object {
         public signal void contents_changed ();
         public signal void deleted ();
 
         public string custom_name { get; set; default = "";}
 
-        public Files.File gof_file { get; private set; }
+        public Files.File gof_file { get; construct; }
 
         public string basename {
             get { return gof_file.get_display_name (); }
@@ -46,20 +31,22 @@ namespace Files {
         };
 
         public Bookmark (Files.File gof_file, string label = "") {
-            this.gof_file = gof_file;
-            if (label != gof_file.basename) {
-                this.custom_name = label;
-            }
-
-            connect_file ();
+            Object (
+                gof_file: gof_file,
+                custom_name: label
+            );
         }
 
         public Bookmark.from_uri (string uri, string label = "") {
-            this.gof_file = Files.File.get_by_uri (uri);
-            if (label != gof_file.basename) {
-                this.custom_name = label;
-            }
+            Object (
+                gof_file: Files.File.get_by_uri (uri),
+                custom_name: label
+            );
+        }
 
+        construct {
+            //Ensure correct icon is available
+            gof_file.ensure_query_info ();
             connect_file ();
         }
 
@@ -76,8 +63,8 @@ namespace Files {
         }
 
         public GLib.Icon get_icon () {
-            if (gof_file.icon != null) {
-                return gof_file.icon;
+            if (gof_file.gicon != null) {
+                return gof_file.gicon;
             } else {
                 // Get minimal info to determine icon
                 var ftype = gof_file.location.query_file_type (FileQueryInfoFlags.NONE);

--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -49,7 +49,7 @@ public class Files.File : GLib.Object {
     public GLib.File target_location = null;
     public Files.File target_gof = null;
 
-    public GLib.Icon? icon = null;
+    public GLib.Icon? gicon = null;
     public GLib.List<string>? emblems_list = null;
     public uint n_emblems = 0;
     public GLib.FileInfo? info = null;
@@ -386,58 +386,55 @@ public class Files.File : GLib.Object {
     public Gdk.Pixbuf? get_icon_pixbuf (int size, int scale, Files.File.IconFlags flags) {
         GLib.return_val_if_fail (size >= 1, null);
 
-        var nicon = get_icon (size, scale, flags);
-        return nicon != null ? nicon.get_pixbuf_nodefault () : null;
+        var icon_info = get_icon_info (size, scale, flags);
+        return icon_info != null ? icon_info.get_pixbuf_nodefault () : null;
     }
 
     public void get_folder_icon_from_uri_or_path () {
-        if (icon != null) {
+        if (gicon != null) {
             return;
         }
 
         if (!is_hidden && uri != null) {
             try {
                 var path = GLib.Filename.from_uri (uri);
-                icon = get_icon_user_special_dirs (path);
+                gicon = get_icon_user_special_dirs (path);
             } catch (Error e) {
                 debug (e.message);
             }
         }
 
-        if (icon == null && !location.is_native () && is_remote_uri_scheme ()) {
-            icon = new GLib.ThemedIcon ("folder-remote");
+        if (gicon == null && !location.is_native () && is_remote_uri_scheme ()) {
+            gicon = new GLib.ThemedIcon ("folder-remote");
         }
 
-        if (icon == null) {
-            icon = new GLib.ThemedIcon ("folder");
+        if (gicon == null) {
+            gicon = new GLib.ThemedIcon ("folder");
         }
     }
 
-    public Files.IconInfo? get_icon (int size, int scale, Files.File.IconFlags flags) {
+    private Files.IconInfo? get_icon_info (int size, int scale, Files.File.IconFlags flags) {
         GLib.return_val_if_fail (size >= 1, null);
 
-        Files.IconInfo? icon = get_special_icon (size, scale, flags);
-        if (icon != null && !icon.is_fallback ()) {
-            return icon;
+        Files.IconInfo? icon_info = get_special_icon_info (size, scale, flags);
+        if (icon_info != null && !icon_info.is_fallback ()) {
+            return icon_info;
         }
 
-        GLib.Icon? gicon = null;
         if (Files.File.IconFlags.USE_THUMBNAILS in flags && this.thumbstate == Files.File.ThumbState.LOADING) {
             gicon = new GLib.ThemedIcon ("image-loading");
-        } else {
-            gicon = this.icon;
         }
 
         if (gicon != null) {
-            icon = Files.IconInfo.lookup (gicon, size, scale);
-            if (icon == null || icon.is_fallback ()) {
-                icon = Files.IconInfo.get_generic_icon (size, scale);
+            icon_info = Files.IconInfo.lookup (gicon, size, scale);
+            if (icon_info == null || icon_info.is_fallback ()) {
+                icon_info = Files.IconInfo.get_generic_icon (size, scale);
             }
         } else {
-            icon = Files.IconInfo.get_generic_icon (size, scale);
+            icon_info = Files.IconInfo.get_generic_icon (size, scale);
         }
 
-        return icon;
+        return icon_info;
     }
 
     public void update () {
@@ -469,7 +466,7 @@ public class Files.File : GLib.Object {
         }
 
         if (info.has_attribute (GLib.FileAttribute.STANDARD_ICON)) {
-            icon = info.get_attribute_object (GLib.FileAttribute.STANDARD_ICON) as GLib.Icon;
+            gicon = info.get_attribute_object (GLib.FileAttribute.STANDARD_ICON) as GLib.Icon;
         }
 
         /* Any location or target on a mount will now have the file->mount and file->is_mounted set */
@@ -550,15 +547,15 @@ public class Files.File : GLib.Object {
             formated_modified = _("Inaccessible");
         }
 
-        /* icon */
+        /* gicon */
         if (is_directory) {
             get_folder_icon_from_uri_or_path ();
         } else if (info.get_file_type () == GLib.FileType.MOUNTABLE) {
-            icon = new GLib.ThemedIcon.with_default_fallbacks ("folder-remote");
+            gicon = new GLib.ThemedIcon.with_default_fallbacks ("folder-remote");
         } else {
             unowned string? ftype = get_ftype ();
-            if (ftype != null && icon == null) {
-                icon = GLib.ContentType.get_icon (ftype);
+            if (ftype != null && gicon == null) {
+                gicon = GLib.ContentType.get_icon (ftype);
             }
         }
 
@@ -611,7 +608,7 @@ public class Files.File : GLib.Object {
 
         unowned string? ftype = get_ftype ();
         if (ftype != null) {
-            icon = GLib.ContentType.get_icon (ftype);
+            gicon = GLib.ContentType.get_icon (ftype);
         }
 
         if (pix_size > 1 && pix_scale > 0) {
@@ -1055,7 +1052,7 @@ public class Files.File : GLib.Object {
         formated_type = null;
         format_size = null;
         formated_modified = null;
-        icon = null;
+        gicon = null;
         custom_display_name = null;
         custom_icon_name = null;
 
@@ -1295,7 +1292,7 @@ public class Files.File : GLib.Object {
         pix_scale = scale;
     }
 
-    private Files.IconInfo? get_special_icon (int size, int scale, Files.File.IconFlags flags) {
+    private Files.IconInfo? get_special_icon_info (int size, int scale, Files.File.IconFlags flags) {
         GLib.return_val_if_fail (size >= 1, null);
 
         if (custom_icon_name != null) {

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,8 @@ plugin_dir = join_paths(get_option('prefix'), get_option('libdir'), meson.projec
 add_project_arguments(
     ['-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
     '-DHANDY_USE_UNSTABLE_API',
+    '-DGDK_DISABLE_DEPRECATED',
+    '-DGTK_DISABLE_DEPRECATED',
     '-w'],
     language:'c'
 )
@@ -45,7 +47,7 @@ gio_dep = dependency('gio-2.0', version: '>='+min_glib_version)
 gio_unix_dep = dependency('gio-unix-2.0', version: '>='+min_glib_version)
 gmodule_dep = dependency('gmodule-2.0', version: '>='+min_glib_version)
 gee_dep = dependency('gee-0.8')
-gtk_dep = dependency('gtk+-3.0', version: '>=3.22.25')
+gtk_dep = dependency('gtk+-3.0', version: '>=3.24')
 granite_dep = dependency('granite', version: '>=6.1.0')
 handy_dep = dependency('libhandy-1', version: '>=0.83.0')
 

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -119,7 +119,7 @@ namespace Files {
             bool is_drop_file = (file == drop_file);
 
             if (file.is_directory) {
-                var names = ((GLib.ThemedIcon) file.icon).get_names ();
+                var names = ((GLib.ThemedIcon) file.gicon).get_names ();
                 if (names.length > 0) {
                     special_icon_name = names[0];
                 } else {


### PR DESCRIPTION
Part one of a series of PRs backporting some changes which #2082 made to the non-Gtk parts of Files.

 * Disable deprecations, ensure runs on Gtk 3.24 (as per migration guide)
 * Backport Bookmark.vala and make consequential changes to File.vala and IconRenderer.vala
 * Update some copyright formats
 * Move historic author into AUTHORS

This should no impact on function.