### PR TITLE
Do not lose tabs when opened from another app (alternative).

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -155,7 +155,7 @@ public class Files.Application : Gtk.Application {
         options [1] = { "tab", 't', 0, OptionArg.NONE, ref open_in_tab,
                         N_("Open one or more URIs, each in their own tab"), null };
         options [2] = { "new-window", 'n', 0, OptionArg.NONE, out create_new_window,
-                        N_("New Window"), null };
+                        N_("Open a New Window that does not restore or save tabs"), null };
         options [3] = { "quit", 'q', 0, OptionArg.NONE, ref kill_shell,
                         N_("Quit Files"), null };
         options [4] = { "debug", 'd', 0, OptionArg.NONE, ref debug,
@@ -220,14 +220,16 @@ public class Files.Application : Gtk.Application {
         /* Open application */
         if (files != null) {
             if (create_new_window || window_count == 0) {
-                /* Open window with tabs at each requested location. */
-                create_window_with_tabs (files);
-            } else {
+                /* Open window with tabs at each requested location 
+                 * If the -n option is given, no restoring or saving of tabs occurs. */
+                create_window_with_tabs (files, ViewMode.PREFERRED, create_new_window);
+            } else { // window_count must be > 0
                 var win = (View.Window)(get_active_window ());
                 win.open_tabs (files, ViewMode.PREFERRED, true); /* Ignore if duplicate tab in existing window */
             }
         } else if (create_new_window || window_count == 0) {
-            create_window_with_tabs ();
+            /* A default tab is created */
+            create_window_with_tabs (null, ViewMode.PREFERRED, create_new_window);
         }
 
         if (window_count > 0) {
@@ -310,17 +312,19 @@ public class Files.Application : Gtk.Application {
     }
 
     public View.Window? create_window (GLib.File? location = null,
-                                       ViewMode viewmode = ViewMode.PREFERRED) {
+                                       ViewMode viewmode = ViewMode.PREFERRED,
+                                       bool no_restore = false) {
 
-        return create_window_with_tabs ({location}, viewmode);
+        return create_window_with_tabs ({location}, viewmode, no_restore);
     }
 
     /* All window creation should be done via this function */
     private View.Window? create_window_with_tabs (GLib.File[] locations = {},
-                                                  ViewMode viewmode = ViewMode.PREFERRED) {
+                                                  ViewMode viewmode,
+                                                  bool no_restore) {
 
         var win = create_empty_window ();
-        win.open_tabs (locations, viewmode);
+        win.open_tabs (locations, viewmode, false, no_restore);
 
         return win;
     }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -527,7 +527,8 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
     public void open_tabs (GLib.File[]? files = null,
                            ViewMode mode = ViewMode.PREFERRED,
-                           bool ignore_duplicate = false) {
+                           bool ignore_duplicate = false,
+                           bool no_restore = false) {
 
         if (files == null || files.length == 0 || files[0] == null) {
             /* Restore session if not root and settings allow */
@@ -542,6 +543,9 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                 current_container.set_active_state (true, false);
             }
         } else {
+            if (!no_restore) {
+                restore_tabs ();
+            }
             /* Open tabs at each requested location */
             /* As files may be derived from commandline, we use a new sanitized one */
             foreach (var file in files) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -160,6 +160,15 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         default_height = height;
 
         if (is_first_window) {
+            Files.app_settings.changed["restore-tabs"].connect (() => {
+                // Always honor this setting if changed while Files is running
+                tabs_restored = Files.app_settings.get_boolean ("restore-tabs");
+            });
+
+            Files.Preferences.get_default ().notify["remember-history"].connect (() => {
+                tabs_restored = Files.Preferences.get_default ().remember_history;
+            });
+
             Files.app_settings.bind ("sidebar-width", lside_pane,
                                        "position", SettingsBindFlags.DEFAULT);
 
@@ -1139,7 +1148,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     private void save_tabs () {
-        if (!is_first_window) {
+        if (!is_first_window || !tabs_restored) {
             return; //TODO Save all windows
         }
 


### PR DESCRIPTION
Fixes #2235

This is an alternative to #2267.  In this PR, the FileManager1 interface restores (and saves) tabs instead opening the folder in a new window with no restore/save.

Using the `-n` option now causes a window to open that does not restore or save tabs. Only the first opened window restores and saves its tabs.  This prevents a second window overwriting saved tabs from the main window if closed last.

As in the alternative this PR also handles settings changes while the first window is open (this could be split out into a separate PR if desired). 

Before testing this PR must be installed and any pre-existing pantheon-files-daemon process ended.

To test:

1 Open Files (with History and retore-tabs both ON and open several tabs 
2 Close Files
3 Use another app with a "Show in Folder" function (e.g. a brower's downloads dialog) to open a folder.
4 The saved tabs *and* the requested folder should appear in a Files window
5. Close FIles and then re-open normally
6. The tabs saved in step 2 *and* the requested folder should be restored (in `main` there are overwritten)
7.  Leaving the Files window open, use another app to show a folder as before
8.  The requested folder is added to the first window as in `main`
9. In a terminal open Files with a command like `io.elementary.files -n <path-to-folder>`
10. A window opens only containing the requested folder.  When this window is closed, saved tabs are not overwritten.