### PR TITLE
[Crash] Fix opening Files with xdg-open , FileManager1 or shortcut

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -517,7 +517,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     public async void open_tabs (
-        GLib.File[]? files,
+        owned GLib.File[]? files,
         ViewMode mode = default_mode,
         bool ignore_duplicate
     ) {


### PR DESCRIPTION
Fixes #2320 

Now open_tabs is async, we have to make sure that the list of files passed to it persists after the calling function ends.