### PR TITLE
meson: Don't run gtk-update-icon-cache

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -121,6 +121,5 @@ subdir('po')
 
 gnome.post_install(
     glib_compile_schemas: true,
-    gtk_update_icon_cache: true,
     update_desktop_database: true
 )


### PR DESCRIPTION
We install nothing to `$datadir/icons/hicolor` right now, this will be a hard failure for us when using `gnome.post_install()`.

```
Running custom install script '/nix/store/mm252sph4mcfv5z1mls56rmwbpzyijcw-gtk+3-3.24.38/bin/gtk-update-icon-cache -q -t -f /nix/store/bphhkmq3n9jpadh0qrcq6gpp32v7r9rv-elementary-files-6.5.0/share/icons/hicolor'
--- stdout ---

--- stderr ---
gtk-update-icon-cache: Failed to open file /nix/store/bphhkmq3n9jpadh0qrcq6gpp32v7r9rv-elementary-files-6.5.0/share/icons/hicolor/.icon-theme.cache : No such file or directory

FAILED: install script '/nix/store/mm252sph4mcfv5z1mls56rmwbpzyijcw-gtk+3-3.24.38/bin/gtk-update-icon-cache -q -t -f /nix/store/bphhkmq3n9jpadh0qrcq6gpp32v7r9rv-elementary-files-6.5.0/share/icons/hicolor' exit code 1, stopped
FAILED: meson-internal__install 
/nix/store/0a1194i61f8smpdrrqz2xm0g04vq01n3-meson-1.2.0/bin/meson install --no-rebuild
ninja: build stopped: subcommand failed.
```

(I am aware of https://github.com/elementary/files/pull/2293#issuecomment-1691961193, do you wish to do that? `update_desktop_database` probably should be kept as long as we install desktop files though I guess it is mostly useful only for people who build this with non-packaging purpose. For users that install via package manager, we do run `update-desktop-database` in NixOS, but this will be managed as [some "hooks"](https://github.com/NixOS/nixpkgs/blob/d240553dcc2180fe486155bea8a846d5941e168c/nixos/modules/config/xdg/mime.nix#L97))