### PR TITLE
[Crash] Add null file check before updating thumbnail and plugins

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2786,13 +2786,14 @@ namespace Files {
                     while (valid_iter && thumbnail_source_id > 0) {
                         file = model.file_for_iter (iter); // Maybe null if dummy row or file being deleted
                         path = model.get_path (iter);
-
-                        update_thumbnail_info_and_plugins (file);
-                        /* Ask thumbnailer only if ThumbState UNKNOWN */
-                        if (file.thumbstate == Files.File.ThumbState.UNKNOWN) {
-                            visible_files.prepend (file);
-                            if (path.compare (sp) >= 0 && path.compare (ep) <= 0) {
-                                actually_visible++;
+                        if (file != null) {
+                            update_thumbnail_info_and_plugins (file);
+                            /* Ask thumbnailer only if ThumbState UNKNOWN */
+                            if (file.thumbstate == Files.File.ThumbState.UNKNOWN) {
+                                visible_files.prepend (file);
+                                if (path.compare (sp) >= 0 && path.compare (ep) <= 0) {
+                                    actually_visible++;
+                                }
                             }
                         }
                         /* check if we've reached the end of the visible range */


### PR DESCRIPTION
Fixes #2315

Restores a null check that was accidentally removed by b1cecbbe39a70499b22c0f092a6e8c45c1bd25ae, causing this regression. 

