### PR TITLE
Do not lose previous tabs when opened from another app

### DIFF
--- a/pantheon-files-daemon/FileManager1.vala
+++ b/pantheon-files-daemon/FileManager1.vala
@@ -37,9 +37,10 @@ public class FileManager1 : Object {
 
     private void open_items_and_folders (string[] uris, string startup_id) throws DBusError, IOError {
         /* The io.elementary.files app will open folder uris as view, other items will cause the parent folder
-         * to open and the item be selected.  Each view will open in a separate tab in one window */
+         * to open and the item be selected.  Each view will open in a separate tab in a new window   They 
+         * will not be remembered or restored */
 
-        StringBuilder sb = new StringBuilder ("io.elementary.files -t");
+        StringBuilder sb = new StringBuilder ("io.elementary.files -n");
         foreach (string s in uris) {
                 sb.append (" ");
                 sb.append (FileManager1.prepare_uri_for_appinfo_create (s));

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -160,7 +160,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         default_height = height;
 
         if (is_first_window) {
-            File.app_settings.changed["restore-tabs"].connect (() => {
+            Files.app_settings.changed["restore-tabs"].connect (() => {
                 // Always honor this setting if changed while Files is running
                 tabs_restored = Files.app_settings.get_boolean ("restore-tabs");
             });

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -160,6 +160,11 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         default_height = height;
 
         if (is_first_window) {
+            File.app_settings.changed["restore-tabs"].connect (() => {
+                // Always honor this setting if changed while Files is running
+                tabs_restored = Files.app_settings.get_boolean ("restore-tabs");
+            });
+
             Files.app_settings.bind ("sidebar-width", lside_pane,
                                        "position", SettingsBindFlags.DEFAULT);
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1139,7 +1139,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     private void save_tabs () {
-        if (!is_first_window) {
+        if (!is_first_window || !tabs_restored) {
             return; //TODO Save all windows
         }
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -165,6 +165,10 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                 tabs_restored = Files.app_settings.get_boolean ("restore-tabs");
             });
 
+            Files.Preferences.get_default ().notify["remember-history"].connect (() => {
+                tabs_restored = Files.Preferences.get_default ().remember_history;
+            });
+
             Files.app_settings.bind ("sidebar-width", lside_pane,
                                        "position", SettingsBindFlags.DEFAULT);
 


### PR DESCRIPTION
FIxes #2235 

* Only save tabs on closing if tabs were originally restored (or restore attempted) i.e. `restored_tabs` is `true`
* If `restore-tabs` setting or `remember-history` changes while open then honor it on closing (first window only)
* Use `-n` option with FileManager1 interface so other apps always open a new Files window which does not save or restore its tabs

Before testing this PR must be installed and any pre-existing pantheon-files-daemon process ended.

To test:

1 Open Files (with History and retore-tabs both ON and open several tabs 
2 Close Files
3 Use another app with a "Show in Folder" function (e.g. a brower's downloads dialog) to open a folder.
4 Only the requested folder should appear in a Files window
5. Close FIles and then re-open normally
6. The tabs saved in step 2 should be restored (in `main` there are overwritten)
7.  Leaving the Files window open, use another app to show a folder as before
8. A second Files window appears showing only the requested folder (in `main` the requested folder is added to the first window)




