### PR TITLE
VolumePropertiesWindow: minor Gtk4 prep

### DIFF
--- a/src/Dialogs/VolumePropertiesWindow.vala
+++ b/src/Dialogs/VolumePropertiesWindow.vala
@@ -20,9 +20,7 @@
 * Authored by: ammonkey <am.monkeyd@gmail.com>
 */
 
-namespace Files.View {
-
-public class VolumePropertiesWindow : AbstractPropertiesDialog {
+public class Files.View.VolumePropertiesWindow : AbstractPropertiesDialog {
 
     public VolumePropertiesWindow (GLib.Mount? mount, Gtk.Window parent) {
         base (_("Disk Properties"), parent);
@@ -54,8 +52,9 @@ public class VolumePropertiesWindow : AbstractPropertiesDialog {
         }
 
         /* Build the header box */
-        var file_icon = new Gtk.Image ();
-        file_icon.set_from_gicon (mount_icon, Gtk.IconSize.DIALOG);
+        var file_icon = new Gtk.Image.from_gicon (mount_icon, Gtk.IconSize.DIALOG) {
+            pixel_size = 48
+        };
 
         if (file_icon != null) {
             var emblems_list = new GLib.List<string> ();
@@ -99,5 +98,4 @@ public class VolumePropertiesWindow : AbstractPropertiesDialog {
         create_storage_bar (info, 3);
         show_all ();
     }
-}
 }


### PR DESCRIPTION
Tiniest cherry from #2225. Then we only have to remove the `Gtk.IconSize.Dialog`