### PR TITLE
AbstractPropertiesDialog: Gtk4 prep

### DIFF
--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -20,9 +20,7 @@
 * Authored by: ammonkey <am.monkeyd@gmail.com>
 */
 
-namespace Files.View {
-
-public class PropertiesWindow : AbstractPropertiesDialog {
+public class Files.View.PropertiesWindow : AbstractPropertiesDialog {
     private Gtk.Entry perm_code;
     private bool perm_code_should_update = true;
     private Gtk.Label l_perm;
@@ -199,15 +197,9 @@ public class PropertiesWindow : AbstractPropertiesDialog {
 
         /* Build header box */
         if (!only_one ) {
-            var label = new Gtk.Label (get_selected_label (selected_folders, selected_files));
-            label.halign = Gtk.Align.START;
-            header_title = label;
+            header_title = new Gtk.Label (get_selected_label (selected_folders, selected_files));
         } else if (!goffile.is_writable ()) {
-            var label = new Gtk.Label (goffile.info.get_name ()) {
-                halign = Gtk.Align.START,
-                selectable = true
-            };
-            header_title = label;
+            header_title = new Gtk.Label (goffile.info.get_name ());
         } else {
             entry = new Gtk.Entry ();
             original_name = goffile.info.get_name ();
@@ -242,7 +234,15 @@ public class PropertiesWindow : AbstractPropertiesDialog {
             perm_grid.add (new Gtk.Label (_("Unable to determine file ownership and permissions")));
         }
 
-        add_section (stack, _("Permissions"), PanelType.PERMISSIONS.to_string (), perm_grid);
+        stack.add_titled (perm_grid, PanelType.PERMISSIONS.to_string (), _("Permissions"));
+
+        var stack_switcher = new Gtk.StackSwitcher () {
+            homogeneous = true,
+            margin_top = 12,
+            stack = stack
+        };
+
+        layout.attach (stack_switcher, 0, 1, 2);
         show_all ();
     }
 
@@ -1305,5 +1305,4 @@ public class PropertiesWindow : AbstractPropertiesDialog {
             contains_value.show ();
         }
     }
-}
 }

--- a/src/Dialogs/VolumePropertiesWindow.vala
+++ b/src/Dialogs/VolumePropertiesWindow.vala
@@ -20,10 +20,7 @@
 * Authored by: ammonkey <am.monkeyd@gmail.com>
 */
 
-namespace Files.View {
-
-public class VolumePropertiesWindow : AbstractPropertiesDialog {
-
+public class Files.View.VolumePropertiesWindow : AbstractPropertiesDialog {
     public VolumePropertiesWindow (GLib.Mount? mount, Gtk.Window parent) {
         base (_("Disk Properties"), parent);
 
@@ -71,9 +68,7 @@ public class VolumePropertiesWindow : AbstractPropertiesDialog {
             overlay_emblems (file_icon, emblems_list);
         }
 
-        header_title = new Gtk.Label (mount_name) {
-            halign = Gtk.Align.START
-        };
+        header_title = new Gtk.Label (mount_name);
 
         create_header_title ();
 
@@ -99,5 +94,4 @@ public class VolumePropertiesWindow : AbstractPropertiesDialog {
         create_storage_bar (info, 3);
         show_all ();
     }
-}
 }


### PR DESCRIPTION
* Granite dialog takes care of `deletable` already
* Doesn't seem to be a good reason not to allow resizing
* `window_position` doesn't exist in Gtk4
* `stack_switcher` is only used in PropertiesWindow so it saves us some abstraction and makes things easier to just create it there. We don't have to worry about hiding and showing etc
* Explicit margins
* Remove unnecessary cast of `get_content_area`
* DRY properties of `header_title` when it's a label
* Simplify emblem overlay and use a box
* inline namespaces while I'm here