### PR TITLE
Support .hidden file

### DIFF
--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -761,7 +761,7 @@ public class Files.Directory : Object {
     }
 
     private void after_load_file (Files.File gof, bool show_hidden, FileLoadedFunc? file_loaded_func) {
-        if (!gof.is_hidden || show_hidden) {
+        if (show_hidden || !(gof.is_hidden || gof.info.get_is_hidden ())) {
             displayed_files_count++;
 
             if (file_loaded_func == null) {


### PR DESCRIPTION
Fixes #2345 

There is no UI to add files to a `.hidden` file in this PR so it is not discoverable within the app.  That can be added later if thought necessary.

Uses the built in functionality of Gio to search a `.hidden` file in the current directory so only supports exact filename matches.