### PR TITLE
Window: don't get position

### DIFF
--- a/data/schemas/io.elementary.files.gschema.xml
+++ b/data/schemas/io.elementary.files.gschema.xml
@@ -81,11 +81,6 @@
       <summary>Categorie Network expander</summary>
       <description>Expand/Collapse categorie Network</description>
     </key>
-    <key name="window-position" type="(ii)">
-      <default>(-1, -1)</default>
-      <summary>Window position</summary>
-      <description>Most recent window position (x, y)</description>
-    </key>
     <key name="window-size" type="(ii)">
       <default>(1000, 680)</default>
       <summary>Most recent window size</summary>

--- a/libcore/Enums.vala
+++ b/libcore/Enums.vala
@@ -21,8 +21,6 @@
 namespace Files {
     public enum WindowState {
         NORMAL,
-        TILED_START,
-        TILED_END,
         MAXIMIZED,
         INVALID;
 
@@ -30,10 +28,6 @@ namespace Files {
             switch (this) {
                 case NORMAL:
                     return "Marlin.WindowState.NORMAL";
-                case TILED_START:
-                    return "Marlin.WindowState.TILED_START";
-                case TILED_END:
-                    return "Marlin.WindowState.TILED_END";
                 case MAXIMIZED:
                     return "Marlin.WindowState.MAXIMIZED";
                 default:
@@ -41,22 +35,12 @@ namespace Files {
             }
         }
 
-        public static Files.WindowState from_gdk_window_state (Gdk.WindowState state, bool start = true) {
+        public static Files.WindowState from_gdk_window_state (Gdk.WindowState state) {
             if (Gdk.WindowState.MAXIMIZED in state || Gdk.WindowState.FULLSCREEN in state) {
                 return Files.WindowState.MAXIMIZED;
-            } else if (Gdk.WindowState.TILED in state) {
-                return start ? Files.WindowState.TILED_START : Files.WindowState.TILED_END;
             } else {
                 return Files.WindowState.NORMAL;
             }
-        }
-
-        public bool is_tiled () {
-            return this == TILED_START | this == TILED_END;
-        }
-
-        public bool is_maximized () {
-            return this == MAXIMIZED;
         }
     }
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -149,20 +149,8 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                                        "position", SettingsBindFlags.DEFAULT);
 
             var state = (Files.WindowState)(Files.app_settings.get_enum ("window-state"));
-
-            switch (state) {
-                case Files.WindowState.MAXIMIZED:
-                    maximize ();
-                    break;
-                default:
-                    int default_x, default_y;
-                    Files.app_settings.get ("window-position", "(ii)", out default_x, out default_y);
-
-                    if (default_x != -1 && default_y != -1) {
-                        move (default_x, default_y);
-                    }
-
-                    break;
+            if (state == Files.WindowState.MAXIMIZED) {
+                maximize ();
             }
         }
 
@@ -1002,22 +990,23 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         sidebar_width = int.max (sidebar_width, min_width);
         Files.app_settings.set_int ("sidebar-width", sidebar_width);
 
-        int width, height, x, y;
+        int width, height;
 
         // Includes shadow for normal windows (but not maximized or tiled)
         get_size (out width, out height);
-        get_position (out x, out y);
 
-        var gdk_state = get_window ().get_state ();
-        // If window is tiled, is it on left (start = true) or right (start = false)?
-        var rect = get_display ().get_monitor_at_point (x, y).get_geometry ();
-        var start = x + width < rect.width;
-
-        Files.app_settings.set_enum ("window-state",
-                                       Files.WindowState.from_gdk_window_state (gdk_state, start));
+        // TODO: replace with Gtk.Window.fullscreened in Gtk4
+        if (is_maximized || Gdk.WindowState.FULLSCREEN in get_window ().get_state ()) {
+            Files.app_settings.set_enum (
+                "window-state", Files.WindowState.MAXIMIZED
+            );
+        } else {
+            Files.app_settings.set_enum (
+                "window-state", Files.WindowState.NORMAL
+            );
+        }
 
         Files.app_settings.set ("window-size", "(ii)", width, height);
-        Files.app_settings.set ("window-position", "(ii)", x, y);
     }
 
     private void save_tabs () {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -990,8 +990,9 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         sidebar_width = int.max (sidebar_width, min_width);
         Files.app_settings.set_int ("sidebar-width", sidebar_width);
 
+        var state = get_window ().get_state ();
         // TODO: replace with Gtk.Window.fullscreened in Gtk4
-        if (is_maximized || Gdk.WindowState.FULLSCREEN in get_window ().get_state ()) {
+        if (is_maximized || Gdk.WindowState.FULLSCREEN in state) {
             Files.app_settings.set_enum (
                 "window-state", Files.WindowState.MAXIMIZED
             );
@@ -1000,7 +1001,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                 "window-state", Files.WindowState.NORMAL
             );
 
-            if (!(get_style_context ().has_class ("tiled"))) {
+            if (!(Gdk.WindowState.TILED in state)) {
                 int width, height;
                 // Includes shadow for normal windows (but not maximized or tiled)
                 get_size (out width, out height);

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -990,11 +990,6 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         sidebar_width = int.max (sidebar_width, min_width);
         Files.app_settings.set_int ("sidebar-width", sidebar_width);
 
-        int width, height;
-
-        // Includes shadow for normal windows (but not maximized or tiled)
-        get_size (out width, out height);
-
         // TODO: replace with Gtk.Window.fullscreened in Gtk4
         if (is_maximized || Gdk.WindowState.FULLSCREEN in get_window ().get_state ()) {
             Files.app_settings.set_enum (
@@ -1004,9 +999,14 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             Files.app_settings.set_enum (
                 "window-state", Files.WindowState.NORMAL
             );
-        }
 
-        Files.app_settings.set ("window-size", "(ii)", width, height);
+            if (!(get_style_context ().has_class ("tiled"))) {
+                int width, height;
+                // Includes shadow for normal windows (but not maximized or tiled)
+                get_size (out width, out height);
+                Files.app_settings.set ("window-size", "(ii)", width, height);
+            }
+        }
     }
 
     private void save_tabs () {


### PR DESCRIPTION
We're not able to get window position in Gtk4. It also doesn't appear we do anything with tiling information anyways, so remove all the unused stuff.

Get maximized state from Gtk.Window and make a note about get fullscreen state here in the future as well