### PR TITLE
Sidebar Gtk4 Prep

### DIFF
--- a/libcore/Interfaces/SidebarInterface.vala
+++ b/libcore/Interfaces/SidebarInterface.vala
@@ -36,9 +36,7 @@ public interface Files.SidebarInterface : Gtk.Widget {
         /* Plugin interface */
         public abstract uint32 add_plugin_item (Files.SidebarPluginItem item, Files.PlaceType category);
         public abstract bool update_plugin_item (Files.SidebarPluginItem item, uint32 item_id);
-        public abstract bool remove_item_by_id (uint32 item_id); //Returns true if successfully removed
         /* Window interface */
-        public signal void request_update ();
         public signal bool request_focus ();
         public signal void sync_needed ();
         public signal void path_change_request (string uri, Files.OpenFlag flag);

--- a/libcore/Interfaces/SidebarItemInterface.vala
+++ b/libcore/Interfaces/SidebarItemInterface.vala
@@ -21,7 +21,7 @@
  * Authors : Jeremy Wootten <jeremy@elementaryos.org>
  */
 
-public interface Sidebar.SidebarItemInterface : Gtk.Widget {
+public interface Sidebar.SidebarItemInterface : Object {
     /* Non constant static members must be initialised in implementing class */
     protected static uint32 row_id;
     protected static Gee.HashMap<uint32, SidebarItemInterface> item_id_map;

--- a/libcore/Interfaces/SidebarListInterface.vala
+++ b/libcore/Interfaces/SidebarListInterface.vala
@@ -9,7 +9,7 @@ public interface Sidebar.SidebarListInterface : Object {
     public abstract Files.SidebarInterface sidebar { get; construct; }
     public abstract Gtk.ListBox list_box { get; internal set; }
 
-    public abstract void select_item (SidebarItemInterface? item);
+    public abstract void select_item (Gtk.ListBoxRow? item);
     public abstract void unselect_all_items ();
 
     public virtual void open_item (SidebarItemInterface item, Files.OpenFlag flag = DEFAULT) {
@@ -27,19 +27,19 @@ public interface Sidebar.SidebarListInterface : Object {
         foreach (unowned var child in list_box.get_children ()) {
             list_box.remove (child);
             if (child is SidebarItemInterface) {
-                ((SidebarItemInterface)child).destroy_bookmark ();
+                ((SidebarItemInterface) child).destroy_bookmark ();
             }
         }
     }
 
     public virtual void rename_bookmark_by_uri (string uri, string new_name) {}
 
-    public virtual bool has_uri (string uri, out unowned SidebarItemInterface? row = null) {
+    public virtual bool has_uri (string uri, out unowned Gtk.ListBoxRow? row = null) {
         row = null;
         foreach (unowned var child in list_box.get_children ()) {
             if (child is SidebarItemInterface) {
                 if (((SidebarItemInterface)child).uri == uri) {
-                    row = (SidebarItemInterface)child;
+                    row = (Gtk.ListBoxRow) child;
                     return true;
                 }
             }
@@ -50,7 +50,7 @@ public interface Sidebar.SidebarListInterface : Object {
 
     public virtual bool select_uri (string uri) {
         unselect_all_items ();
-        SidebarItemInterface? row = null;
+        Gtk.ListBoxRow? row = null;
         if (has_uri (uri, out row)) {
             select_item (row);
             return true;
@@ -68,7 +68,7 @@ public interface Sidebar.SidebarListInterface : Object {
                 }
 
                 if (row.id == id) {
-                    list_box.remove (row);
+                    list_box.remove (child);
                     row.destroy_bookmark ();
                     return true;
                 }
@@ -85,8 +85,8 @@ public interface Sidebar.SidebarListInterface : Object {
 
     /* Second parameter is index of target after which the item should be inserted */
     public virtual bool move_item_after (SidebarItemInterface item, int target_index) {
-        return false;
-    } // By default not-reorderable
+        return false; // By default not-reorderable
+    }
 
     // Whether can drop rows or uris onto list itself (as opposed to onto rows in list)
     public virtual bool is_drop_target () {

--- a/libcore/Interfaces/SidebarListInterface.vala
+++ b/libcore/Interfaces/SidebarListInterface.vala
@@ -1,44 +1,31 @@
 /*
- * SidebarListInterface.vala
- *
- * Copyright 2020 elementary LLC. <https://elementary.io>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
- * MA 02110-1301, USA.
+ * SPDX-License-Identifier: GPL-2.0+
+ * SPDX-FileCopyrightText: 2020-2023 elementary, Inc. (https://elementary.io)
  *
  * Authors : Jeremy Wootten <jeremy@elementaryos.org>
  */
 
-public interface Sidebar.SidebarListInterface : Gtk.Container {
+public interface Sidebar.SidebarListInterface : Gtk.Widget {
     public abstract Files.SidebarInterface sidebar { get; construct; }
+    public abstract Gtk.ListBox list_box { get; internal set; }
 
     public abstract void select_item (SidebarItemInterface? item);
     public abstract void unselect_all_items ();
 
-    public virtual void open_item (SidebarItemInterface item, Files.OpenFlag flag = Files.OpenFlag.DEFAULT) {
+    public virtual void open_item (SidebarItemInterface item, Files.OpenFlag flag = DEFAULT) {
         sidebar.path_change_request (item.uri, flag);
     }
 
     public abstract void refresh (); //Clear and recreate all rows
     public virtual void refresh_info () {} //Update all rows without recreating them
 
-    public virtual uint32 add_plugin_item (Files.SidebarPluginItem plugin_item) {return 0;}
+    public virtual uint32 add_plugin_item (Files.SidebarPluginItem plugin_item) {
+        return 0;
+    }
 
     public virtual void clear () {
-        foreach (Gtk.Widget child in get_children ()) {
-            remove (child);
+        foreach (unowned var child in list_box.get_children ()) {
+            list_box.remove (child);
             if (child is SidebarItemInterface) {
                 ((SidebarItemInterface)child).destroy_bookmark ();
             }
@@ -47,20 +34,9 @@ public interface Sidebar.SidebarListInterface : Gtk.Container {
 
     public virtual void rename_bookmark_by_uri (string uri, string new_name) {}
 
-    public virtual void remove_bookmark_by_uri (string uri) {
-        SidebarItemInterface? row = null;
-        if (has_uri (uri, out row)) {
-            if (row.permanent) {
-                return;
-            }
-            remove (row);
-            row.destroy_bookmark ();
-        }
-    }
-
     public virtual bool has_uri (string uri, out unowned SidebarItemInterface? row = null) {
         row = null;
-        foreach (unowned Gtk.Widget child in get_children ()) {
+        foreach (unowned var child in list_box.get_children ()) {
             if (child is SidebarItemInterface) {
                 if (((SidebarItemInterface)child).uri == uri) {
                     row = (SidebarItemInterface)child;
@@ -84,7 +60,7 @@ public interface Sidebar.SidebarListInterface : Gtk.Container {
     }
 
     public virtual bool remove_item_by_id (uint32 id) {
-        foreach (Gtk.Widget child in get_children ()) {
+        foreach (unowned var child in list_box.get_children ()) {
             if (child is SidebarItemInterface) {
                 unowned var row = (SidebarItemInterface)child;
                 if (row.permanent) {
@@ -92,7 +68,7 @@ public interface Sidebar.SidebarListInterface : Gtk.Container {
                 }
 
                 if (row.id == id) {
-                    remove (row);
+                    list_box.remove (row);
                     row.destroy_bookmark ();
                     return true;
                 }
@@ -112,5 +88,8 @@ public interface Sidebar.SidebarListInterface : Gtk.Container {
         return false;
     } // By default not-reorderable
 
-    public virtual bool is_drop_target () { return false; } // Whether can drop rows or uris onto list itself (as opposed to onto rows in list)
+    // Whether can drop rows or uris onto list itself (as opposed to onto rows in list)
+    public virtual bool is_drop_target () {
+        return false;
+    }
 }

--- a/libcore/Interfaces/SidebarListInterface.vala
+++ b/libcore/Interfaces/SidebarListInterface.vala
@@ -25,10 +25,11 @@ public interface Sidebar.SidebarListInterface : Object {
 
     public virtual void clear () {
         foreach (unowned var child in list_box.get_children ()) {
-            list_box.remove (child);
             if (child is SidebarItemInterface) {
                 ((SidebarItemInterface) child).destroy_bookmark ();
             }
+
+            list_box.remove (child);
         }
     }
 

--- a/libcore/Interfaces/SidebarListInterface.vala
+++ b/libcore/Interfaces/SidebarListInterface.vala
@@ -5,7 +5,7 @@
  * Authors : Jeremy Wootten <jeremy@elementaryos.org>
  */
 
-public interface Sidebar.SidebarListInterface : Gtk.Widget {
+public interface Sidebar.SidebarListInterface : Object {
     public abstract Files.SidebarInterface sidebar { get; construct; }
     public abstract Gtk.ListBox list_box { get; internal set; }
 

--- a/libcore/Interfaces/SidebarListInterface.vala
+++ b/libcore/Interfaces/SidebarListInterface.vala
@@ -24,12 +24,11 @@ public interface Sidebar.SidebarListInterface : Object {
     }
 
     public virtual void clear () {
-        foreach (unowned var child in list_box.get_children ()) {
+        foreach (Gtk.Widget child in list_box.get_children ()) {
+            list_box.remove (child);
             if (child is SidebarItemInterface) {
                 ((SidebarItemInterface) child).destroy_bookmark ();
             }
-
-            list_box.remove (child);
         }
     }
 

--- a/src/View/Sidebar/BookmarkListBox.vala
+++ b/src/View/Sidebar/BookmarkListBox.vala
@@ -46,19 +46,19 @@ public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
         });
 
         list_box.row_activated.connect ((row) => {
-            if (row is SidebarItemInterface) {
-                ((SidebarItemInterface) row).activated ();
+            if (row is BookmarkRow) {
+                ((BookmarkRow) row).activated ();
             }
         });
 
         list_box.row_selected.connect ((row) => {
-            if (row is SidebarItemInterface) {
-                select_item ((SidebarItemInterface) row);
+            if (row is BookmarkRow) {
+                select_item (row);
             }
         });
     }
 
-    public SidebarItemInterface? add_bookmark (string label,
+    public BookmarkRow? add_bookmark (string label,
                                                string uri,
                                                Icon gicon,
                                                bool pinned = false,
@@ -67,7 +67,7 @@ public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
         return insert_bookmark (label, uri, gicon, -1, pinned, permanent);
     }
 
-    private SidebarItemInterface? insert_bookmark (string label,
+    private BookmarkRow? insert_bookmark (string label,
                                                    string uri,
                                                    Icon gicon,
                                                    int index,
@@ -100,9 +100,9 @@ public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
     }
 
 
-    public void select_item (SidebarItemInterface? item) {
+    public void select_item (Gtk.ListBoxRow? item) {
         if (item != null && item is BookmarkRow) {
-            list_box.select_row ((BookmarkRow)item);
+            list_box.select_row (item);
         } else {
             unselect_all_items ();
         }
@@ -115,7 +115,7 @@ public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
     public void refresh () {
         clear ();
 
-        SidebarItemInterface? row;
+        BookmarkRow? row;
         var home_uri = "";
         try {
             home_uri = GLib.Filename.to_uri (PF.UserUtils.get_real_user_home (), null);
@@ -196,7 +196,7 @@ public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
 
         int pinned = 0; // Assume pinned items only at start and end of list
         foreach (unowned var child in list_box.get_children ()) {
-            if (((SidebarItemInterface)child).pinned) {
+            if (((BookmarkRow)child).pinned) {
                 pinned++;
             } else {
                 break;
@@ -219,8 +219,8 @@ public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
     public override bool remove_item_by_id (uint32 id) {
         bool removed = false;
         list_box.@foreach ((child) => {
-            if (child is SidebarItemInterface) {
-                unowned var row = (SidebarItemInterface)child;
+            if (child is BookmarkRow) {
+                unowned var row = (BookmarkRow)child;
                if (!row.permanent && row.id == id) {
                     list_box.remove (row);
                     bookmark_list.delete_items_with_uri (row.uri); //Assumes no duplicates
@@ -237,7 +237,7 @@ public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
             return null;
         }
 
-        return (SidebarItemInterface?)(list_box.get_row_at_index (index));
+        return (SidebarItemInterface?) list_box.get_row_at_index (index);
     }
 
     public override bool move_item_after (SidebarItemInterface item, int target_index) {
@@ -250,12 +250,12 @@ public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
             return false;
         }
 
-        list_box.remove (item);
+        list_box.remove ((Gtk.ListBoxRow) item);
 
         if (old_index > target_index) {
-            list_box.insert (item, ++target_index);
+            list_box.insert ((Gtk.ListBoxRow) item, ++target_index);
         } else {
-            list_box.insert (item, target_index);
+            list_box.insert ((Gtk.ListBoxRow) item, target_index);
         }
 
         bookmark_list.move_item_uri (item.uri, target_index - old_index);

--- a/src/View/Sidebar/BookmarkListBox.vala
+++ b/src/View/Sidebar/BookmarkListBox.vala
@@ -21,7 +21,7 @@
  */
 
 public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
-    public Files.SidebarInterface sidebar {get; construct;}
+    public Files.SidebarInterface sidebar { get; construct; }
     public Gtk.ListBox list_box { get; internal set; }
 
     private Files.BookmarkList bookmark_list;

--- a/src/View/Sidebar/BookmarkListBox.vala
+++ b/src/View/Sidebar/BookmarkListBox.vala
@@ -20,32 +20,38 @@
  * Authors : Jeremy Wootten <jeremy@elementaryos.org>
  */
 
-public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
+public class Sidebar.BookmarkListBox : Gtk.Box, Sidebar.SidebarListInterface {
+    public Files.SidebarInterface sidebar {get; construct;}
+    public Gtk.ListBox list_box { get; internal set; }
+
     private Files.BookmarkList bookmark_list;
     private unowned Files.TrashMonitor trash_monitor;
 
-    public Files.SidebarInterface sidebar {get; construct;}
-
     public BookmarkListBox (Files.SidebarInterface sidebar) {
-        Object (
-            sidebar: sidebar
-        );
+        Object (sidebar: sidebar);
     }
 
     construct {
-        hexpand = true;
-        selection_mode = Gtk.SelectionMode.SINGLE;
+        list_box = new Gtk.ListBox () {
+            hexpand = true,
+            selection_mode = Gtk.SelectionMode.SINGLE
+        };
+
+        add (list_box);
+
         trash_monitor = Files.TrashMonitor.get_default ();
         bookmark_list = Files.BookmarkList.get_instance ();
         bookmark_list.loaded.connect (() => {
             refresh ();
         });
-        row_activated.connect ((row) => {
+
+        list_box.row_activated.connect ((row) => {
             if (row is SidebarItemInterface) {
                 ((SidebarItemInterface) row).activated ();
             }
         });
-        row_selected.connect ((row) => {
+
+        list_box.row_selected.connect ((row) => {
             if (row is SidebarItemInterface) {
                 select_item ((SidebarItemInterface) row);
             }
@@ -74,9 +80,9 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
 
         var row = new BookmarkRow (label, uri, gicon, this, pinned, permanent);
         if (index >= 0) {
-            insert (row, index);
+            list_box.insert (row, index);
         } else {
-            add (row);
+            list_box.add (row);
         }
 
         return row;
@@ -96,14 +102,14 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
 
     public void select_item (SidebarItemInterface? item) {
         if (item != null && item is BookmarkRow) {
-            select_row ((BookmarkRow)item);
+            list_box.select_row ((BookmarkRow)item);
         } else {
             unselect_all_items ();
         }
     }
 
     public void unselect_all_items () {
-        unselect_all ();
+        list_box.unselect_all ();
     }
 
     public void refresh () {
@@ -189,7 +195,7 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
                                        int pos = 0) {
 
         int pinned = 0; // Assume pinned items only at start and end of list
-        foreach (unowned Gtk.Widget child in get_children ()) {
+        foreach (unowned var child in list_box.get_children ()) {
             if (((SidebarItemInterface)child).pinned) {
                 pinned++;
             } else {
@@ -212,11 +218,11 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
 
     public override bool remove_item_by_id (uint32 id) {
         bool removed = false;
-        this.@foreach ((child) => {
+        list_box.@foreach ((child) => {
             if (child is SidebarItemInterface) {
                 unowned var row = (SidebarItemInterface)child;
                if (!row.permanent && row.id == id) {
-                    remove (row);
+                    list_box.remove (row);
                     bookmark_list.delete_items_with_uri (row.uri); //Assumes no duplicates
                     removed = true;
                 }
@@ -227,11 +233,11 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
     }
 
     public SidebarItemInterface? get_item_at_index (int index) {
-        if (index < 0 || index > get_children ().length ()) {
+        if (index < 0 || index > list_box.get_children ().length ()) {
             return null;
         }
 
-        return (SidebarItemInterface?)(get_row_at_index (index));
+        return (SidebarItemInterface?)(list_box.get_row_at_index (index));
     }
 
     public override bool move_item_after (SidebarItemInterface item, int target_index) {
@@ -244,12 +250,12 @@ public class Sidebar.BookmarkListBox : Gtk.ListBox, Sidebar.SidebarListInterface
             return false;
         }
 
-        remove (item);
+        list_box.remove (item);
 
         if (old_index > target_index) {
-            insert (item, ++target_index);
+            list_box.insert (item, ++target_index);
         } else {
-            insert (item, target_index);
+            list_box.insert (item, target_index);
         }
 
         bookmark_list.move_item_uri (item.uri, target_index - old_index);

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -364,7 +364,7 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
 
         drag_failed.connect ((ctx, res) => {
             if (res == Gtk.DragResult.NO_TARGET) {
-                Gdk.Window app_window = list.get_window ().get_effective_toplevel ();
+                Gdk.Window app_window = list.list_box.get_window ().get_effective_toplevel ();
                 Gdk.Window drag_window = ctx.get_drag_window ();
                 Gdk.Rectangle app_rect, drag_rect, intersect_rect;
 

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -44,14 +44,14 @@ public class Sidebar.DeviceListBox : Gtk.Box, Sidebar.SidebarListInterface {
         volume_monitor.volume_added.connect (bookmark_volume);
 
         list_box.row_activated.connect ((row) => {
-            if (row is SidebarItemInterface) {
-                ((SidebarItemInterface) row).activated ();
+            if (row is BookmarkRow) {
+                ((BookmarkRow) row).activated ();
             }
         });
 
         list_box.row_selected.connect ((row) => {
-            if (row is SidebarItemInterface) {
-                select_item ((SidebarItemInterface) row);
+            if (row is BookmarkRow) {
+                select_item (row);
             }
         });
 
@@ -250,7 +250,7 @@ public class Sidebar.DeviceListBox : Gtk.Box, Sidebar.SidebarListInterface {
         return false;
     }
 
-    public SidebarItemInterface? add_sidebar_row (string label, string uri, Icon gicon) {
+    public BookmarkRow? add_sidebar_row (string label, string uri, Icon gicon) {
         //We do not want devices to be added by external agents
         return null;
     }
@@ -263,9 +263,9 @@ public class Sidebar.DeviceListBox : Gtk.Box, Sidebar.SidebarListInterface {
         }
     }
 
-    public void select_item (SidebarItemInterface? item) {
+    public void select_item (Gtk.ListBoxRow? item) {
         if (item != null && item is AbstractMountableRow) {
-            list_box.select_row ((AbstractMountableRow)item);
+            list_box.select_row (item);
         } else {
             unselect_all_items ();
         }

--- a/src/View/Sidebar/NetworkListBox.vala
+++ b/src/View/Sidebar/NetworkListBox.vala
@@ -40,14 +40,14 @@ public class Sidebar.NetworkListBox : Gtk.Box, Sidebar.SidebarListInterface {
         volume_monitor.mount_added.connect (bookmark_mount_if_not_shadowed);
 
         list_box.row_activated.connect ((row) => {
-            if (row is SidebarItemInterface) {
-                ((SidebarItemInterface) row).activated ();
+            if (row is BookmarkRow) {
+                ((BookmarkRow) row).activated ();
             }
         });
 
         list_box.row_selected.connect ((row) => {
-            if (row is SidebarItemInterface) {
-                select_item ((SidebarItemInterface) row);
+            if (row is BookmarkRow) {
+                select_item (row);
             }
         });
 
@@ -61,8 +61,8 @@ public class Sidebar.NetworkListBox : Gtk.Box, Sidebar.SidebarListInterface {
         return strcmp (key1, key2);
     }
 
-    private SidebarItemInterface? add_bookmark (string label, string uri, Icon gicon, bool permanent, bool pinned, string? uuid, Mount? mount) {
-        SidebarItemInterface? row = null;
+    private BookmarkRow? add_bookmark (string label, string uri, Icon gicon, bool permanent, bool pinned, string? uuid, Mount? mount) {
+        Gtk.ListBoxRow? row = null;
 
         if (!has_uri (uri, out row)) {
             row = new NetworkRow (
@@ -79,7 +79,7 @@ public class Sidebar.NetworkListBox : Gtk.Box, Sidebar.SidebarListInterface {
             list_box.add (row);
         }
 
-        return row;
+        return (BookmarkRow) row;
     }
 
     public override uint32 add_plugin_item (Files.SidebarPluginItem plugin_item) {
@@ -149,9 +149,9 @@ public class Sidebar.NetworkListBox : Gtk.Box, Sidebar.SidebarListInterface {
         list_box.unselect_all ();
     }
 
-    public void select_item (SidebarItemInterface? item) {
+    public void select_item (Gtk.ListBoxRow? item) {
         if (item != null && item is NetworkRow) {
-            list_box.select_row ((NetworkRow)item);
+            list_box.select_row (item);
         } else {
             unselect_all_items ();
         }

--- a/src/View/Sidebar/NetworkListBox.vala
+++ b/src/View/Sidebar/NetworkListBox.vala
@@ -20,29 +20,38 @@
  * Authors : Jeremy Wootten <jeremy@elementaryos.org>
  */
 
-public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface {
+public class Sidebar.NetworkListBox : Gtk.Box, Sidebar.SidebarListInterface {
     public Files.SidebarInterface sidebar { get; construct; }
+    public Gtk.ListBox list_box { get; internal set; }
+
     public NetworkListBox (Files.SidebarInterface sidebar) {
-        Object (
-            sidebar: sidebar
-        );
+        Object (sidebar: sidebar);
     }
 
     construct {
+        list_box = new Gtk.ListBox () {
+            hexpand = true,
+            selection_mode = Gtk.SelectionMode.SINGLE
+        };
+
+        add (list_box);
+
         var volume_monitor = VolumeMonitor.@get ();
         volume_monitor.mount_added.connect (bookmark_mount_if_not_shadowed);
-        row_activated.connect ((row) => {
+
+        list_box.row_activated.connect ((row) => {
             if (row is SidebarItemInterface) {
                 ((SidebarItemInterface) row).activated ();
             }
         });
-        row_selected.connect ((row) => {
+
+        list_box.row_selected.connect ((row) => {
             if (row is SidebarItemInterface) {
                 select_item ((SidebarItemInterface) row);
             }
         });
 
-        set_sort_func (network_sort_func);
+        list_box.set_sort_func (network_sort_func);
     }
 
     private int network_sort_func (Gtk.ListBoxRow? row1, Gtk.ListBoxRow? row2) {
@@ -67,7 +76,7 @@ public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface 
                 mount
             );
 
-            add (row);
+            list_box.add (row);
         }
 
         return row;
@@ -137,12 +146,12 @@ public class Sidebar.NetworkListBox : Gtk.ListBox, Sidebar.SidebarListInterface 
     }
 
     public void unselect_all_items () {
-        unselect_all ();
+        list_box.unselect_all ();
     }
 
     public void select_item (SidebarItemInterface? item) {
         if (item != null && item is NetworkRow) {
-            select_row ((NetworkRow)item);
+            list_box.select_row ((NetworkRow)item);
         } else {
             unselect_all_items ();
         }

--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -8,9 +8,9 @@
 
 public class Sidebar.SidebarWindow : Gtk.Box, Files.SidebarInterface {
     private Gtk.ScrolledWindow scrolled_window;
-    private SidebarListInterface bookmark_listbox;
-    private SidebarListInterface device_listbox;
-    private SidebarListInterface network_listbox;
+    private BookmarkListBox bookmark_listbox;
+    private DeviceListBox device_listbox;
+    private NetworkListBox network_listbox;
 
     private string selected_uri = "";
     private bool loading = false;

--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -178,13 +178,6 @@ public class Sidebar.SidebarWindow : Gtk.Box, Files.SidebarInterface {
         return true;
     }
 
-    public bool remove_item_by_id (uint32 item_id) {
-        // We do not know which listbox the row is in so try remove from each in turn
-        return bookmark_listbox.remove_item_by_id (item_id) ||
-               device_listbox.remove_item_by_id (item_id) ||
-               network_listbox.remove_item_by_id (item_id);
-    }
-
     uint sync_timeout_id = 0;
     public void sync_uri (string location) {
         if (sync_timeout_id > 0) {


### PR DESCRIPTION
Starting over based on changes from #2082

I think this is The Least™ to make sure these don't subclass ListBox without any errors or warnings in terminal etc

`SidebarInterface`, `SidebarWindow`
* Remove unused `remove_item_by_id`

`SidebarItemInterface`
* subclasses Object rather than Gtk.Widget

`SidebarListInterface`
* subclasses Object rather than Gtk.Widget
* remove unused `remove_bookmark_by_uri`
* Use `Gtk.ListBoxRow` instead of `SidebarItemInterface` where possible to avoid issues with pointers/casting
* Misc code style

`BookmarkListBox`, `DeviceListBox`, `NetworkListBox`
* Subclass Box, ListBox is a child
* Use `Gtk.ListBoxRow` instead of `SidebarItemInterface` where possible to avoid issues with pointers/casting
* Misc code style