### PR TITLE
Fix unexpected selection after file added

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -945,9 +945,13 @@ namespace Files {
         // file operations
         private void add_file (Files.File file, Directory dir, bool is_internal = true) {
             model.insert_sorted (file, dir);
-
             if (is_internal) { /* This true once view finished loading */
-                add_gof_file_to_selection (file);
+                // Do not select until the model has resorted else wrong file is selected
+                ulong model_resorted = 0;
+                model_resorted = model.rows_reordered.connect (() => {
+                     model.disconnect (model_resorted);
+                     add_gof_file_to_selection (file);
+                });
             }
         }
 


### PR DESCRIPTION
Fixes #2357

For performance reasons, resorting the model after adding files was throttled in a previous commit.  So files should not be added to the selection until the model has resorted else the wrong file may be selected.

It was noted that adding and, in particular, removing files does not scale well but that will need to be addressed later, maybe after porting to Gtk4.