### PR TITLE
Create flatpak.yml

### DIFF
--- a/data/io.elementary.files.service.in
+++ b/data/io.elementary.files.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
-Name=@exec_name@.db
+Name=@exec_name@
 Exec=@install_prefix@/@bin_dir@/@exec_name@-daemon

--- a/data/meson.build
+++ b/data/meson.build
@@ -13,7 +13,7 @@ configure_file(
 
 configure_file(
     input: meson.project_name() + '-filemanager1.service.in',
-    output: meson.project_name() + '.Filemanager1.service',
+    output: 'org.freedesktop.FileManager1.service',
     configuration: config_data,
     install: true,
     install_dir: join_paths(get_option('datadir'), 'dbus-1', 'services')

--- a/io.elementary.files.yml
+++ b/io.elementary.files.yml
@@ -11,11 +11,13 @@ finish-args:
   - '--filesystem=home'
   - '--filesystem=/media'
   - '--filesystem=/run/media'
+  - '--filesystem=xdg-cache/thumbnails'
   - '--share=ipc'
   - '--share=network'
   - '--socket=fallback-x11'
   - '--socket=wayland'
   - '--talk-name=org.freedesktop.FileManager1'
+  - '--talk-name=org.freedesktop.thumbnails.Thumbnailer1'
 
 modules:
   - name: canberra

--- a/io.elementary.files.yml
+++ b/io.elementary.files.yml
@@ -1,0 +1,75 @@
+app-id: io.elementary.files
+
+runtime: io.elementary.Platform
+runtime-version: '7.2'
+sdk: io.elementary.Sdk
+
+command: io.elementary.files
+
+finish-args:
+  - '--device=dri'
+  - '--share=ipc'
+  - '--socket=fallback-x11'
+  - '--socket=wayland'
+  - '--share=network'
+
+modules:
+  - name: canberra
+    config-opts:
+      - '--enable-gstreamer'
+      - '--enable-pulse'
+      - '--disable-oss'
+      - '--disable-static'
+      - '--with-builtin=dso'
+    sources:
+      - type: git
+        url: http://git.0pointer.net/clone/libcanberra.git
+        disable-shallow-clone: true
+
+  - name: cloudproviders
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/World/libcloudproviders.git
+
+  - name: git2-glib
+    buildsystem: meson
+    builddir: true
+    config-opts:
+      - '-Dpython=false'
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/libgit2-glib.git
+        tag: v1.1.0
+    modules:
+      - name: ssh2
+        buildsystem: cmake-ninja
+        config-opts:
+          - '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+          - '-DBUILD_SHARED_LIBS:BOOL=ON'
+          - '-DBUILD_EXAMPLES:BOOL=OFF'
+          - '-DBUILD_TESTING:BOOL=OFF'
+          - '-DCMAKE_INSTALL_LIBDIR:PATH=/app/lib'
+        cleanup:
+          - '/share/man'
+          - '/share/doc'
+        sources:
+          - type: git
+            url: https://github.com/libssh2/libssh2.git
+            tag: libssh2-1.10.0
+      - name: libgit2
+        buildsystem: cmake-ninja
+        config-opts:
+          - '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+        sources:
+          - type: git
+            url: https://github.com/libgit2/libgit2.git
+            tag: 'v1.5.1'
+
+  - name: files
+    buildsystem: meson
+    config-opts:
+      - '-Dsystemduserunitdir=no'
+    sources:
+      - type: dir
+        path: .

--- a/io.elementary.files.yml
+++ b/io.elementary.files.yml
@@ -8,10 +8,14 @@ command: io.elementary.files
 
 finish-args:
   - '--device=dri'
+  - '--filesystem=home'
+  - '--filesystem=/media'
+  - '--filesystem=/run/media'
   - '--share=ipc'
+  - '--share=network'
   - '--socket=fallback-x11'
   - '--socket=wayland'
-  - '--share=network'
+  - '--talk-name=org.freedesktop.FileManager1'
 
 modules:
   - name: canberra

--- a/meson.build
+++ b/meson.build
@@ -70,7 +70,10 @@ posix_dep = vala.find_library('posix')
 linux_dep = vala.find_library('linux')
 math_dep = cc.find_library('m')
 
-plank_dep = dependency('plank', version: '>=0.10.9')
+plank_dep = dependency('plank', version: '>=0.10.9', required: get_option('with-plank'))
+if (plank_dep.found())
+    add_project_arguments('--define=HAVE_PLANK', language: 'vala')
+endif
 
 zeitgeist_dep = dependency('zeitgeist-2.0', required: get_option('with-zeitgeist'))
 if (zeitgeist_dep.found())
@@ -121,6 +124,5 @@ subdir('po')
 
 gnome.post_install(
     glib_compile_schemas: true,
-    gtk_update_icon_cache: true,
     update_desktop_database: true
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
+option('with-plank', type : 'feature', value : 'auto', description : 'Use Plank poof window')
 option('with-zeitgeist', type : 'feature', value : 'auto', description : 'Add Zeitgeist support')
 option('systemduserunitdir', type: 'string', value: '', description: 'custom directory for systemd user units, or \'no\' to disable')

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -376,9 +376,11 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
                     var device = ctx.get_device ();
                     int x, y;
                     device.get_position (null, out x, out y);
+#if HAVE_PLANK
                     Plank.PoofWindow poof_window;
                     poof_window = Plank.PoofWindow.get_default ();
                     poof_window.show_at (x, y);
+#endif
                     return true;
                 }
             }


### PR DESCRIPTION
Just kind of an experiment to see what's missing/broken and if it could ever make sense to ship Files in a flatpak

Things to do:
- [ ] Not depend on LibPlank. Plank is going away anyways with the new dock. If the poofwindow is a pattern we want to keep we should move that into Granite probably or move it here for now
- [ ] `error: Name in service file /files/build/export/share/dbus-1/services/io.elementary.files.service does not match app id: io.elementary.files.db`
- [ ] No icon cache in the container? Why are we messing with the icon cache anyways :thinking: 
- [ ] `Icon not matching app id in /home/dani/Projects/files/build/export/share/applications/io.elementary.files.desktop: system-file-manager`
- [ ] `io.elementary.files.Filemanager1.service` is not an allowed file name?

Portal issues:
- [ ] `Not exporting share/dbus-1/services/org.freedesktop.impl.portal.desktop.elementary.files.service, non-allowed export filename`
- [ ] `../filechooser-portal/meson.build:29:4: ERROR: Assert failed: systemd required but not found, please provide a valid systemd user unit dir or disable it`