### PR TITLE
[Feature] Allow hiding any file

### DIFF
--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -809,8 +809,18 @@ public class Files.Directory : Object {
         }
     }
 
+    // Called by Model when loading a subdirectory
     public List<unowned Files.File> get_files () {
-        return file_hash.get_values ();
+        List<unowned Files.File> file_list = null;
+        foreach (unowned Files.File gof in file_hash.get_values ()) {
+            if (gof != null && gof.info != null &&
+                (!gof.is_hidden || Preferences.get_default ().show_hidden_files)) {
+
+                file_list.prepend (gof);
+            }
+        }
+
+        return file_list;
     }
 
     public void load_hiddens () {

--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -35,7 +35,7 @@ public class Files.File : GLib.Object {
         "standard::is-hidden,standard::is-backup,standard::is-symlink,standard::type,standard::name," +
         "standard::display-name,standard::content-type,standard::fast-content-type,standard::size," +
         "standard::symlink-target,standard::target-uri,access::*,time::*,owner::*,trash::*,unix::*,id::filesystem," +
-        "thumbnail::*,mountable::*,metadata::marlin-sort-column-id,metadata::marlin-sort-reversed";
+        "thumbnail::*,mountable::*,metadata::marlin-sort-column-id,metadata::marlin-sort-reversed,metadata::hidden";
 
     public signal void changed ();
     public signal void icon_changed ();
@@ -78,8 +78,8 @@ public class Files.File : GLib.Object {
         get {
             return is_hidden_format ||
                 (info != null &&
-                info.has_attribute ("standard::is-hidden") &&
-                info.get_attribute_boolean ("standard::is-hidden"));
+                info.has_attribute ("metadata::hidden") &&
+                bool.parse (info.get_attribute_string ("metadata::hidden")));
         }
     }
     public bool is_hidden_format { get; construct; }
@@ -189,7 +189,7 @@ public class Files.File : GLib.Object {
             }
         });
 
-        // Filename formats to regard as permanently hidden 
+        // Filename formats to regard as permanently hidden
         is_hidden_format = basename.has_prefix (".") ||
                            basename.has_prefix ("~") ||
                            basename.has_suffix ("~"); // Temporary backup files are regarded as hidden

--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -74,7 +74,12 @@ public class Files.File : GLib.Object {
     public int sort_column_id = Files.ListModel.ColumnID.FILENAME;
     public Gtk.SortType sort_order = Gtk.SortType.ASCENDING;
     public GLib.FileType file_type;
-    public bool is_hidden { get; construct; }
+    public bool is_hidden {
+        get {
+            return is_hidden_format || (info != null && info.has_attribute ("metadata::hidden"));
+        }
+    }
+    public bool is_hidden_format { get; construct; }
     public bool is_directory = false;
     public bool is_desktop = false;
     public bool is_expanded = false;
@@ -181,11 +186,9 @@ public class Files.File : GLib.Object {
             }
         });
 
-        // We do not allow "hidden" status to change as this causes problems with
-        // adding/removing files from view model
-        is_hidden = basename.has_prefix (".") || // Linux hidden file
-                    basename.has_prefix ("~") ||
-                    basename.has_suffix ("~"); // Temporary backup files are regarded as hidden
+        is_hidden_format = basename.has_prefix (".") || // Linux hidden file
+                            basename.has_prefix ("~") ||
+                            basename.has_suffix ("~"); // Temporary backup files are regarded as hidden
     }
 
     public void remove_from_caches () {

--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -76,7 +76,10 @@ public class Files.File : GLib.Object {
     public GLib.FileType file_type;
     public bool is_hidden {
         get {
-            return is_hidden_format || (info != null && info.has_attribute ("metadata::hidden"));
+            return is_hidden_format ||
+                (info != null &&
+                info.has_attribute ("standard::is-hidden") &&
+                info.get_attribute_boolean ("standard::is-hidden"));
         }
     }
     public bool is_hidden_format { get; construct; }
@@ -186,9 +189,10 @@ public class Files.File : GLib.Object {
             }
         });
 
-        is_hidden_format = basename.has_prefix (".") || // Linux hidden file
-                            basename.has_prefix ("~") ||
-                            basename.has_suffix ("~"); // Temporary backup files are regarded as hidden
+        // Filename formats to regard as permanently hidden 
+        is_hidden_format = basename.has_prefix (".") ||
+                           basename.has_prefix ("~") ||
+                           basename.has_suffix ("~"); // Temporary backup files are regarded as hidden
     }
 
     public void remove_from_caches () {

--- a/libcore/ListModel.vala
+++ b/libcore/ListModel.vala
@@ -59,7 +59,6 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
         }
     }
 
-    public bool show_hidden_files { get; set; default = false; }
 
     private enum PrivColumnID {
         DUMMY = ColumnID.NUM_COLUMNS
@@ -314,9 +313,6 @@ public class Files.ListModel : Gtk.TreeStore, Gtk.TreeModel {
 
             set_sorting_off ();
             foreach (var file in files) {
-                if (!show_hidden_files && file.is_hidden) {
-                    continue;
-                }
 
                 if (change_dummy) {
                     // Instead of inserting a new row, change the dummy one

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1144,8 +1144,7 @@ namespace Files {
         }
 
         private void on_selection_action_mark_as_hidden (GLib.SimpleAction action, GLib.Variant? param) {
-
-            bool hide = param.get_boolean ();
+            var hide = param.get_boolean ();
             unowned var selection = get_selected_files ();
             foreach (File file in selection) {
                 if (hide && !file.info.has_attribute ("metadata::hidden")) {
@@ -1154,6 +1153,12 @@ namespace Files {
                     file.info.remove_attribute ("metadata::hidden");
                 }
             }
+
+            // If not showing hidden files reload view to reflect changes
+            if (!Files.Preferences.get_default ().show_hidden_files) {
+                on_show_hidden_files_changed ();
+            }
+
         }
 
         private void on_selection_action_trash (GLib.SimpleAction action, GLib.Variant? param) {
@@ -1467,8 +1472,8 @@ namespace Files {
         }
 
     /** Handle Preference changes */
-        private void on_show_hidden_files_changed (GLib.Object prefs, GLib.ParamSpec pspec) {
-            bool show = ((Files.Preferences) prefs).show_hidden_files;
+        private void on_show_hidden_files_changed () {
+            bool show = ((Files.Preferences).get_default ()).show_hidden_files;
             cancel ();
             /* As directory may reload, for consistent behaviour always lose selection */
             unselect_all ();

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1469,21 +1469,16 @@ namespace Files {
     /** Handle Preference changes */
         private void on_show_hidden_files_changed (GLib.Object prefs, GLib.ParamSpec pspec) {
             bool show = ((Files.Preferences) prefs).show_hidden_files;
-            model.show_hidden_files = show;
             cancel ();
             /* As directory may reload, for consistent behaviour always lose selection */
             unselect_all ();
 
-            if (!show) {
-                block_model ();
-                model.clear ();
-            }
+            block_model ();
+            model.clear ();
 
             directory_hidden_changed (slot.directory, show);
 
-            if (!show) {
-                unblock_model ();
-            }
+            unblock_model ();
 
             foreach (Files.File file in slot.directory.get_files ()) {
                 if (file.is_folder ()) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1147,10 +1147,10 @@ namespace Files {
             var hide = param.get_boolean ();
             unowned var selection = get_selected_files ();
             foreach (File file in selection) {
-                if (hide && !file.info.has_attribute ("metadata::hidden")) {
-                    file.info.set_attribute_string ("metadata::hidden", "true");
-                } else if (!hide && file.info.has_attribute ("metadata::hidden")) {
-                    file.info.remove_attribute ("metadata::hidden");
+                if (hide && !file.is_hidden_format && !file.info.has_attribute ("standard::is-hidden")) {
+                    file.info.set_attribute_boolean ("standard::is-hidden", true);
+                } else if (!hide && file.info.has_attribute ("standard::is-hidden")) {
+                    file.info.set_attribute_boolean ("standard::is-hidden", false);
                 }
             }
 
@@ -2151,16 +2151,22 @@ namespace Files {
                     action_name = "selection.mark-as-hidden"
                 };
 
-                bool some_not_hidden = false;
+                bool some_not_hidden = false, some_permanently_hidden = false;
                 foreach (File file in selection) {
                     if (!file.is_hidden) {
                         some_not_hidden = true;
+                    }
+
+                    if (file.is_hidden_format) {
+                        some_permanently_hidden = true;
                     }
                 }
 
                 var val = new GLib.Variant.boolean (some_not_hidden);
                 mark_as_hidden_menuitem.action_target = val;
                 mark_as_hidden_menuitem.label = some_not_hidden ? _("Mark as Hidden") : _("Unmark as Hidden");
+
+                action_set_enabled (selection_actions, "mark-as-hidden", !some_permanently_hidden);
 
                 /* In trash, only show context menu when all selected files are in root folder */
                 if (in_trash && valid_selection_for_restore ()) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1147,11 +1147,17 @@ namespace Files {
             var hide = param.get_boolean ();
             unowned var selection = get_selected_files ();
             foreach (File file in selection) {
-                if (hide && !file.is_hidden_format && !file.info.has_attribute ("standard::is-hidden")) {
-                    file.info.set_attribute_boolean ("standard::is-hidden", true);
-                } else if (!hide && file.info.has_attribute ("standard::is-hidden")) {
-                    file.info.set_attribute_boolean ("standard::is-hidden", false);
+                bool val = false;
+                if (hide && !file.is_hidden) {
+                    val = true;
+                } else if (!hide && !file.is_hidden_format) {
+                    val = false;
+                } else {
+                    continue;
                 }
+
+                file.info.set_attribute_string ("metadata::hidden", val.to_string ());
+                file.location.set_attribute_string ("metadata::hidden", val.to_string (), FileQueryInfoFlags.NONE, null);
             }
 
             // If not showing hidden files reload view to reflect changes

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1157,7 +1157,12 @@ namespace Files {
                 }
 
                 file.info.set_attribute_string ("metadata::hidden", val.to_string ());
-                file.location.set_attribute_string ("metadata::hidden", val.to_string (), FileQueryInfoFlags.NONE, null);
+                try {
+                    file.location.set_attribute_string ("metadata::hidden", val.to_string (), FileQueryInfoFlags.NONE, null);
+                } catch (Error e) {
+                    warning ("Error setting attribute 'metadata::hidden' - %s", e.message);
+                }
+
             }
 
             // If not showing hidden files reload view to reflect changes

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2147,30 +2147,20 @@ namespace Files {
                 };
                 delete_menuitem.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
-                var mark_as_hidden_menuitem = new Gtk.CheckMenuItem () {
+                var mark_as_hidden_menuitem = new Gtk.MenuItem () {
                     action_name = "selection.mark-as-hidden"
                 };
 
-                bool all_hidden = true, all_not_hidden = true, inconsistent = true;
+                bool some_not_hidden = false;
                 foreach (File file in selection) {
-                    var hidden = false;
-                    if (file.info.has_attribute ("metadata::hidden")) {
-                        hidden = bool.parse (file.info.get_attribute_string ("metadata::hidden"));
-                    }
-
-                    all_hidden = all_hidden && hidden;
-                    all_not_hidden = all_not_hidden && !hidden;
-                    inconsistent = !all_hidden && !all_not_hidden;
-                    if (inconsistent) {
-                        break;
+                    if (!file.is_hidden) {
+                        some_not_hidden = true;
                     }
                 }
 
-                var val = new GLib.Variant.boolean (!all_hidden);
-                mark_as_hidden_menuitem.set_active (all_hidden);
-                mark_as_hidden_menuitem.set_inconsistent (inconsistent);
+                var val = new GLib.Variant.boolean (some_not_hidden);
                 mark_as_hidden_menuitem.action_target = val;
-                mark_as_hidden_menuitem.label = all_hidden ? _("Unmark as Hidden") : _("Mark as Hidden");
+                mark_as_hidden_menuitem.label = some_not_hidden ? _("Mark as Hidden") : _("Unmark as Hidden");
 
                 /* In trash, only show context menu when all selected files are in root folder */
                 if (in_trash && valid_selection_for_restore ()) {


### PR DESCRIPTION
Fixes #2345 

 - Add a selection menuitem to set/unset a new "metadata::hidden" file attribute
 - Prevent altering hidden status of certain filename formats
 - Make consequential changes to handling of hidden files in ListModel, File and Directory to allow hidden state to change after File construction.

Could not use `standard::is-hidden` because this attribute is not writable so the tag could not persist.