### PR TITLE
[Gtk4Prep] Treeviews cleanup and Gtk4 prep

### DIFF
--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -32,6 +32,7 @@ namespace Files {
         public Gdk.Rectangle hover_helper_rect;
         public Gdk.Rectangle hover_rect;
         public int lpad {get; set; default = 0;}
+        public bool show_emblems { get; set; default = true; }
         public Files.File? drop_file {get; set;}
 
         public ZoomLevel zoom_level {
@@ -63,7 +64,7 @@ namespace Files {
         private int h_overlap; // Horizontal overlap between helper and icon
         private int v_overlap; // Vertical overlap between helper and icon
         private int helper_size;
-        private bool show_emblems;
+
         private ZoomLevel _zoom_level = ZoomLevel.NORMAL;
         private Files.File? _file;
         private Files.IconSize icon_size;
@@ -82,10 +83,6 @@ namespace Files {
             hover_helper_rect = {0, 0, (int) Files.IconSize.EMBLEM, (int) Files.IconSize.EMBLEM};
         }
 
-        public IconRenderer (ViewMode view_mode) {
-            show_emblems = view_mode == ViewMode.ICON;
-            xpad = 0;
-        }
 
         public override void render (Cairo.Context cr, Gtk.Widget widget, Gdk.Rectangle background_area,
                                      Gdk.Rectangle cell_area, Gtk.CellRendererState flags) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3981,25 +3981,6 @@ namespace Files {
             scroll_to_path (path, scroll_to_top);
         }
 
-        protected virtual Settings? get_view_settings () { return null; }
-        protected virtual void set_up_zoom_level () {
-            var view_settings = get_view_settings ();
-            if (view_settings == null) {
-                return;
-            }
-
-            minimum_zoom = (ZoomLevel)view_settings.get_enum ("minimum-zoom-level");
-            maximum_zoom = (ZoomLevel)view_settings.get_enum ("maximum-zoom-level");
-            zoom_level = (ZoomLevel)view_settings.get_enum ("zoom-level");
-
-            view_settings.bind (
-                "zoom-level",
-                this, "zoom-level",
-                GLib.SettingsBindFlags.SET
-            );
-        }
-
-
 /** Abstract methods - must be overridden*/
         public abstract GLib.List<Gtk.TreePath> get_selected_paths () ;
         public abstract Gtk.TreePath? get_path_at_pos (int x, int win);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3957,6 +3957,25 @@ namespace Files {
             scroll_to_path (path, scroll_to_top);
         }
 
+        protected virtual Settings? get_settings () { return null; }
+        protected virtual void set_up_zoom_level () {
+            var view_settings = get_settings ();
+            if (view_settings == null) {
+                return;
+            }
+
+            minimum_zoom = (ZoomLevel)view_settings.get_enum ("minimum-zoom-level");
+            maximum_zoom = (ZoomLevel)view_settings.get_enum ("maximum-zoom-level");
+            zoom_level = (ZoomLevel)view_settings.get_enum ("zoom-level");
+
+            view_settings.bind (
+                "zoom-level",
+                this, "zoom-level",
+                GLib.SettingsBindFlags.SET
+            );
+        }
+
+
 /** Abstract methods - must be overridden*/
         public abstract GLib.List<Gtk.TreePath> get_selected_paths () ;
         public abstract Gtk.TreePath? get_path_at_pos (int x, int win);
@@ -4001,7 +4020,7 @@ namespace Files {
         protected virtual bool handle_multi_select (Gtk.TreePath path) {return false;}
 
         protected abstract Gtk.Widget? create_view ();
-        protected abstract void set_up_zoom_level ();
+
         protected abstract ZoomLevel get_normal_zoom_level ();
         protected abstract uint get_event_position_info (Gdk.EventButton event,
                                                          out Gtk.TreePath? path,

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -427,12 +427,12 @@ namespace Files {
         }
 
         public void zoom_normal () {
-            var view_settings = get_settings ();
+            var view_settings = get_view_settings ();
             if (view_settings == null) {
                 return;
             }
 
-            zoom_level = view_settings.get_enum ("default-zoom-level"); // syncs to settings
+            zoom_level = (ZoomLevel)view_settings.get_enum ("default-zoom-level"); // syncs to settings
         }
 
         private uint set_cursor_timeout_id = 0;
@@ -3962,9 +3962,9 @@ namespace Files {
             scroll_to_path (path, scroll_to_top);
         }
 
-        protected virtual Settings? get_settings () { return null; }
+        protected virtual Settings? get_view_settings () { return null; }
         protected virtual void set_up_zoom_level () {
-            var view_settings = get_settings ();
+            var view_settings = get_view_settings ();
             if (view_settings == null) {
                 return;
             }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3862,7 +3862,7 @@ namespace Files {
             return true;
         }
 
-        protected virtual bool handle_default_button_click (Gdk.EventButton event) {
+        protected virtual bool handle_default_button_click (Gdk.Event event) {
             /* pass unhandled events to the View.Window */
             return false;
         }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3922,9 +3922,40 @@ namespace Files {
             update_selected_files_and_menu ();
         }
 
+        protected uint get_selected_files_from_model (out GLib.List<Files.File> selected_files) {
+            List<Files.File> list = null;
+            uint count = 0;
+            var selected_paths = get_selected_paths ();
+            foreach (var path in selected_paths) {
+                var file = model.file_for_path (path);
+                if (file != null) {
+                    list.prepend ((owned)file);
+                    count++;
+                } else {
+                    critical ("Null file in model");
+                }
+            }
+            selected_files = (owned)list;
+            return count;
+        }
+
         public virtual void highlight_path (Gtk.TreePath? path) {}
         protected virtual Gtk.TreePath up (Gtk.TreePath path) {path.up (); return path;}
         protected virtual Gtk.TreePath down (Gtk.TreePath path) {path.down (); return path;}
+
+        protected virtual bool view_has_focus () {
+            return view.has_focus;
+        }
+
+        protected virtual void scroll_to_cell (Gtk.TreePath? path, bool scroll_to_top) {
+            if (path == null || slot == null || slot.directory == null ||
+                slot.directory.permission_denied || slot.directory.is_empty ()) {
+
+                return;
+            }
+
+            scroll_to_path (path, scroll_to_top);
+        }
 
 /** Abstract methods - must be overridden*/
         public abstract GLib.List<Gtk.TreePath> get_selected_paths () ;
@@ -3942,6 +3973,7 @@ namespace Files {
                                          bool select,
                                          bool scroll_to_top);
 
+        protected abstract void scroll_to_path (Gtk.TreePath path, bool scroll_to_top);
         /* By default use the native widget cursor handling by returning false */
         protected virtual bool move_cursor (uint keyval, bool only_shift_pressed, bool control_pressed) {
             return false;
@@ -3971,14 +4003,10 @@ namespace Files {
         protected abstract Gtk.Widget? create_view ();
         protected abstract void set_up_zoom_level ();
         protected abstract ZoomLevel get_normal_zoom_level ();
-        protected abstract bool view_has_focus ();
-        protected abstract uint get_selected_files_from_model (out GLib.List<Files.File> selected_files);
         protected abstract uint get_event_position_info (Gdk.EventButton event,
                                                          out Gtk.TreePath? path,
                                                          bool rubberband = false);
 
-        protected abstract void scroll_to_cell (Gtk.TreePath? path,
-                                                bool scroll_to_top);
         protected abstract void set_cursor_on_cell (Gtk.TreePath path,
                                                     Gtk.CellRenderer renderer,
                                                     bool start_editing,

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3471,7 +3471,7 @@ namespace Files {
             return false;
         }
 
-        protected virtual bool handle_primary_button_click (Gdk.EventButton event, Gtk.TreePath? path) {
+        protected virtual bool handle_primary_button_click (Gdk.Event event, Gtk.TreePath? path) {
             return true;
         }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -427,7 +427,12 @@ namespace Files {
         }
 
         public void zoom_normal () {
-            zoom_level = get_normal_zoom_level ();
+            var view_settings = get_settings ();
+            if (view_settings == null) {
+                return;
+            }
+
+            zoom_level = view_settings.get_enum ("default-zoom-level"); // syncs to settings
         }
 
         private uint set_cursor_timeout_id = 0;
@@ -4021,7 +4026,6 @@ namespace Files {
 
         protected abstract Gtk.Widget? create_view ();
 
-        protected abstract ZoomLevel get_normal_zoom_level ();
         protected abstract uint get_event_position_info (Gdk.EventButton event,
                                                          out Gtk.TreePath? path,
                                                          bool rubberband = false);

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -30,7 +30,21 @@ namespace Files {
             debug ("ATV destruct");
         }
 
-        protected virtual void create_and_set_up_name_column () {
+        protected override void connect_tree_signals () {
+            tree.get_selection ().changed.connect (on_view_selection_changed);
+        }
+        protected override void disconnect_tree_signals () {
+            tree.get_selection ().changed.disconnect (on_view_selection_changed);
+        }
+
+        protected override Gtk.Widget? create_view () {
+            tree = new Files.TreeView () {
+                model = model,
+                headers_visible = false,
+                rubber_banding = true
+            };
+            tree.get_selection ().set_mode (Gtk.SelectionMode.MULTIPLE);
+
             name_column = new Gtk.TreeViewColumn () {
                 sort_column_id = Files.ListModel.ColumnID.FILENAME,
                 expand = true,
@@ -38,8 +52,18 @@ namespace Files {
             };
 
             name_renderer = new Files.TextRenderer (ViewMode.LIST);
-            set_up_name_renderer ();
-            set_up_icon_renderer ();
+            name_renderer.@set ("wrap-width", -1);
+            name_renderer.@set ("zoom-level", ZoomLevel.NORMAL);
+            name_renderer.@set ("ellipsize-set", true);
+            name_renderer.@set ("ellipsize", Pango.EllipsizeMode.END);
+            name_renderer.xalign = 0.0f;
+            name_renderer.yalign = 0.5f;
+
+            icon_renderer = new IconRenderer () {
+                show_emblems = false,
+                lpad = 6
+            };
+
             var emblem_renderer = new Files.EmblemRenderer ();
             emblem_renderer.yalign = 0.5f;
 
@@ -58,46 +82,14 @@ namespace Files {
                                         "file", Files.ListModel.ColumnID.FILE_COLUMN);
 
             tree.append_column (name_column);
-        }
 
-        protected abstract void set_up_icon_renderer ();
 
-        protected void set_up_view () {
             connect_tree_signals ();
             tree.realize.connect ((w) => {
                 tree.grab_focus ();
                 tree.columns_autosize ();
                 tree.zoom_level = zoom_level;
             });
-        }
-
-        protected override void set_up_name_renderer () {
-            base.set_up_name_renderer ();
-            name_renderer.@set ("wrap-width", -1);
-            name_renderer.@set ("zoom-level", ZoomLevel.NORMAL);
-            name_renderer.@set ("ellipsize-set", true);
-            name_renderer.@set ("ellipsize", Pango.EllipsizeMode.END);
-            name_renderer.xalign = 0.0f;
-            name_renderer.yalign = 0.5f;
-        }
-
-        protected override void connect_tree_signals () {
-            tree.get_selection ().changed.connect (on_view_selection_changed);
-        }
-        protected override void disconnect_tree_signals () {
-            tree.get_selection ().changed.disconnect (on_view_selection_changed);
-        }
-
-        protected override Gtk.Widget? create_view () {
-            tree = new Files.TreeView () {
-                model = model,
-                headers_visible = false,
-                rubber_banding = true
-            };
-
-            tree.get_selection ().set_mode (Gtk.SelectionMode.MULTIPLE);
-            create_and_set_up_name_column ();
-            set_up_view ();
 
             return tree as Gtk.Widget;
         }

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -51,40 +51,46 @@ namespace Files {
                 resizable = true
             };
 
-            name_renderer = new Files.TextRenderer (ViewMode.LIST);
-            name_renderer.@set ("wrap-width", -1);
-            name_renderer.@set ("zoom-level", ZoomLevel.NORMAL);
-            name_renderer.@set ("ellipsize-set", true);
-            name_renderer.@set ("ellipsize", Pango.EllipsizeMode.END);
-            name_renderer.xalign = 0.0f;
-            name_renderer.yalign = 0.5f;
+            name_renderer = new Files.TextRenderer (ViewMode.LIST) {
+                wrap_width = -1,
+                zoom_level = NORMAL,
+                ellipsize_set = true,
+                ellipsize = END,
+                xalign = 0.0f,
+                yalign = 0.5f
+            };
 
             icon_renderer = new IconRenderer () {
                 show_emblems = false,
                 lpad = 6
             };
 
-            var emblem_renderer = new Files.EmblemRenderer ();
-            emblem_renderer.yalign = 0.5f;
+            var emblem_renderer = new Files.EmblemRenderer () {
+                yalign = 0.5f
+            };
 
             name_column.pack_start (icon_renderer, false);
             name_column.set_attributes (icon_renderer,
                                         "file", Files.ListModel.ColumnID.FILE_COLUMN);
 
             name_column.pack_start (name_renderer, true);
-            name_column.set_attributes (name_renderer,
-                                        "text", Files.ListModel.ColumnID.FILENAME,
-                                        "file", Files.ListModel.ColumnID.FILE_COLUMN,
-                                        "background", Files.ListModel.ColumnID.COLOR);
+            name_column.set_attributes (
+                name_renderer,
+                "text", Files.ListModel.ColumnID.FILENAME,
+                "file", Files.ListModel.ColumnID.FILE_COLUMN,
+                "background", Files.ListModel.ColumnID.COLOR
+            );
 
             name_column.pack_start (emblem_renderer, false);
-            name_column.set_attributes (emblem_renderer,
-                                        "file", Files.ListModel.ColumnID.FILE_COLUMN);
+            name_column.set_attributes (
+                emblem_renderer,
+                "file", Files.ListModel.ColumnID.FILE_COLUMN
+            );
 
             tree.append_column (name_column);
 
-
             connect_tree_signals ();
+
             tree.realize.connect ((w) => {
                 tree.grab_focus ();
                 tree.columns_autosize ();

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -172,26 +172,6 @@ namespace Files {
             return tree.get_visible_range (out start_path, out end_path);
         }
 
-        protected override uint get_selected_files_from_model (out GLib.List<Files.File> selected_files) {
-            uint count = 0;
-
-            GLib.List<Files.File> list = null;
-            tree.get_selection ().selected_foreach ((model, path, iter) => {
-                Files.File? file; /* can be null if click on blank row in list view */
-                model.@get (iter, Files.ListModel.ColumnID.FILE_COLUMN, out file, -1);
-                if (file != null) {
-                    list.prepend ((owned) file);
-                    count++;
-                }
-            });
-
-            selected_files = (owned)list;
-            return count;
-        }
-
-        protected override bool view_has_focus () {
-            return tree.has_focus;
-        }
 
         protected override uint get_event_position_info (Gdk.EventButton event,
                                                          out Gtk.TreePath? path,
@@ -284,13 +264,7 @@ namespace Files {
             return zone;
         }
 
-        protected override void scroll_to_cell (Gtk.TreePath? path, bool scroll_to_top) {
-            if (tree == null || path == null || slot == null || slot.directory == null ||
-                slot.directory.permission_denied || slot.directory.is_empty ()) {
-
-                return;
-            }
-
+        protected override void scroll_to_path (Gtk.TreePath path, bool scroll_to_top) {
             tree.scroll_to_cell (path, name_column, scroll_to_top, 0.5f, 0.5f);
         }
 

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -16,388 +16,386 @@
     Authors : Jeremy Wootten <jeremy@elementaryos.org>
 ***/
 
-namespace Files {
-    /* Implement common features of ColumnView and ListView */
-    public abstract class AbstractTreeView : AbstractDirectoryView {
-        protected Files.TreeView tree;
-        protected Gtk.TreeViewColumn name_column;
+/* Implement common features of ColumnView and ListView */
+public abstract class Files.AbstractTreeView : Files.AbstractDirectoryView {
+    protected Files.TreeView tree;
+    protected Gtk.TreeViewColumn name_column;
 
-        protected AbstractTreeView (View.Slot _slot) {
-            base (_slot);
-        }
+    protected AbstractTreeView (View.Slot _slot) {
+        base (_slot);
+    }
 
-        ~AbstractTreeView () {
-            debug ("ATV destruct");
-        }
+    ~AbstractTreeView () {
+        debug ("ATV destruct");
+    }
 
-        protected override void connect_tree_signals () {
-            tree.get_selection ().changed.connect (on_view_selection_changed);
-        }
+    protected override void connect_tree_signals () {
+        tree.get_selection ().changed.connect (on_view_selection_changed);
+    }
 
-        protected override void disconnect_tree_signals () {
-            tree.get_selection ().changed.disconnect (on_view_selection_changed);
-        }
+    protected override void disconnect_tree_signals () {
+        tree.get_selection ().changed.disconnect (on_view_selection_changed);
+    }
 
-        protected override Gtk.Widget? create_view () {
-            tree = new Files.TreeView () {
-                model = model,
-                headers_visible = false,
-                rubber_banding = true
-            };
-            tree.get_selection ().set_mode (Gtk.SelectionMode.MULTIPLE);
+    protected override Gtk.Widget? create_view () {
+        tree = new Files.TreeView () {
+            model = model,
+            headers_visible = false,
+            rubber_banding = true
+        };
+        tree.get_selection ().set_mode (Gtk.SelectionMode.MULTIPLE);
 
-            name_column = new Gtk.TreeViewColumn () {
-                sort_column_id = Files.ListModel.ColumnID.FILENAME,
-                expand = true,
-                resizable = true
-            };
+        name_column = new Gtk.TreeViewColumn () {
+            sort_column_id = Files.ListModel.ColumnID.FILENAME,
+            expand = true,
+            resizable = true
+        };
 
-            name_renderer = new Files.TextRenderer (ViewMode.LIST) {
-                wrap_width = -1,
-                zoom_level = NORMAL,
-                ellipsize_set = true,
-                ellipsize = END,
-                xalign = 0.0f,
-                yalign = 0.5f
-            };
+        name_renderer = new Files.TextRenderer (ViewMode.LIST) {
+            wrap_width = -1,
+            zoom_level = NORMAL,
+            ellipsize_set = true,
+            ellipsize = END,
+            xalign = 0.0f,
+            yalign = 0.5f
+        };
 
-            icon_renderer = new IconRenderer () {
-                show_emblems = false,
-                lpad = 6
-            };
+        icon_renderer = new IconRenderer () {
+            show_emblems = false,
+            lpad = 6
+        };
 
-            var emblem_renderer = new Files.EmblemRenderer () {
-                yalign = 0.5f
-            };
+        var emblem_renderer = new Files.EmblemRenderer () {
+            yalign = 0.5f
+        };
 
-            name_column.pack_start (icon_renderer, false);
-            name_column.set_attributes (
-                icon_renderer,
-                "file", Files.ListModel.ColumnID.FILE_COLUMN
-            );
+        name_column.pack_start (icon_renderer, false);
+        name_column.set_attributes (
+            icon_renderer,
+            "file", Files.ListModel.ColumnID.FILE_COLUMN
+        );
 
-            name_column.pack_start (name_renderer, true);
-            name_column.set_attributes (
-                name_renderer,
-                "text", Files.ListModel.ColumnID.FILENAME,
-                "file", Files.ListModel.ColumnID.FILE_COLUMN,
-                "background", Files.ListModel.ColumnID.COLOR
-            );
+        name_column.pack_start (name_renderer, true);
+        name_column.set_attributes (
+            name_renderer,
+            "text", Files.ListModel.ColumnID.FILENAME,
+            "file", Files.ListModel.ColumnID.FILE_COLUMN,
+            "background", Files.ListModel.ColumnID.COLOR
+        );
 
-            name_column.pack_start (emblem_renderer, false);
-            name_column.set_attributes (
-                emblem_renderer,
-                "file", Files.ListModel.ColumnID.FILE_COLUMN
-            );
+        name_column.pack_start (emblem_renderer, false);
+        name_column.set_attributes (
+            emblem_renderer,
+            "file", Files.ListModel.ColumnID.FILE_COLUMN
+        );
 
-            tree.append_column (name_column);
+        tree.append_column (name_column);
 
-            connect_tree_signals ();
+        connect_tree_signals ();
 
-            tree.realize.connect ((w) => {
-                tree.grab_focus ();
-                tree.columns_autosize ();
-                tree.zoom_level = zoom_level;
-            });
+        tree.realize.connect ((w) => {
+            tree.grab_focus ();
+            tree.columns_autosize ();
+            tree.zoom_level = zoom_level;
+        });
 
-            return tree as Gtk.Widget;
-        }
+        return tree as Gtk.Widget;
+    }
 
-        public override void change_zoom_level () {
-            if (tree != null) {
-                base.change_zoom_level ();
-                tree.columns_autosize ();
-                tree.set_property ("zoom-level", zoom_level);
-            }
-        }
-
-        public override GLib.List<Gtk.TreePath> get_selected_paths () {
-            return tree.get_selection ().get_selected_rows (null);
-        }
-
-        public override void highlight_path (Gtk.TreePath? path) {
-            tree.set_drag_dest_row (path, Gtk.TreeViewDropPosition.INTO_OR_AFTER);
-        }
-
-        public override Gtk.TreePath? get_path_at_pos (int x, int y) {
-            Gtk.TreePath? path = null;
-
-            if (x >= 0 && y >= 0 && tree.get_dest_row_at_pos (x, y, out path, null)) {
-                return path;
-            } else {
-                return null;
-            }
-        }
-
-        public override void tree_select_all () {
-            tree.get_selection ().select_all ();
-        }
-
-        public override void tree_unselect_all () {
-            tree.get_selection ().unselect_all ();
-        }
-
-        /* Avoid using this function with "cursor_follows = true" to select large numbers of files one by one
-         * It would take an exponentially long time. Use "select_files" function in parent class.
-         */
-        public override void select_path (Gtk.TreePath? path, bool cursor_follows = false) {
-            if (path == null) {
-                return;
-            }
-
-            var selection = tree.get_selection ();
-            selection.select_path (path);
-            if (cursor_follows) {
-                /* Unlike for IconView, set_cursor unselects previously selected paths (Gtk bug?),
-                 * so we have to remember them and reselect afterwards */
-                GLib.List<Gtk.TreePath> selected_paths = null;
-                selection.selected_foreach ((m, p, i) => {
-                    selected_paths.prepend (p);
-                });
-                /* Ensure cursor follows last selection */
-                tree.set_cursor (path, null, false); /* This selects path but unselects rest! */
-
-                selected_paths.@foreach ((p) => {
-                   selection.select_path (p);
-                });
-            }
-        }
-        public override void unselect_path (Gtk.TreePath? path) {
-            if (path != null) {
-                tree.get_selection ().unselect_path (path);
-            }
-        }
-
-        public override bool path_is_selected (Gtk.TreePath? path) {
-            if (path != null) {
-                return tree.get_selection ().path_is_selected (path);
-            } else {
-                return false;
-            }
-        }
-
-        public override bool get_visible_range (
-            out Gtk.TreePath? start_path,
-            out Gtk.TreePath? end_path
-        ) {
-            start_path = null;
-            end_path = null;
-            return tree.get_visible_range (out start_path, out end_path);
-        }
-
-        protected override uint get_event_position_info (
-            Gdk.EventButton event,
-            out Gtk.TreePath? path,
-            bool rubberband = false
-        ) {
-            Gtk.TreePath? p = null;
-            unowned Gtk.TreeViewColumn? c = null;
-            uint zone;
-            int cx, cy, depth;
-            path = null;
-
-            var ewindow = event.get_window ();
-            if (ewindow != tree.get_bin_window ()) {
-                return ClickZone.INVALID;
-            }
-
-            double x, y;
-            event.get_coords (out x, out y);
-            tree.get_path_at_pos ((int)x, (int)y, out p, out c, out cx, out cy);
-            path = p;
-            depth = p != null ? p.get_depth () : 0;
-            /* Get rect for whole column; no simple way to get individual renderer sizes? */
-            Gdk.Rectangle rect;
-            tree.get_cell_area (p, c, out rect);
-            int height = rect.height;
-             /* Note: is_blank_at_pos () returns "true" on the whitespace below and
-             * above text pixels, which we do not want. We deal with this later.*/
-            var is_blank = tree.is_blank_at_pos ((int)x, (int)y, null, null, null, null);
-            // Ensure blank area continues across row division
-            is_blank = is_blank || cy < 5 || cy > height - 5;
-
-            /* Do not allow rubberbanding to start except on a row in tree view */
-            zone = (p != null && is_blank ? ClickZone.BLANK_PATH : ClickZone.INVALID);
-
-            if (p != null && c != null && c == name_column) {
-                Files.File? file = model.file_for_path (p);
-
-                if (file == null) {
-                    zone = ClickZone.INVALID;
-                } else {
-                    var rtl = (get_direction () == Gtk.TextDirection.RTL);
-                    // Calculate position of the edge between icon to text renderers
-                    int icon_text_edge;
-                    if (rtl) {
-                        icon_text_edge = tree.get_allocated_width () - rect.x - icon_size - 16;
-                    } else {
-                        icon_text_edge = icon_size + 16;
-                    }
-                    // Calculate whether pointer over icon renderer or text renderer
-                    if (rtl ? cx > icon_text_edge : cx < icon_text_edge) {
-                        // On icon renderer (or expander)
-                        bool on_helper = false;
-                        bool on_icon = is_on_icon ((int)x, (int)y, ref on_helper);
-                        if (on_helper) {
-                            zone = ClickZone.HELPER;
-                        } else if (on_icon) {
-                            zone = ClickZone.ICON;
-                        } else {
-                            zone = ClickZone.EXPANDER;
-                        }
-                    } else {
-                        // On name renderer
-                        // Cannot rely on current state of name_renderer so have to layout the
-                        // text again to get pixel width
-                        Gtk.TreeIter iter;
-                        model.get_iter (out iter, path);
-                        string? text = null;
-                        model.@get (iter, ListModel.ColumnID.FILENAME, out text);
-                        name_renderer.set_up_layout (text, name_renderer.width);
-                        // Calculate where click will activate
-                        var active_width = name_renderer.text_width + name_renderer.double_border_radius;
-                        bool is_on_active;
-                        if (rtl) {
-                            is_on_active = cx >= icon_text_edge - active_width - 8;
-                        } else {
-                            is_on_active = cx <= icon_text_edge + active_width + 8;
-                        }
-
-                        if (is_on_active) {
-                            zone = ClickZone.NAME;
-                        } else if (!is_blank) {
-                            zone = ClickZone.BLANK_PATH;
-                        }
-                    }
-                }
-            } else if (c != name_column) {
-                /* Cause unselect all to occur on other columns and allow rubberbanding */
-                zone = ClickZone.BLANK_NO_PATH;
-            }
-
-            return zone;
-        }
-
-        protected override void scroll_to_path (Gtk.TreePath path, bool scroll_to_top) {
-            tree.scroll_to_cell (path, name_column, scroll_to_top, 0.5f, 0.5f);
-        }
-
-        protected override void set_cursor_on_cell (
-            Gtk.TreePath path,
-            Gtk.CellRenderer renderer,
-            bool start_editing,
-            bool scroll_to_top
-        ) {
-            scroll_to_cell (path, scroll_to_top);
-            tree.set_cursor_on_cell (path, name_column, renderer, start_editing);
-        }
-
-        public override void set_cursor (
-            Gtk.TreePath? path,
-            bool start_editing,
-            bool select,
-            bool scroll_to_top
-        ) {
-            if (path == null) {
-                return;
-            }
-
-            Gtk.TreeSelection selection = tree.get_selection ();
-            bool no_selection = selected_files == null;
-
-            if (!select) {
-                selection.changed.disconnect (on_view_selection_changed);
-            } else {
-                select_path (path);
-            }
-
-            set_cursor_on_cell (path, name_renderer, start_editing, scroll_to_top);
-
-            if (!select) {
-                /* When just focusing first for empty selection we do not want the row selected.
-                 * This makes behaviour consistent with Icon View */
-                if (no_selection) {
-                    unselect_path (path); /* Reverse automatic selection by set_cursor_on_cell for TreeView */
-                }
-
-                selection.changed.connect (on_view_selection_changed);
-            }
-        }
-
-        public override Gtk.TreePath? get_path_at_cursor () {
-            Gtk.TreePath? path;
-            tree.get_cursor (out path, null);
-            return path;
-        }
-
-        /* These two functions accelerate the loading of Views especially for large folders
-         * Views are not displayed until fully loaded */
-        protected override void freeze_tree () {
-            if (!tree_frozen) {
-                tree.freeze_child_notify ();
-                tree_frozen = true;
-            }
-        }
-
-        protected override void thaw_tree () {
-            if (tree_frozen) {
-                tree.thaw_child_notify ();
-                tree_frozen = false;
-            }
-        }
-
-        // For scrolling
-        protected override void freeze_child_notify () {
-            tree.freeze_child_notify ();
-        }
-
-        protected override void thaw_child_notify () {
-            // Do not prematurely thaw tree when loading
-            if (!tree_frozen) {
-                tree.thaw_child_notify ();
-            }
+    public override void change_zoom_level () {
+        if (tree != null) {
+            base.change_zoom_level ();
+            tree.columns_autosize ();
+            tree.set_property ("zoom-level", zoom_level);
         }
     }
 
-    protected class TreeView : Gtk.TreeView {
-        private ZoomLevel _zoom_level = ZoomLevel.INVALID;
-        public ZoomLevel zoom_level {
-            set {
-                if (_zoom_level == value || !get_realized ()) {
-                    return;
+    public override GLib.List<Gtk.TreePath> get_selected_paths () {
+        return tree.get_selection ().get_selected_rows (null);
+    }
+
+    public override void highlight_path (Gtk.TreePath? path) {
+        tree.set_drag_dest_row (path, Gtk.TreeViewDropPosition.INTO_OR_AFTER);
+    }
+
+    public override Gtk.TreePath? get_path_at_pos (int x, int y) {
+        Gtk.TreePath? path = null;
+
+        if (x >= 0 && y >= 0 && tree.get_dest_row_at_pos (x, y, out path, null)) {
+            return path;
+        } else {
+            return null;
+        }
+    }
+
+    public override void tree_select_all () {
+        tree.get_selection ().select_all ();
+    }
+
+    public override void tree_unselect_all () {
+        tree.get_selection ().unselect_all ();
+    }
+
+    /* Avoid using this function with "cursor_follows = true" to select large numbers of files one by one
+     * It would take an exponentially long time. Use "select_files" function in parent class.
+     */
+    public override void select_path (Gtk.TreePath? path, bool cursor_follows = false) {
+        if (path == null) {
+            return;
+        }
+
+        var selection = tree.get_selection ();
+        selection.select_path (path);
+        if (cursor_follows) {
+            /* Unlike for IconView, set_cursor unselects previously selected paths (Gtk bug?),
+             * so we have to remember them and reselect afterwards */
+            GLib.List<Gtk.TreePath> selected_paths = null;
+            selection.selected_foreach ((m, p, i) => {
+                selected_paths.prepend (p);
+            });
+            /* Ensure cursor follows last selection */
+            tree.set_cursor (path, null, false); /* This selects path but unselects rest! */
+
+            selected_paths.@foreach ((p) => {
+               selection.select_path (p);
+            });
+        }
+    }
+    public override void unselect_path (Gtk.TreePath? path) {
+        if (path != null) {
+            tree.get_selection ().unselect_path (path);
+        }
+    }
+
+    public override bool path_is_selected (Gtk.TreePath? path) {
+        if (path != null) {
+            return tree.get_selection ().path_is_selected (path);
+        } else {
+            return false;
+        }
+    }
+
+    public override bool get_visible_range (
+        out Gtk.TreePath? start_path,
+        out Gtk.TreePath? end_path
+    ) {
+        start_path = null;
+        end_path = null;
+        return tree.get_visible_range (out start_path, out end_path);
+    }
+
+    protected override uint get_event_position_info (
+        Gdk.EventButton event,
+        out Gtk.TreePath? path,
+        bool rubberband = false
+    ) {
+        Gtk.TreePath? p = null;
+        unowned Gtk.TreeViewColumn? c = null;
+        uint zone;
+        int cx, cy, depth;
+        path = null;
+
+        var ewindow = event.get_window ();
+        if (ewindow != tree.get_bin_window ()) {
+            return ClickZone.INVALID;
+        }
+
+        double x, y;
+        event.get_coords (out x, out y);
+        tree.get_path_at_pos ((int)x, (int)y, out p, out c, out cx, out cy);
+        path = p;
+        depth = p != null ? p.get_depth () : 0;
+        /* Get rect for whole column; no simple way to get individual renderer sizes? */
+        Gdk.Rectangle rect;
+        tree.get_cell_area (p, c, out rect);
+        int height = rect.height;
+         /* Note: is_blank_at_pos () returns "true" on the whitespace below and
+         * above text pixels, which we do not want. We deal with this later.*/
+        var is_blank = tree.is_blank_at_pos ((int)x, (int)y, null, null, null, null);
+        // Ensure blank area continues across row division
+        is_blank = is_blank || cy < 5 || cy > height - 5;
+
+        /* Do not allow rubberbanding to start except on a row in tree view */
+        zone = (p != null && is_blank ? ClickZone.BLANK_PATH : ClickZone.INVALID);
+
+        if (p != null && c != null && c == name_column) {
+            Files.File? file = model.file_for_path (p);
+
+            if (file == null) {
+                zone = ClickZone.INVALID;
+            } else {
+                var rtl = (get_direction () == Gtk.TextDirection.RTL);
+                // Calculate position of the edge between icon to text renderers
+                int icon_text_edge;
+                if (rtl) {
+                    icon_text_edge = tree.get_allocated_width () - rect.x - icon_size - 16;
                 } else {
-                    _zoom_level = value;
+                    icon_text_edge = icon_size + 16;
+                }
+                // Calculate whether pointer over icon renderer or text renderer
+                if (rtl ? cx > icon_text_edge : cx < icon_text_edge) {
+                    // On icon renderer (or expander)
+                    bool on_helper = false;
+                    bool on_icon = is_on_icon ((int)x, (int)y, ref on_helper);
+                    if (on_helper) {
+                        zone = ClickZone.HELPER;
+                    } else if (on_icon) {
+                        zone = ClickZone.ICON;
+                    } else {
+                        zone = ClickZone.EXPANDER;
+                    }
+                } else {
+                    // On name renderer
+                    // Cannot rely on current state of name_renderer so have to layout the
+                    // text again to get pixel width
+                    Gtk.TreeIter iter;
+                    model.get_iter (out iter, path);
+                    string? text = null;
+                    model.@get (iter, ListModel.ColumnID.FILENAME, out text);
+                    name_renderer.set_up_layout (text, name_renderer.width);
+                    // Calculate where click will activate
+                    var active_width = name_renderer.text_width + name_renderer.double_border_radius;
+                    bool is_on_active;
+                    if (rtl) {
+                        is_on_active = cx >= icon_text_edge - active_width - 8;
+                    } else {
+                        is_on_active = cx <= icon_text_edge + active_width + 8;
+                    }
+
+                    if (is_on_active) {
+                        zone = ClickZone.NAME;
+                    } else if (!is_blank) {
+                        zone = ClickZone.BLANK_PATH;
+                    }
                 }
             }
+        } else if (c != name_column) {
+            /* Cause unselect all to occur on other columns and allow rubberbanding */
+            zone = ClickZone.BLANK_NO_PATH;
+        }
 
-            get {
-                return _zoom_level;
+        return zone;
+    }
+
+    protected override void scroll_to_path (Gtk.TreePath path, bool scroll_to_top) {
+        tree.scroll_to_cell (path, name_column, scroll_to_top, 0.5f, 0.5f);
+    }
+
+    protected override void set_cursor_on_cell (
+        Gtk.TreePath path,
+        Gtk.CellRenderer renderer,
+        bool start_editing,
+        bool scroll_to_top
+    ) {
+        scroll_to_cell (path, scroll_to_top);
+        tree.set_cursor_on_cell (path, name_column, renderer, start_editing);
+    }
+
+    public override void set_cursor (
+        Gtk.TreePath? path,
+        bool start_editing,
+        bool select,
+        bool scroll_to_top
+    ) {
+        if (path == null) {
+            return;
+        }
+
+        Gtk.TreeSelection selection = tree.get_selection ();
+        bool no_selection = selected_files == null;
+
+        if (!select) {
+            selection.changed.disconnect (on_view_selection_changed);
+        } else {
+            select_path (path);
+        }
+
+        set_cursor_on_cell (path, name_renderer, start_editing, scroll_to_top);
+
+        if (!select) {
+            /* When just focusing first for empty selection we do not want the row selected.
+             * This makes behaviour consistent with Icon View */
+            if (no_selection) {
+                unselect_path (path); /* Reverse automatic selection by set_cursor_on_cell for TreeView */
+            }
+
+            selection.changed.connect (on_view_selection_changed);
+        }
+    }
+
+    public override Gtk.TreePath? get_path_at_cursor () {
+        Gtk.TreePath? path;
+        tree.get_cursor (out path, null);
+        return path;
+    }
+
+    /* These two functions accelerate the loading of Views especially for large folders
+     * Views are not displayed until fully loaded */
+    protected override void freeze_tree () {
+        if (!tree_frozen) {
+            tree.freeze_child_notify ();
+            tree_frozen = true;
+        }
+    }
+
+    protected override void thaw_tree () {
+        if (tree_frozen) {
+            tree.thaw_child_notify ();
+            tree_frozen = false;
+        }
+    }
+
+    // For scrolling
+    protected override void freeze_child_notify () {
+        tree.freeze_child_notify ();
+    }
+
+    protected override void thaw_child_notify () {
+        // Do not prematurely thaw tree when loading
+        if (!tree_frozen) {
+            tree.thaw_child_notify ();
+        }
+    }
+}
+
+protected class Files.TreeView : Gtk.TreeView {
+    private ZoomLevel _zoom_level = ZoomLevel.INVALID;
+    public ZoomLevel zoom_level {
+        set {
+            if (_zoom_level == value || !get_realized ()) {
+                return;
+            } else {
+                _zoom_level = value;
             }
         }
 
-        /* Override base class in order to disable the Gtk.TreeView local search functionality */
-        public override bool key_press_event (Gdk.EventKey event) {
-            /* We still need the base class to handle cursor keys first */
-            uint keyval;
-            event.get_keyval (out keyval);
-            switch (keyval) {
-                case Gdk.Key.Up:
-                case Gdk.Key.Down:
-                case Gdk.Key.KP_Up:
-                case Gdk.Key.KP_Down:
-                case Gdk.Key.Page_Up:
-                case Gdk.Key.Page_Down:
-                case Gdk.Key.KP_Page_Up:
-                case Gdk.Key.KP_Page_Down:
-                case Gdk.Key.Home:
-                case Gdk.Key.End:
+        get {
+            return _zoom_level;
+        }
+    }
 
-                    return base.key_press_event (event);
+    /* Override base class in order to disable the Gtk.TreeView local search functionality */
+    public override bool key_press_event (Gdk.EventKey event) {
+        /* We still need the base class to handle cursor keys first */
+        uint keyval;
+        event.get_keyval (out keyval);
+        switch (keyval) {
+            case Gdk.Key.Up:
+            case Gdk.Key.Down:
+            case Gdk.Key.KP_Up:
+            case Gdk.Key.KP_Down:
+            case Gdk.Key.Page_Up:
+            case Gdk.Key.Page_Down:
+            case Gdk.Key.KP_Page_Up:
+            case Gdk.Key.KP_Page_Down:
+            case Gdk.Key.Home:
+            case Gdk.Key.End:
 
-                default:
+                return base.key_press_event (event);
 
-                    return false; // Pass event to Window handler.
-            }
+            default:
+
+                return false; // Pass event to Window handler.
         }
     }
 }

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -33,6 +33,7 @@ namespace Files {
         protected override void connect_tree_signals () {
             tree.get_selection ().changed.connect (on_view_selection_changed);
         }
+
         protected override void disconnect_tree_signals () {
             tree.get_selection ().changed.disconnect (on_view_selection_changed);
         }
@@ -70,8 +71,10 @@ namespace Files {
             };
 
             name_column.pack_start (icon_renderer, false);
-            name_column.set_attributes (icon_renderer,
-                                        "file", Files.ListModel.ColumnID.FILE_COLUMN);
+            name_column.set_attributes (
+                icon_renderer,
+                "file", Files.ListModel.ColumnID.FILE_COLUMN
+            );
 
             name_column.pack_start (name_renderer, true);
             name_column.set_attributes (
@@ -138,23 +141,25 @@ namespace Files {
          * It would take an exponentially long time. Use "select_files" function in parent class.
          */
         public override void select_path (Gtk.TreePath? path, bool cursor_follows = false) {
-            if (path != null) {
-                var selection = tree.get_selection ();
-                selection.select_path (path);
-                if (cursor_follows) {
-                    /* Unlike for IconView, set_cursor unselects previously selected paths (Gtk bug?),
-                     * so we have to remember them and reselect afterwards */
-                    GLib.List<Gtk.TreePath> selected_paths = null;
-                    selection.selected_foreach ((m, p, i) => {
-                        selected_paths.prepend (p);
-                    });
-                    /* Ensure cursor follows last selection */
-                    tree.set_cursor (path, null, false); /* This selects path but unselects rest! */
+            if (path == null) {
+                return;
+            }
 
-                    selected_paths.@foreach ((p) => {
-                       selection.select_path (p);
-                    });
-                }
+            var selection = tree.get_selection ();
+            selection.select_path (path);
+            if (cursor_follows) {
+                /* Unlike for IconView, set_cursor unselects previously selected paths (Gtk bug?),
+                 * so we have to remember them and reselect afterwards */
+                GLib.List<Gtk.TreePath> selected_paths = null;
+                selection.selected_foreach ((m, p, i) => {
+                    selected_paths.prepend (p);
+                });
+                /* Ensure cursor follows last selection */
+                tree.set_cursor (path, null, false); /* This selects path but unselects rest! */
+
+                selected_paths.@foreach ((p) => {
+                   selection.select_path (p);
+                });
             }
         }
         public override void unselect_path (Gtk.TreePath? path) {
@@ -171,17 +176,20 @@ namespace Files {
             }
         }
 
-        public override bool get_visible_range (out Gtk.TreePath? start_path,
-                                                out Gtk.TreePath? end_path) {
+        public override bool get_visible_range (
+            out Gtk.TreePath? start_path,
+            out Gtk.TreePath? end_path
+        ) {
             start_path = null;
             end_path = null;
             return tree.get_visible_range (out start_path, out end_path);
         }
 
-
-        protected override uint get_event_position_info (Gdk.EventButton event,
-                                                         out Gtk.TreePath? path,
-                                                         bool rubberband = false) {
+        protected override uint get_event_position_info (
+            Gdk.EventButton event,
+            out Gtk.TreePath? path,
+            bool rubberband = false
+        ) {
             Gtk.TreePath? p = null;
             unowned Gtk.TreeViewColumn? c = null;
             uint zone;
@@ -274,18 +282,22 @@ namespace Files {
             tree.scroll_to_cell (path, name_column, scroll_to_top, 0.5f, 0.5f);
         }
 
-        protected override void set_cursor_on_cell (Gtk.TreePath path,
-                                                    Gtk.CellRenderer renderer,
-                                                    bool start_editing,
-                                                    bool scroll_to_top) {
+        protected override void set_cursor_on_cell (
+            Gtk.TreePath path,
+            Gtk.CellRenderer renderer,
+            bool start_editing,
+            bool scroll_to_top
+        ) {
             scroll_to_cell (path, scroll_to_top);
             tree.set_cursor_on_cell (path, name_column, renderer, start_editing);
         }
 
-        public override void set_cursor (Gtk.TreePath? path,
-                                         bool start_editing,
-                                         bool select,
-                                         bool scroll_to_top) {
+        public override void set_cursor (
+            Gtk.TreePath? path,
+            bool start_editing,
+            bool select,
+            bool scroll_to_top
+        ) {
             if (path == null) {
                 return;
             }
@@ -344,7 +356,6 @@ namespace Files {
             if (!tree_frozen) {
                 tree.thaw_child_notify ();
             }
-
         }
     }
 

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -148,10 +148,6 @@ namespace Files {
             return base.handle_default_button_click (event);
         }
 
-        protected override void change_zoom_level () {
-            base.change_zoom_level ();
-        }
-
         public override void cancel () {
             base.cancel ();
             cancel_await_double_click ();

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -57,7 +57,7 @@ namespace Files {
             return false;
         }
 
-        protected override Settings? get_settings () {
+        protected override Settings? get_view_settings () {
             return Files.column_view_settings;
         }
 

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -43,7 +43,7 @@ namespace Files {
             }
         }
 
-        private bool not_double_click (Gdk.EventButton event, Gtk.TreePath? path) {
+        private bool not_double_click () {
             if (double_click_timeout_id != 0) {
                 awaiting_double_click = false;
                 double_click_timeout_id = 0;
@@ -116,7 +116,7 @@ namespace Files {
             return base.on_view_key_press_event (event);
         }
 
-        protected override bool handle_primary_button_click (Gdk.EventButton event, Gtk.TreePath? path) {
+        protected override bool handle_primary_button_click (Gdk.Event event, Gtk.TreePath? path) {
             Files.File? file = null;
             Files.File? selected_folder = null;
             Gtk.TreeIter? iter = null;
@@ -146,7 +146,7 @@ namespace Files {
                     awaiting_double_click = true;
                     is_frozen = true;
                     double_click_timeout_id = GLib.Timeout.add (300, () => {
-                        not_double_click (event, path);
+                        not_double_click ();
                         return GLib.Source.REMOVE;
                     });
                 }

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -24,14 +24,9 @@ namespace Files {
 
         public ColumnView (View.Slot _slot) {
             base (_slot);
+            icon_renderer.show_emblems = false;
             /* We do not need to load the directory - this is done by Miller View*/
             /* We do not need to connect to "row-activated" signal - we handle left-clicks ourselves */
-        }
-
-        protected override void set_up_icon_renderer () {
-            icon_renderer = new IconRenderer (ViewMode.MILLER_COLUMNS) {
-                lpad = 6
-            };
         }
 
         protected new void on_view_selection_changed () {

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -61,12 +61,7 @@ namespace Files {
             return Files.column_view_settings;
         }
 
-        public override ZoomLevel get_normal_zoom_level () {
-            var zoom = Files.column_view_settings.get_enum ("default-zoom-level");
-            Files.column_view_settings.set_enum ("zoom-level", zoom);
 
-            return (ZoomLevel)zoom;
-        }
 
         protected override Gtk.Widget? create_view () {
             model.has_child = false;

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -61,8 +61,6 @@ namespace Files {
             return Files.column_view_settings;
         }
 
-
-
         protected override Gtk.Widget? create_view () {
             model.has_child = false;
             base.create_view ();
@@ -145,7 +143,7 @@ namespace Files {
             return result;
         }
 
-        protected override bool handle_default_button_click (Gdk.EventButton event) {
+        protected override bool handle_default_button_click (Gdk.Event event) {
             cancel_await_double_click ();
             return base.handle_default_button_click (event);
         }

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -57,22 +57,8 @@ namespace Files {
             return false;
         }
 
-        protected override void set_up_zoom_level () {
-            Files.column_view_settings.bind (
-                "zoom-level",
-                this, "zoom-level",
-                GLib.SettingsBindFlags.DEFAULT
-            );
-
-            maximum_zoom = (ZoomLevel)Files.column_view_settings.get_enum ("maximum-zoom-level");
-
-            if (zoom_level < minimum_zoom) { /* Defaults to ZoomLevel.SMALLEST */
-                zoom_level = minimum_zoom;
-            }
-
-            if (zoom_level > maximum_zoom) {
-                zoom_level = maximum_zoom;
-            }
+        protected override Settings? get_settings () {
+            return Files.column_view_settings;
         }
 
         public override ZoomLevel get_normal_zoom_level () {

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -16,141 +16,139 @@
     Authors : Jeremy Wootten <jeremy@elementaryos.org>
 ***/
 
-namespace Files {
-    public class ColumnView : AbstractTreeView {
-        /** Miller View support */
-        bool awaiting_double_click = false;
-        uint double_click_timeout_id = 0;
+public class Files.ColumnView : AbstractTreeView {
+    /** Miller View support */
+    bool awaiting_double_click = false;
+    uint double_click_timeout_id = 0;
 
-        public ColumnView (View.Slot _slot) {
-            base (_slot);
-            icon_renderer.show_emblems = false;
-            /* We do not need to load the directory - this is done by Miller View*/
-            /* We do not need to connect to "row-activated" signal - we handle left-clicks ourselves */
+    public ColumnView (View.Slot _slot) {
+        base (_slot);
+        icon_renderer.show_emblems = false;
+        /* We do not need to load the directory - this is done by Miller View*/
+        /* We do not need to connect to "row-activated" signal - we handle left-clicks ourselves */
+    }
+
+    protected new void on_view_selection_changed () {
+        set_active_slot ();
+        base.on_view_selection_changed ();
+    }
+
+    private void cancel_await_double_click () {
+        if (awaiting_double_click) {
+            GLib.Source.remove (double_click_timeout_id);
+            double_click_timeout_id = 0;
+            awaiting_double_click = false;
+            is_frozen = false;
+        }
+    }
+
+    private bool not_double_click () {
+        if (double_click_timeout_id != 0) {
+            awaiting_double_click = false;
+            double_click_timeout_id = 0;
+            is_frozen = false;
+
+            if (source_drag_file_list == null &&
+                selection_only_contains_folders (get_selected_files ())) {
+                activate_selected_items ();
+            }
         }
 
-        protected new void on_view_selection_changed () {
-            set_active_slot ();
-            base.on_view_selection_changed ();
+        return false;
+    }
+
+    protected override Settings? get_view_settings () {
+        return Files.column_view_settings;
+    }
+
+    protected override Gtk.Widget? create_view () {
+        model.has_child = false;
+        base.create_view ();
+        tree.show_expanders = false;
+        return tree as Gtk.Widget;
+    }
+
+    protected override bool on_view_key_press_event (Gdk.EventKey event) {
+        Gdk.ModifierType state;
+        event.get_state (out state);
+        uint keyval;
+        event.get_keyval (out keyval);
+        var mods = state & Gtk.accelerator_get_default_mod_mask ();
+        bool no_mods = (mods == 0);
+
+        switch (keyval) {
+            /* Do not emit alert sound on left and right cursor keys in Miller View */
+            case Gdk.Key.Left:
+            case Gdk.Key.Right:
+            case Gdk.Key.BackSpace:
+                if (no_mods) {
+                    /* Pass event to MillerView */
+                    slot.colpane.key_press_event (event);
+                    return true;
+                }
+                break;
+
+            default:
+                break;
         }
 
-        private void cancel_await_double_click () {
+        return base.on_view_key_press_event (event);
+    }
+
+    protected override bool handle_primary_button_click (Gdk.Event event, Gtk.TreePath? path) {
+        Files.File? file = null;
+        Files.File? selected_folder = null;
+        Gtk.TreeIter? iter = null;
+
+        if (path != null) {
+            model.get_iter (out iter, path);
+        }
+
+        if (iter != null) {
+            model.@get (iter, ListModel.ColumnID.FILE_COLUMN, out file, -1);
+        }
+
+        if (file == null || !file.is_folder ()) {
+            return base.handle_primary_button_click (event, path);
+        }
+
+        selected_folder = file;
+        bool result = true;
+        var type = event.get_event_type ();
+        if (type == Gdk.EventType.BUTTON_PRESS) {
+            /* Ignore second GDK_BUTTON_PRESS event of double-click */
             if (awaiting_double_click) {
-                GLib.Source.remove (double_click_timeout_id);
-                double_click_timeout_id = 0;
-                awaiting_double_click = false;
-                is_frozen = false;
-            }
-        }
-
-        private bool not_double_click () {
-            if (double_click_timeout_id != 0) {
-                awaiting_double_click = false;
-                double_click_timeout_id = 0;
-                is_frozen = false;
-
-                if (source_drag_file_list == null &&
-                    selection_only_contains_folders (get_selected_files ())) {
-                    activate_selected_items ();
-                }
-            }
-
-            return false;
-        }
-
-        protected override Settings? get_view_settings () {
-            return Files.column_view_settings;
-        }
-
-        protected override Gtk.Widget? create_view () {
-            model.has_child = false;
-            base.create_view ();
-            tree.show_expanders = false;
-            return tree as Gtk.Widget;
-        }
-
-        protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            Gdk.ModifierType state;
-            event.get_state (out state);
-            uint keyval;
-            event.get_keyval (out keyval);
-            var mods = state & Gtk.accelerator_get_default_mod_mask ();
-            bool no_mods = (mods == 0);
-
-            switch (keyval) {
-                /* Do not emit alert sound on left and right cursor keys in Miller View */
-                case Gdk.Key.Left:
-                case Gdk.Key.Right:
-                case Gdk.Key.BackSpace:
-                    if (no_mods) {
-                        /* Pass event to MillerView */
-                        slot.colpane.key_press_event (event);
-                        return true;
-                    }
-                    break;
-
-                default:
-                    break;
-            }
-
-            return base.on_view_key_press_event (event);
-        }
-
-        protected override bool handle_primary_button_click (Gdk.Event event, Gtk.TreePath? path) {
-            Files.File? file = null;
-            Files.File? selected_folder = null;
-            Gtk.TreeIter? iter = null;
-
-            if (path != null) {
-                model.get_iter (out iter, path);
-            }
-
-            if (iter != null) {
-                model.@get (iter, ListModel.ColumnID.FILE_COLUMN, out file, -1);
-            }
-
-            if (file == null || !file.is_folder ()) {
-                return base.handle_primary_button_click (event, path);
-            }
-
-            selected_folder = file;
-            bool result = true;
-            var type = event.get_event_type ();
-            if (type == Gdk.EventType.BUTTON_PRESS) {
-                /* Ignore second GDK_BUTTON_PRESS event of double-click */
-                if (awaiting_double_click) {
-                    result = true;
-                } else {
-                    /*  ... store clicked folder and start double-click timeout */
-                    awaiting_double_click = true;
-                    is_frozen = true;
-                    double_click_timeout_id = GLib.Timeout.add (300, () => {
-                        not_double_click ();
-                        return GLib.Source.REMOVE;
-                    });
-                }
-            } else if (type == Gdk.EventType.@2BUTTON_PRESS) {
-                should_activate = false;
-                cancel_await_double_click ();
-
-                if (selected_folder != null) {
-                    load_root_location (selected_folder.get_target_location ());
-                }
-
                 result = true;
+            } else {
+                /*  ... store clicked folder and start double-click timeout */
+                awaiting_double_click = true;
+                is_frozen = true;
+                double_click_timeout_id = GLib.Timeout.add (300, () => {
+                    not_double_click ();
+                    return GLib.Source.REMOVE;
+                });
+            }
+        } else if (type == Gdk.EventType.@2BUTTON_PRESS) {
+            should_activate = false;
+            cancel_await_double_click ();
+
+            if (selected_folder != null) {
+                load_root_location (selected_folder.get_target_location ());
             }
 
-            return result;
+            result = true;
         }
 
-        protected override bool handle_default_button_click (Gdk.Event event) {
-            cancel_await_double_click ();
-            return base.handle_default_button_click (event);
-        }
+        return result;
+    }
 
-        public override void cancel () {
-            base.cancel ();
-            cancel_await_double_click ();
-        }
+    protected override bool handle_default_button_click (Gdk.Event event) {
+        cancel_await_double_click ();
+        return base.handle_default_button_click (event);
+    }
+
+    public override void cancel () {
+        base.cancel ();
+        cancel_await_double_click ();
     }
 }

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -49,7 +49,8 @@ namespace Files {
                 double_click_timeout_id = 0;
                 is_frozen = false;
 
-                if (source_drag_file_list == null && selection_only_contains_folders (get_selected_files ())) {
+                if (source_drag_file_list == null &&
+                    selection_only_contains_folders (get_selected_files ())) {
                     activate_selected_items ();
                 }
             }
@@ -114,7 +115,6 @@ namespace Files {
 
             selected_folder = file;
             bool result = true;
-
             var type = event.get_event_type ();
             if (type == Gdk.EventType.BUTTON_PRESS) {
                 /* Ignore second GDK_BUTTON_PRESS event of double-click */

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -82,23 +82,8 @@ namespace Files {
             return tree as Gtk.Widget;
         }
 
-        protected override void set_up_zoom_level () {
-            Files.icon_view_settings.bind (
-                "zoom-level",
-                this, "zoom-level",
-                GLib.SettingsBindFlags.DEFAULT
-            );
-
-            minimum_zoom = (ZoomLevel)Files.icon_view_settings.get_enum ("minimum-zoom-level");
-            maximum_zoom = (ZoomLevel)Files.icon_view_settings.get_enum ("maximum-zoom-level");
-
-            if (zoom_level < minimum_zoom) {
-                zoom_level = minimum_zoom;
-            }
-
-            if (zoom_level > maximum_zoom) {
-                zoom_level = maximum_zoom;
-            }
+        protected override Settings? get_settings () {
+            return Files.icon_view_settings;
         }
 
         public override ZoomLevel get_normal_zoom_level () {

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -82,11 +82,9 @@ namespace Files {
             return tree as Gtk.Widget;
         }
 
-        protected override Settings? get_settings () {
+        protected override Settings? get_view_settings () {
             return Files.icon_view_settings;
         }
-
-
 
         public override void change_zoom_level () {
             int spacing = (int)((double)icon_size * (0.3 - zoom_level * 0.03));

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -164,7 +164,6 @@ namespace Files {
             return tree.get_visible_range (out start_path, out end_path);
         }
 
-
         protected override uint get_event_position_info (Gdk.EventButton event,
                                                          out Gtk.TreePath? path,
                                                          bool rubberband = false) {

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -40,7 +40,9 @@ namespace Files {
             tree.set_columns (-1);
 
             name_renderer = new Files.TextRenderer (ViewMode.ICON);
-            icon_renderer = new Files.IconRenderer (ViewMode.ICON);
+            icon_renderer = new Files.IconRenderer () {
+                show_emblems = true
+            };
 
             set_up_name_renderer ();
 

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -186,27 +186,6 @@ namespace Files {
             return tree.get_visible_range (out start_path, out end_path);
         }
 
-        protected override uint get_selected_files_from_model (out GLib.List<Files.File> selected_files) {
-            GLib.List<Files.File> list = null;
-            uint count = 0;
-
-            tree.selected_foreach ((tree, path) => {
-                Files.File? file = model.file_for_path (path);
-                if (file != null) {
-                    list.prepend ((owned)file);
-                    count++;
-                } else {
-                    critical ("Null file in model");
-                }
-            });
-
-            selected_files = (owned)list;
-            return count;
-        }
-
-        protected override bool view_has_focus () {
-            return tree.has_focus;
-        }
 
         protected override uint get_event_position_info (Gdk.EventButton event,
                                                          out Gtk.TreePath? path,
@@ -275,14 +254,7 @@ namespace Files {
             return zone;
         }
 
-        protected override void scroll_to_cell (Gtk.TreePath? path, bool scroll_to_top) {
-            /* slot && directory should not be null but see lp:1595438  & https://github.com/elementary/files/issues/1699 */
-            if (tree == null || path == null || slot == null || slot.directory == null ||
-                slot.directory.permission_denied || slot.directory.is_empty ()) {
-
-                return;
-            }
-
+        protected override void scroll_to_path (Gtk.TreePath path, bool scroll_to_top) {
             tree.scroll_to_path (path, scroll_to_top, 0.5f, 0.5f);
         }
 

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -86,12 +86,7 @@ namespace Files {
             return Files.icon_view_settings;
         }
 
-        public override ZoomLevel get_normal_zoom_level () {
-            var zoom = Files.icon_view_settings.get_enum ("default-zoom-level");
-            Files.icon_view_settings.set_enum ("zoom-level", zoom);
 
-            return (ZoomLevel)zoom;
-        }
 
         public override void change_zoom_level () {
             int spacing = (int)((double)icon_size * (0.3 - zoom_level * 0.03));

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -202,7 +202,7 @@ namespace Files {
             return tree as Gtk.Widget;
         }
 
-        protected override Settings? get_settings () {
+        protected override Settings? get_view_settings () {
             return Files.list_view_settings;
         }
 

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -202,23 +202,12 @@ namespace Files {
             return tree as Gtk.Widget;
         }
 
-        protected override void set_up_zoom_level () {
-            Files.list_view_settings.bind (
-                "zoom-level",
-                this, "zoom-level",
-                GLib.SettingsBindFlags.DEFAULT
-            );
-
-            maximum_zoom = (ZoomLevel)Files.list_view_settings.get_enum ("maximum-zoom-level");
-
-            if (zoom_level < minimum_zoom) { /* Defaults to ZoomLevel.SMALLEST */
-                zoom_level = minimum_zoom;
-            }
-
-            if (zoom_level > maximum_zoom) {
-                zoom_level = maximum_zoom;
-            }
+        protected override Settings? get_settings () {
+            return Files.list_view_settings;
         }
+
+
+
 
         public override ZoomLevel get_normal_zoom_level () {
             var zoom = Files.list_view_settings.get_enum ("default-zoom-level");

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -16,267 +16,265 @@
     Authors : Jeremy Wootten <jeremy@elementaryos.org>
 ***/
 
-namespace Files {
-    public class ListView : AbstractTreeView {
+public class Files.ListView : AbstractTreeView {
 
-        /* We wait two seconds after row is collapsed to unload the subdirectory */
-        const int COLLAPSE_TO_UNLOAD_DELAY = 2;
+    /* We wait two seconds after row is collapsed to unload the subdirectory */
+    const int COLLAPSE_TO_UNLOAD_DELAY = 2;
 
-        static string [] column_titles = {
-            _("Filename"),
-            _("Size"),
-            _("Type"),
-            _("Modified")
-        };
+    static string [] column_titles = {
+        _("Filename"),
+        _("Size"),
+        _("Type"),
+        _("Modified")
+    };
 
-        /* ListView manages the loading and unloading of subdirectories displayed */
-        private uint unload_file_timeout_id = 0;
-        private GLib.List<Gtk.TreeRowReference> subdirectories_to_unload = null;
-        private GLib.List<Directory> loaded_subdirectories = null;
+    /* ListView manages the loading and unloading of subdirectories displayed */
+    private uint unload_file_timeout_id = 0;
+    private GLib.List<Gtk.TreeRowReference> subdirectories_to_unload = null;
+    private GLib.List<Directory> loaded_subdirectories = null;
 
-        public ListView (View.Slot _slot) {
-            base (_slot);
-        }
+    public ListView (View.Slot _slot) {
+        base (_slot);
+    }
 
-        private void connect_additional_signals () {
-            tree.row_expanded.connect (on_row_expanded);
-            tree.row_collapsed.connect (on_row_collapsed);
-            model.subdirectory_unloaded.connect (on_model_subdirectory_unloaded);
-        }
+    private void connect_additional_signals () {
+        tree.row_expanded.connect (on_row_expanded);
+        tree.row_collapsed.connect (on_row_collapsed);
+        model.subdirectory_unloaded.connect (on_model_subdirectory_unloaded);
+    }
 
-        private void append_extra_tree_columns () {
-            int fnc = ListModel.ColumnID.FILENAME;
+    private void append_extra_tree_columns () {
+        int fnc = ListModel.ColumnID.FILENAME;
 
-            int preferred_column_width = Files.column_view_settings.get_int ("preferred-column-width");
-            for (int k = fnc; k < ListModel.ColumnID.NUM_COLUMNS; k++) {
-                if (k == fnc) {
-                    /* name_column already created by AbstractTreeVIew */
-                    name_column.set_title (column_titles [0]);
-                    name_column.min_width = preferred_column_width;
+        int preferred_column_width = Files.column_view_settings.get_int ("preferred-column-width");
+        for (int k = fnc; k < ListModel.ColumnID.NUM_COLUMNS; k++) {
+            if (k == fnc) {
+                /* name_column already created by AbstractTreeVIew */
+                name_column.set_title (column_titles [0]);
+                name_column.min_width = preferred_column_width;
+            } else {
+                var renderer = new Gtk.CellRendererText ();
+                var col = new Gtk.TreeViewColumn.with_attributes (
+                    column_titles [k - fnc],
+                    renderer,
+                    "text",
+                    k
+                ) {
+                    sort_column_id = k,
+                    resizable = false,
+                    expand = false,
+                    min_width = 24
+                };
+
+                if (k == ListModel.ColumnID.SIZE || k == ListModel.ColumnID.MODIFIED) {
+                    renderer.@set ("xalign", 1.0f);
                 } else {
-                    var renderer = new Gtk.CellRendererText ();
-                    var col = new Gtk.TreeViewColumn.with_attributes (
-                        column_titles [k - fnc],
-                        renderer,
-                        "text",
-                        k
-                    ) {
-                        sort_column_id = k,
-                        resizable = false,
-                        expand = false,
-                        min_width = 24
-                    };
+                    renderer.@set ("xalign", 0.0f);
+                }
 
-                    if (k == ListModel.ColumnID.SIZE || k == ListModel.ColumnID.MODIFIED) {
-                        renderer.@set ("xalign", 1.0f);
-                    } else {
-                        renderer.@set ("xalign", 0.0f);
+                tree.append_column (col);
+            }
+        }
+    }
+
+    private void on_row_expanded (Gtk.TreeIter iter, Gtk.TreePath path) {
+        set_path_expanded (path, true);
+        add_subdirectory_at_path (path);
+    }
+
+    private void on_row_collapsed (Gtk.TreeIter iter, Gtk.TreePath path) {
+        set_path_expanded (path, false);
+        schedule_unload_subdirectory_at_path (path);
+    }
+
+    private void on_model_subdirectory_unloaded (Directory dir) {
+        /* ensure the model and our list of subdirectories are kept in sync */
+        remove_subdirectory (dir);
+    }
+
+    private void schedule_unload_subdirectory_at_path (Gtk.TreePath path) {
+        /* unload subdirectory from model and remove from our list of subdirectories
+         * after a delay, in case of rapid collapsing and re-expanding of rows */
+        subdirectories_to_unload.append (new Gtk.TreeRowReference (model, path));
+        schedule_model_unload_directories ();
+    }
+
+    private void set_path_expanded (Gtk.TreePath path, bool expanded) {
+        Files.File? file = model.file_for_path (path);
+
+        if (file != null) {
+            file.set_expanded (expanded);
+        }
+    }
+
+    private void schedule_model_unload_directories () {
+        cancel_file_timeout ();
+        unload_file_timeout_id = GLib.Timeout.add_seconds (COLLAPSE_TO_UNLOAD_DELAY,
+                                                           unload_directories);
+    }
+
+    private bool unload_directories () {
+        foreach (unowned Gtk.TreeRowReference rowref in subdirectories_to_unload) {
+            Gtk.TreeIter? iter = null;
+            Gtk.TreePath path;
+            if (rowref.valid ()) {
+                path = rowref.get_path ();
+            } else {
+                warning ("TreeRowRef invalid when unloading subdirectory");
+                continue;
+            }
+
+            if (((Gtk.TreeView)tree).is_row_expanded (path)) {
+                continue;
+            }
+
+            if (model.get_iter (out iter, path) && iter != null) {
+                    model.unload_subdirectory (iter);
+            } else {
+                warning ("Subdirectory to unload not found in model");
+            }
+        }
+
+        subdirectories_to_unload.@foreach ((rowref) => {
+            subdirectories_to_unload.remove (rowref);
+        });
+
+        unload_file_timeout_id = 0;
+        return false;
+    }
+
+    private void cancel_file_timeout () {
+        if (unload_file_timeout_id > 0) {
+            GLib.Source.remove (unload_file_timeout_id);
+            unload_file_timeout_id = 0;
+        }
+    }
+
+    protected override bool on_view_key_press_event (Gdk.EventKey event) {
+        Gdk.ModifierType state;
+        event.get_state (out state);
+        bool control_pressed = ((state & Gdk.ModifierType.CONTROL_MASK) != 0);
+        bool shift_pressed = ((state & Gdk.ModifierType.SHIFT_MASK) != 0);
+
+        if (!control_pressed && !shift_pressed) {
+            uint keyval;
+            event.get_keyval (out keyval);
+            switch (keyval) {
+                case Gdk.Key.Right:
+                    Gtk.TreePath? path = null;
+                    tree.get_cursor (out path, null);
+
+                    if (path != null) {
+                        tree.expand_row (path, false);
                     }
 
-                    tree.append_column (col);
-                }
-            }
-        }
-
-        private void on_row_expanded (Gtk.TreeIter iter, Gtk.TreePath path) {
-            set_path_expanded (path, true);
-            add_subdirectory_at_path (path);
-        }
-
-        private void on_row_collapsed (Gtk.TreeIter iter, Gtk.TreePath path) {
-            set_path_expanded (path, false);
-            schedule_unload_subdirectory_at_path (path);
-        }
-
-        private void on_model_subdirectory_unloaded (Directory dir) {
-            /* ensure the model and our list of subdirectories are kept in sync */
-            remove_subdirectory (dir);
-        }
-
-        private void schedule_unload_subdirectory_at_path (Gtk.TreePath path) {
-            /* unload subdirectory from model and remove from our list of subdirectories
-             * after a delay, in case of rapid collapsing and re-expanding of rows */
-            subdirectories_to_unload.append (new Gtk.TreeRowReference (model, path));
-            schedule_model_unload_directories ();
-        }
-
-        private void set_path_expanded (Gtk.TreePath path, bool expanded) {
-            Files.File? file = model.file_for_path (path);
-
-            if (file != null) {
-                file.set_expanded (expanded);
-            }
-        }
-
-        private void schedule_model_unload_directories () {
-            cancel_file_timeout ();
-            unload_file_timeout_id = GLib.Timeout.add_seconds (COLLAPSE_TO_UNLOAD_DELAY,
-                                                               unload_directories);
-        }
-
-        private bool unload_directories () {
-            foreach (unowned Gtk.TreeRowReference rowref in subdirectories_to_unload) {
-                Gtk.TreeIter? iter = null;
-                Gtk.TreePath path;
-                if (rowref.valid ()) {
-                    path = rowref.get_path ();
-                } else {
-                    warning ("TreeRowRef invalid when unloading subdirectory");
-                    continue;
-                }
-
-                if (((Gtk.TreeView)tree).is_row_expanded (path)) {
-                    continue;
-                }
-
-                if (model.get_iter (out iter, path) && iter != null) {
-                        model.unload_subdirectory (iter);
-                } else {
-                    warning ("Subdirectory to unload not found in model");
-                }
-            }
-
-            subdirectories_to_unload.@foreach ((rowref) => {
-                subdirectories_to_unload.remove (rowref);
-            });
-
-            unload_file_timeout_id = 0;
-            return false;
-        }
-
-        private void cancel_file_timeout () {
-            if (unload_file_timeout_id > 0) {
-                GLib.Source.remove (unload_file_timeout_id);
-                unload_file_timeout_id = 0;
-            }
-        }
-
-        protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            Gdk.ModifierType state;
-            event.get_state (out state);
-            bool control_pressed = ((state & Gdk.ModifierType.CONTROL_MASK) != 0);
-            bool shift_pressed = ((state & Gdk.ModifierType.SHIFT_MASK) != 0);
-
-            if (!control_pressed && !shift_pressed) {
-                uint keyval;
-                event.get_keyval (out keyval);
-                switch (keyval) {
-                    case Gdk.Key.Right:
-                        Gtk.TreePath? path = null;
-                        tree.get_cursor (out path, null);
-
-                        if (path != null) {
-                            tree.expand_row (path, false);
-                        }
-
-                        return true;
-
-                    case Gdk.Key.Left:
-                        Gtk.TreePath? path = null;
-                        tree.get_cursor (out path, null);
-
-                        if (path != null) {
-                            if (tree.is_row_expanded (path)) {
-                                tree.collapse_row (path);
-                            } else if (path.up ()) {
-                                tree.collapse_row (path);
-                            }
-                        }
-
-                        return true;
-
-                    default:
-                        break;
-                }
-            }
-
-            return base.on_view_key_press_event (event);
-        }
-
-        protected override Gtk.Widget? create_view () {
-            model.has_child = true;
-            base.create_view ();
-            tree.set_show_expanders (true);
-            tree.set_headers_visible (true);
-            tree.set_rubber_banding (true);
-            append_extra_tree_columns ();
-            connect_additional_signals ();
-
-            return tree as Gtk.Widget;
-        }
-
-        protected override Settings? get_view_settings () {
-            return Files.list_view_settings;
-        }
-
-        private void add_subdirectory_at_path (Gtk.TreePath path) {
-            /* If a new subdirectory is loaded, connect it, load it
-             * and add it to the list of subdirectories */
-            Files.Directory? dir = null;
-            if (model.get_subdirectory (path, out dir)) { // Returns true if dir non null
-                connect_directory_handlers (dir);
-                dir.init ();
-                /* Maintain our own reference on dir, independent of the model */
-                /* Also needed for updating show hidden status */
-                loaded_subdirectories.prepend (dir);
-            }
-        }
-
-        private void remove_subdirectory (Directory? dir) {
-            if (dir != null) {
-                disconnect_directory_handlers (dir);
-                /* Release our reference on dir */
-                loaded_subdirectories.remove (dir);
-            } else {
-                warning ("List View: directory null in remove_subdirectory");
-            }
-        }
-
-        protected override bool expand_collapse (Gtk.TreePath? path) {
-            if (tree.is_row_expanded (path)) {
-                tree.collapse_row (path);
-            } else {
-                tree.expand_row (path, false);
-            }
-
-            return true;
-        }
-
-        protected override bool get_next_visible_iter (ref Gtk.TreeIter iter, bool recurse = true) {
-            Gtk.TreePath? path = model.get_path (iter);
-            Gtk.TreeIter start = iter;
-
-            if (path == null) {
-                return false;
-            }
-
-            if (recurse && tree.is_row_expanded (path)) {
-                Gtk.TreeIter? child_iter = null;
-                if (model.iter_children (out child_iter, iter)) {
-                    iter = child_iter;
                     return true;
-                }
-            }
 
-            if (model.iter_next (ref iter)) {
-                return true;
-            } else {
-                Gtk.TreeIter? parent = null;
-                if (model.iter_parent (out parent, start)) {
-                    iter = parent;
-                    return get_next_visible_iter (ref iter, false);
-                }
-            }
+                case Gdk.Key.Left:
+                    Gtk.TreePath? path = null;
+                    tree.get_cursor (out path, null);
 
+                    if (path != null) {
+                        if (tree.is_row_expanded (path)) {
+                            tree.collapse_row (path);
+                        } else if (path.up ()) {
+                            tree.collapse_row (path);
+                        }
+                    }
+
+                    return true;
+
+                default:
+                    break;
+            }
+        }
+
+        return base.on_view_key_press_event (event);
+    }
+
+    protected override Gtk.Widget? create_view () {
+        model.has_child = true;
+        base.create_view ();
+        tree.set_show_expanders (true);
+        tree.set_headers_visible (true);
+        tree.set_rubber_banding (true);
+        append_extra_tree_columns ();
+        connect_additional_signals ();
+
+        return tree as Gtk.Widget;
+    }
+
+    protected override Settings? get_view_settings () {
+        return Files.list_view_settings;
+    }
+
+    private void add_subdirectory_at_path (Gtk.TreePath path) {
+        /* If a new subdirectory is loaded, connect it, load it
+         * and add it to the list of subdirectories */
+        Files.Directory? dir = null;
+        if (model.get_subdirectory (path, out dir)) { // Returns true if dir non null
+            connect_directory_handlers (dir);
+            dir.init ();
+            /* Maintain our own reference on dir, independent of the model */
+            /* Also needed for updating show hidden status */
+            loaded_subdirectories.prepend (dir);
+        }
+    }
+
+    private void remove_subdirectory (Directory? dir) {
+        if (dir != null) {
+            disconnect_directory_handlers (dir);
+            /* Release our reference on dir */
+            loaded_subdirectories.remove (dir);
+        } else {
+            warning ("List View: directory null in remove_subdirectory");
+        }
+    }
+
+    protected override bool expand_collapse (Gtk.TreePath? path) {
+        if (tree.is_row_expanded (path)) {
+            tree.collapse_row (path);
+        } else {
+            tree.expand_row (path, false);
+        }
+
+        return true;
+    }
+
+    protected override bool get_next_visible_iter (ref Gtk.TreeIter iter, bool recurse = true) {
+        Gtk.TreePath? path = model.get_path (iter);
+        Gtk.TreeIter start = iter;
+
+        if (path == null) {
             return false;
         }
 
-        public override void cancel () {
-            cancel_file_timeout ();
-            base.cancel ();
-            loaded_subdirectories.@foreach ((dir) => {
-                remove_subdirectory (dir);
-            });
+        if (recurse && tree.is_row_expanded (path)) {
+            Gtk.TreeIter? child_iter = null;
+            if (model.iter_children (out child_iter, iter)) {
+                iter = child_iter;
+                return true;
+            }
         }
+
+        if (model.iter_next (ref iter)) {
+            return true;
+        } else {
+            Gtk.TreeIter? parent = null;
+            if (model.iter_parent (out parent, start)) {
+                iter = parent;
+                return get_next_visible_iter (ref iter, false);
+            }
+        }
+
+        return false;
+    }
+
+    public override void cancel () {
+        cancel_file_timeout ();
+        base.cancel ();
+        loaded_subdirectories.@foreach ((dir) => {
+            remove_subdirectory (dir);
+        });
     }
 }

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -55,9 +55,12 @@ namespace Files {
                     name_column.min_width = preferred_column_width;
                 } else {
                     var renderer = new Gtk.CellRendererText ();
-                    var col = new Gtk.TreeViewColumn.with_attributes (column_titles [k - fnc],
-                                                                        renderer,
-                                                                        "text", k) {
+                    var col = new Gtk.TreeViewColumn.with_attributes (
+                        column_titles [k - fnc],
+                        renderer,
+                        "text",
+                        k
+                    ) {
                         sort_column_id = k,
                         resizable = false,
                         expand = false,
@@ -91,10 +94,10 @@ namespace Files {
         }
 
         private void schedule_unload_subdirectory_at_path (Gtk.TreePath path) {
-                /* unload subdirectory from model and remove from our list of subdirectories
-                 * after a delay, in case of rapid collapsing and re-expanding of rows */
-                subdirectories_to_unload.append (new Gtk.TreeRowReference (model, path));
-                schedule_model_unload_directories ();
+            /* unload subdirectory from model and remove from our list of subdirectories
+             * after a delay, in case of rapid collapsing and re-expanding of rows */
+            subdirectories_to_unload.append (new Gtk.TreeRowReference (model, path));
+            schedule_model_unload_directories ();
         }
 
         private void set_path_expanded (Gtk.TreePath path, bool expanded) {
@@ -206,11 +209,6 @@ namespace Files {
             return Files.list_view_settings;
         }
 
-
-
-
-
-
         private void add_subdirectory_at_path (Gtk.TreePath path) {
             /* If a new subdirectory is loaded, connect it, load it
              * and add it to the list of subdirectories */
@@ -269,6 +267,7 @@ namespace Files {
                     return get_next_visible_iter (ref iter, false);
                 }
             }
+
             return false;
         }
 

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -209,12 +209,7 @@ namespace Files {
 
 
 
-        public override ZoomLevel get_normal_zoom_level () {
-            var zoom = Files.list_view_settings.get_enum ("default-zoom-level");
-            Files.list_view_settings.set_enum ("zoom-level", zoom);
 
-            return (ZoomLevel)zoom;
-        }
 
         private void add_subdirectory_at_path (Gtk.TreePath path) {
             /* If a new subdirectory is loaded, connect it, load it

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -38,12 +38,6 @@ namespace Files {
             base (_slot);
         }
 
-        protected override void set_up_icon_renderer () {
-            icon_renderer = new IconRenderer (ViewMode.LIST) {
-                lpad = 6
-            };
-        }
-
         private void connect_additional_signals () {
             tree.row_expanded.connect (on_row_expanded);
             tree.row_collapsed.connect (on_row_collapsed);


### PR DESCRIPTION
Gtk4 related:
 - Avoid use of Gdk.EventButton in some cases

Cleanup:
 - Merge single use functions
 - Avoid repeating some code
 - Modernise code style
 -  Inline namespace

All changes should be functionally equivalent to the original

Hide whitespace when reviewing to ignore inlining of namespace