### PR TITLE
Replace ScrolledWindow.add with child property

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -314,7 +314,7 @@ namespace Files {
             view = create_view ();
 
             if (view != null) {
-                add (view);
+                child = view;
                 show_all ();
                 connect_drag_drop_signals (view);
                 view.add_events (Gdk.EventMask.POINTER_MOTION_MASK |

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -57,20 +57,19 @@ namespace Files.View {
 
             colpane = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 
+            viewport = new Gtk.Viewport (null, null) {
+                shadow_type = Gtk.ShadowType.NONE
+            };
+            viewport.add (colpane);
+
             scrolled_window = new Gtk.ScrolledWindow (null, null) {
+                child = viewport,
                 hscrollbar_policy = Gtk.PolicyType.AUTOMATIC,
                 vscrollbar_policy = Gtk.PolicyType.NEVER
             };
 
             hadj = scrolled_window.get_hadjustment ();
 
-            viewport = new Gtk.Viewport (null, null) {
-                shadow_type = Gtk.ShadowType.NONE
-            };
-
-            viewport.add (this.colpane);
-
-            scrolled_window.add (viewport);
             add_overlay (scrolled_window);
 
             content_box.show_all ();

--- a/src/View/Widgets/MultiLineEditableLabel.vala
+++ b/src/View/Widgets/MultiLineEditableLabel.vala
@@ -29,8 +29,10 @@ namespace Files {
             /* Block propagation of button press event as this would cause renaming to end */
             textview.button_press_event.connect_after (() => { return true; });
 
-            scrolled_window = new Gtk.ScrolledWindow (null, null);
-            scrolled_window.add (textview);
+            scrolled_window = new Gtk.ScrolledWindow (null, null) {
+                child = textview
+            };
+
             return scrolled_window as Gtk.Widget;
         }
 

--- a/src/View/Widgets/SearchResults.vala
+++ b/src/View/Widgets/SearchResults.vala
@@ -166,14 +166,6 @@ namespace Files.View.Chrome {
 
             zg_index = new Zeitgeist.Index ();
 #endif
-            var frame = new Gtk.Frame (null) {
-                shadow_type = Gtk.ShadowType.ETCHED_IN
-            };
-
-            scroll = new Gtk.ScrolledWindow (null, null) {
-                hscrollbar_policy = Gtk.PolicyType.NEVER
-            };
-
             view = new Gtk.TreeView () {
                 headers_visible = false,
                 level_indentation = 12,
@@ -186,6 +178,11 @@ namespace Files.View.Chrome {
             view.get_selection ().set_select_function ((selection, list, path, path_selected) => {
                 return path.get_depth () != 0;
             });
+
+            scroll = new Gtk.ScrolledWindow (null, null) {
+                child = view,
+                hscrollbar_policy = Gtk.PolicyType.NEVER
+            };
 
             get_style_context ().add_class ("completion-popup");
 
@@ -249,9 +246,7 @@ namespace Files.View.Chrome {
             list.append (out zeitgeist_results, null);
 #endif
 
-            scroll.add (view);
-            frame.add (scroll);
-            add (frame);
+            child = scroll;
 
             button_press_event.connect (on_button_press_event);
             view.button_press_event.connect (on_view_button_press_event);


### PR DESCRIPTION
Gtk4 prep. Remove an unnecessary frame in `src/View/Widgets/SearchResults.vala` while here, borders are drawn with CSS