### PR TITLE
Control: add desktop-file-utils

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: x11
 Priority: optional
 Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
+               desktop-file-utils,
                gettext,
                gnome-common,
                libcanberra-dev (>= 0.30),


### PR DESCRIPTION
See: https://launchpadlibrarian.net/683369241/buildlog_ubuntu-jammy-amd64.pantheon-files_6.5.0+r6004+pkg121~ubuntu7.1_BUILDING.txt.gz

Looks like we need desktop-file-utils to use the meson GNOME module's `update-desktop-database` action