### PR TITLE
[Crash] Check tab created before expand miller view

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1233,10 +1233,16 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
             if (yield add_tab_by_uri (root_uri, mode)) {
                 restoring_tabs++;
-            }
 
-            if (mode == ViewMode.MILLER_COLUMNS && tip_uri != root_uri) {
-                expand_miller_view (tip_uri, root_uri);
+                var tab = tab_view.selected_page;
+
+                if (tab != null &&
+                    mode == ViewMode.MILLER_COLUMNS &&
+                    tip_uri != root_uri) {
+
+                    var miller = (Miller)((ViewContainer)(tab.child)).view;
+                    expand_miller_view (miller, tip_uri, root_uri);
+                }
             }
 
             mode = ViewMode.INVALID;
@@ -1273,11 +1279,8 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         return restoring_tabs;
     }
 
-    private void expand_miller_view (string tip_uri, string unescaped_root_uri) {
+    private void expand_miller_view (Miller miller_view, string tip_uri, string unescaped_root_uri) {
         /* It might be more elegant for Miller.vala to handle this */
-        var tab = tab_view.selected_page;
-        var view = (ViewContainer)(tab.child);
-        var mwcols = (Miller)(view.view) ;
         var unescaped_tip_uri = FileUtils.sanitize_path (tip_uri);
 
         if (unescaped_tip_uri == null) {
@@ -1298,7 +1301,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                 uri += (GLib.Path.DIR_SEPARATOR_S + dir);
                 gfile = get_file_from_uri (uri);
 
-                mwcols.add_location (gfile, mwcols.current_slot); // MillerView can deal with multiple scroll requests
+                miller_view.add_location (gfile, miller_view.current_slot); // MillerView can deal with multiple scroll requests
             }
         } else {
             warning ("Invalid tip uri for Miller View %s", unescaped_tip_uri);

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1233,16 +1233,18 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
             if (yield add_tab_by_uri (root_uri, mode)) {
                 restoring_tabs++;
-
                 var tab = tab_view.selected_page;
-
                 if (tab != null &&
-                    mode == ViewMode.MILLER_COLUMNS &&
+                    tab.child != null &&
                     tip_uri != root_uri) {
 
-                    var miller = (Miller)((ViewContainer)(tab.child)).view;
-                    expand_miller_view (miller, tip_uri, root_uri);
+                    var view = ((ViewContainer)(tab.child)).view;
+                    if (view != null && view is Miller) {
+                        expand_miller_view ((Miller)view, tip_uri, root_uri);
+                    }
                 }
+            } else {
+                debug ("Failed to restore tab %s", root_uri);
             }
 
             mode = ViewMode.INVALID;


### PR DESCRIPTION
Fixes #2330 (see https://github.com/elementary/files/issues/2330#issuecomment-1752115655)

 - Do not attempt to expand miller view unless adding tab succeeds

Adds several extra checks to ensure that `expand_miller_view` is only called with valid parameters.

The issue can be reproduced by attempting to restore a disconnected location into a Column View.