### PR TITLE
Fix scroll to bottom after rename.

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3423,7 +3423,14 @@ namespace Files {
             /* new_file will be null if rename failed */
             if (new_file != null) {
                 selected_files_invalid = true;
-                select_and_scroll_to_gof_file (new_file);
+                Idle.add (() => {
+                    if (model.sort_pending) {
+                        return Source.CONTINUE;
+                    } else {
+                        select_and_scroll_to_gof_file (new_file);
+                        return Source.REMOVE;
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
Fixes #2325 

 - Do not scroll to renamed file until model has resorted.

Because resorting of the model is now throttled and delayed it is necessary to delay selecting and scrolling to the renamed file until the model has resorted else the incorrect path may be scrolled to.  This PR simply idles while a sort is pending rather than introducing a signal and handler.