### PR TITLE
Window: only construction args in Object

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -71,15 +71,10 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     public signal void folder_deleted (GLib.File location);
     public signal void free_space_change ();
 
-    public Window (Files.Application application, Gdk.Screen myscreen = Gdk.Screen.get_default ()) {
+    public Window (Files.Application application) {
         Object (
             application: application,
             marlin_app: application,
-            height_request: 300,
-            icon_name: "system-file-manager",
-            screen: myscreen,
-            title: _(APP_TITLE),
-            width_request: 500,
             window_number: application.window_count
         );
     }
@@ -89,6 +84,11 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     construct {
+        height_request = 300;
+        width_request = 500;
+        icon_name = "system-file-manager";
+        title = _(APP_TITLE);
+
         add_action_entries (WIN_ENTRIES, this);
         undo_actions_set_insensitive ();
 


### PR DESCRIPTION
Make sure that only things that are passed as construction arguments are present in `Object ()` call

Remove the `screen` argument. We don't seem to set this anything other than the default. This was added [a very long time ago](https://github.com/elementary/files/commit/1a12cd0a763b1959d19cc8220ce64c70e297b978) so seems vestigial. [According to docs](https://valadoc.org/gtk+-3.0/Gtk.Window.set_screen.html) it sounds like this would be used for launching windows on a specific Gdk.Screen, but there's no such functionality so nothing should be lost

This is commented out in #2225 