### PR TITLE
Always restore tabs when settings allow, save tabs from last window closed.

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -520,12 +520,10 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                            ViewMode mode = ViewMode.PREFERRED,
                            bool ignore_duplicate = false) {
 
-        uint n_restored_tabs = 0;
-        if (Files.app_settings.get_boolean ("restore-tabs") && !Files.is_admin ()) {
-            n_restored_tabs = restore_tabs ();
-        }
-
-        if (n_restored_tabs < 1 && (files == null || files.length == 0 || files[0] == null)) {
+        if (
+            restore_tabs () < 1 &&
+            (files == null || files.length == 0 || files[0] == null)
+        ) {
             /* Open a tab pointing at the default location if no tabs restored and none provided*/
             var location = GLib.File.new_for_path (PF.UserUtils.get_real_user_home ());
             add_tab (location, mode);
@@ -1176,9 +1174,15 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         );
     }
 
-    public uint restore_tabs () {
-        /* Do not restore tabs if history off nor more than once */
-        if (!Files.Preferences.get_default ().remember_history || tabs_restored || !is_first_window) { //TODO Restore all windows
+    private uint restore_tabs () {
+        /* Do not restore tabs more than once or if various conditions not met */
+        if (
+            tabs_restored ||
+            !is_first_window ||
+            !Files.Preferences.get_default ().remember_history ||
+            Files.app_settings.get_boolean ("restore-tabs") ||
+            Files.is_admin ()
+        ) {
             return 0;
         } else {
             tabs_restored = true;

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1138,8 +1138,14 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     private void save_tabs () {
-        if (!Files.Preferences.get_default ().remember_history) {
-            return;  /* Do not clear existing settings if history is off */
+        /* Do not overwrite existing settings if history or restore-tabs is off
+         * or is admin window */
+        if (
+            !Files.Preferences.get_default ().remember_history ||
+            !Files.app_settings.get_boolean ("restore-tabs") ||
+            Files.is_admin ()
+        ) {
+            return;
         }
 
         VariantBuilder vb = new VariantBuilder (new VariantType ("a(uss)"));

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -520,18 +520,17 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                            ViewMode mode = ViewMode.PREFERRED,
                            bool ignore_duplicate = false) {
 
-        if (files == null || files.length == 0 || files[0] == null) {
-            /* Restore session if not root and settings allow */
-            if (Files.is_admin () ||
-                !Files.app_settings.get_boolean ("restore-tabs") ||
-                restore_tabs () < 1) {
+        uint n_restored_tabs = 0;
+        if (Files.app_settings.get_boolean ("restore-tabs") && !Files.is_admin ()) {
+            n_restored_tabs = restore_tabs ();
+        }
 
-                /* Open a tab pointing at the default location if no tabs restored*/
-                var location = GLib.File.new_for_path (PF.UserUtils.get_real_user_home ());
-                add_tab (location, mode);
-                /* Ensure default tab's slot is active so it can be focused */
-                current_container.set_active_state (true, false);
-            }
+        if (n_restored_tabs < 1 && (files == null || files.length == 0 || files[0] == null)) {
+            /* Open a tab pointing at the default location if no tabs restored and none provided*/
+            var location = GLib.File.new_for_path (PF.UserUtils.get_real_user_home ());
+            add_tab (location, mode);
+            /* Ensure default tab's slot is active so it can be focused */
+            current_container.set_active_state (true, false);
         } else {
             /* Open tabs at each requested location */
             /* As files may be derived from commandline, we use a new sanitized one */

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1138,10 +1138,6 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     private void save_tabs () {
-        if (!is_first_window) {
-            return; //TODO Save all windows
-        }
-
         if (!Files.Preferences.get_default ().remember_history) {
             return;  /* Do not clear existing settings if history is off */
         }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -520,8 +520,9 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                            ViewMode mode = ViewMode.PREFERRED,
                            bool ignore_duplicate = false) {
 
-        if (
-            restore_tabs () < 1 &&
+        // Always try to restore tabs
+        var n_tabs_restored = restore_tabs ();
+        if (n_tabs_restored < 1 &&
             (files == null || files.length == 0 || files[0] == null)
         ) {
             /* Open a tab pointing at the default location if no tabs restored and none provided*/

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1181,7 +1181,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             tabs_restored ||
             !is_first_window ||
             !Files.Preferences.get_default ().remember_history ||
-            Files.app_settings.get_boolean ("restore-tabs") ||
+            !Files.app_settings.get_boolean ("restore-tabs") ||
             Files.is_admin ()
         ) {
             return 0;


### PR DESCRIPTION
Fixes #2235.

Following feedback from other PRs, this PR leaves restoring and saving tabs to the settings only, except that only the first window restores tabs. 

 * Files opened from another app adds the requested tab to the active window, or opens a window with restored tabs if no active window and settings allow.
 * Every window saves its tabs, if settings allow, so the tabs from the last one closed only persist.


Tabs are restored if:
 * The window is the first opened window and
 * The Files "restore-tabs" settings is `true`  and 
 * The System "remember-history" setting is `true` and
 * The window was not opened as administrator

Tabs are saved if:
 * The Files "restore-tabs" settings is `true`  and 
 * The System "remember-history" setting is `true` and
 * The window was not opened as administrator

As a consequence of this PR it is no longer possible to open a window that does not save its tabs except by changing one of the above settings.

A further PR that exposes the "restore-tabs" setting in the AppMenu will be proposed to compensate for this.