### PR TITLE
Fix regression adding folder to view (shows children until refreshed)

### DIFF
--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -1074,19 +1074,20 @@ public class Files.Directory : Object {
         bool already_present = false;
         bool files_added = false;
         Directory? first_dir = cache_lookup_parent (changes.data.from);
-        GLib.File? prev_loc = null;
         if (first_dir != null) {
             foreach (unowned var change in changes) {
-                unowned var loc = change.from;
-                // Each set or changes should refer to the same folder but check anyway
-                if (prev_loc == null || !loc.equal (prev_loc)) {
-                    Files.File gof = first_dir.file_cache_find_or_insert (loc, out already_present, true);
+                // `change.from`` holds the location of the newly created file, not where it came from
+                var dir = cache_lookup_parent (change.from);
+                // Children of newly created folder must have null parent Files.Directory
+                // We expect each set of changes to refer to the same Directory
+                if (dir != null && dir == first_dir) {
+                    Files.File gof = first_dir.file_cache_find_or_insert (change.from, out already_present, true);
                     if (!already_present) {
                         files_added = true;
                         first_dir.notify_file_added (gof, change.is_internal);
                     } // Else ignore files already added from duplicate event or internally
-
-                    prev_loc = loc;
+                } else {
+                    critical ("Unexpected parent of newly created file");
                 }
             }
 


### PR DESCRIPTION
Fixes #2238 

Fixes a regression caused by commit https://github.com/elementary/files/commit/c0a70d796e7fb9f6523eef64205c3a1d7fade8ef

This does have any implications for the Gtk4 port

