### PR TITLE
Save selection for all slots that will reload

### DIFF
--- a/src/View/DirectoryNotFound.vala
+++ b/src/View/DirectoryNotFound.vala
@@ -54,7 +54,7 @@ namespace Files.View {
                 }
 
                 if (success) {
-                    ctab.reload ();
+                    get_action_group ("win").activate_action ("refresh", null);
                 }
             });
 

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -181,6 +181,7 @@ namespace Files.View {
 
         private void on_directory_need_reload (Directory dir, bool original_request) {
             if (!is_frozen) {
+                ctab.prepare_reload (); // Save selection
                 dir_view.prepare_reload (dir); /* clear model but do not change directory */
                 /* view and slot are unfrozen when done loading signal received */
                 is_frozen = true;

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -531,11 +531,18 @@ namespace Files.View {
             return path;
         }
 
-        public void reload () {
+        // Saves selected locations to be restored after reloading
+        // Called by all slots that will reload
+        public AbstractSlot? prepare_reload () {
             var slot = get_current_slot ();
             if (slot != null) {
-                slot.reload ();
+                selected_locations = null;
+                foreach (Files.File file in slot.get_selected_files ()) {
+                    selected_locations.prepend (file.location);
+                }
             }
+
+            return slot;
         }
 
         public Gee.List<string> get_go_back_path_list () {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -856,7 +856,12 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             warning ("Too rapid reloading suppressed");
             return;
         }
-        current_container.reload ();
+
+        var slot = current_container.prepare_reload ();
+        if (slot != null) {
+            slot.reload (); // Initial reload request - will propagate to all alots showing same location
+        }
+
         sidebar.reload ();
     }
 
@@ -1031,7 +1036,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
     public void after_undo_redo () {
         if (current_container.slot.directory.is_recent) {
-            current_container.reload ();
+            get_action_group ("win").activate_action ("refresh", null);
         }
 
         doing_undo_redo = false;


### PR DESCRIPTION
Fixes #2328 

 - Adds a `prepare_reload ()` function to ViewContainer that saves the current selection
 - Every slot that will reload calls `prepare_reload ()` before clearing model.
 - All refresh operations initiated with `win.refresh` action


Now slots opened at the same location in different tabs/windows with different selections will all refresh and keep their selection.