### PR TITLE
[Gtk4Prep] Viewcontainer cleanup and prepare for Gtk4

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -42,9 +42,6 @@ public class Files.Application : Gtk.Application {
     public Settings gnome_privacy_settings { get; construct; }
     public Settings gtk_file_chooser_settings { get; construct; }
 
-
-    public int window_count { get; private set; }
-
     bool quitting = false;
 
     static construct {
@@ -154,12 +151,6 @@ public class Files.Application : Gtk.Application {
 #if HAVE_UNITY
         QuicklistHandler.get_singleton ();
 #endif
-
-        window_count = 0;
-        this.window_added.connect_after (() => {window_count++;});
-        this.window_removed.connect (() => {
-            window_count--;
-        });
 
         var granite_settings = Granite.Settings.get_default ();
         var gtk_settings = Gtk.Settings.get_default ();

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -269,7 +269,11 @@ namespace Files {
         protected Files.ListModel model;
         protected Files.IconRenderer icon_renderer;
         protected unowned View.Slot slot; // Must be unowned else cyclic reference stops destruction
-        protected unowned View.Window window; /*For convenience - this can be derived from slot */
+        protected unowned View.Window? window {
+            get {
+                return slot.ctab.window;
+            }
+        }
         protected static DndHandler dnd_handler = new DndHandler ();
 
         protected unowned Gtk.RecentManager recent;
@@ -279,7 +283,6 @@ namespace Files {
 
         protected AbstractDirectoryView (View.Slot _slot) {
             slot = _slot;
-            window = _slot.window;
             editable_cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), "text");
             activatable_cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), "pointer");
             selectable_cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), "default");

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -961,7 +961,7 @@ namespace Files {
             }
         }
 
-        private void handle_free_space_change () {
+        private void handle_free_space_change () requires (window != null) {
             /* Wait at least 250 mS after last space change before signalling to avoid unnecessary updates*/
             if (add_remove_file_timeout_id == 0) {
                 signal_free_space_change = false;
@@ -1190,7 +1190,7 @@ namespace Files {
             open_file (file, null, null);
         }
 
-        private void on_common_action_bookmark (GLib.SimpleAction action, GLib.Variant? param) {
+        private void on_common_action_bookmark (GLib.SimpleAction action, GLib.Variant? param) requires (window != null) {
             GLib.File location;
             if (selected_files != null) {
                 location = selected_files.data.get_target_location ();
@@ -1203,11 +1203,11 @@ namespace Files {
 
         /** Background actions */
 
-        private void change_state_show_hidden (GLib.SimpleAction action) {
+        private void change_state_show_hidden (GLib.SimpleAction action) requires (window != null) {
             window.change_state_show_hidden (action);
         }
 
-        private void change_state_show_remote_thumbnails (GLib.SimpleAction action) {
+        private void change_state_show_remote_thumbnails (GLib.SimpleAction action) requires (window != null) {
             window.change_state_show_remote_thumbnails (action);
         }
 
@@ -1927,7 +1927,7 @@ namespace Files {
             }
         }
 
-        protected void show_context_menu (Gdk.Event event) {
+        protected void show_context_menu (Gdk.Event event) requires (window != null) {
             cancel_drag_timer ();
             /* select selection or background context menu */
             update_menu_actions ();
@@ -2892,7 +2892,7 @@ namespace Files {
             real_view.motion_notify_event.disconnect (on_drag_timeout_motion_notify);
         }
 
-        private void start_drag_scroll_timer (Gdk.DragContext context) {
+        private void start_drag_scroll_timer (Gdk.DragContext context) requires (window != null) {
             drag_scroll_timer_id = GLib.Timeout.add_full (GLib.Priority.LOW,
                                                           50,
                                                           () => {

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -44,7 +44,7 @@ namespace Files.View {
             }
         }
 
-        public unowned View.Window window {
+        public unowned View.Window? window {
             get { return ctab.window; }
         }
 
@@ -136,7 +136,9 @@ namespace Files.View {
             });
 
             folder_deleted.connect ((file, dir) => {
-               ((Files.Application)(window.application)).folder_deleted (file.location);
+                if (window != null) {
+                    ((Files.Application)(window.application)).folder_deleted (file.location);
+                }
             });
         }
 

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -41,6 +41,7 @@ namespace Files.View {
                 _window = value;
                 _window.folder_deleted.connect (on_folder_deleted);
                 _window.connect_content_signals (this);
+                _window.loading_uri (slot.location.get_uri ());
             }
         }
 
@@ -322,6 +323,10 @@ namespace Files.View {
 
         private void refresh_slot_info (GLib.File loc) {
             update_tab_name ();
+            if (window == null) { // On initial creation window is set later
+                return;
+            }
+
             window.loading_uri (loc.get_uri ()); /* Updates labels as well */
             /* Do not update top menu (or record uri) unless folder loads successfully */
         }

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -428,7 +428,6 @@ namespace Files.View {
             }
 
             if (can_show_folder) {
-                assert (view != null);
                 content = view.get_content_box ();
                 var directory = dir.file;
 
@@ -564,12 +563,10 @@ namespace Files.View {
         }
 
         public Gee.List<string> get_go_back_path_list () {
-            assert (browser != null);
             return browser.go_back_list ();
         }
 
         public Gee.List<string> get_go_forward_path_list () {
-            assert (browser != null);
             return browser.go_forward_list ();
         }
 

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -148,37 +148,6 @@ namespace Files.View {
             loading.connect ((loading) => {
                 is_loading = loading;
             });
-
-            var button_controller = new Gtk.GestureMultiPress (this) {
-                button = 0,
-                propagation_phase = CAPTURE
-            };
-            button_controller.pressed.connect ((n_press, x, y) => {
-                Gdk.ModifierType state;
-                Gtk.get_current_event_state (out state);
-                var mods = state & Gtk.accelerator_get_default_mod_mask ();
-                switch (button_controller.button) {
-                    /* Extra mouse button actions */
-                    case 6:
-                    case 8:
-                        if (mods == 0) {
-                            button_controller.set_state (CLAIMED);
-                            go_back ();
-                        }
-                        break;
-
-                    case 7:
-                    case 9:
-                        if (mods == 0) {
-                            button_controller.set_state (CLAIMED);
-                            go_forward ();
-                        }
-                        break;
-
-                    default:
-                        break;
-                }
-            });
         }
 
         ~ViewContainer () {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -146,14 +146,6 @@ namespace Files.View {
         construct {
             browser = new Browser ();
             set_events (Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
-            connect_signals ();
-        }
-
-        ~ViewContainer () {
-            debug ("ViewContainer destruct");
-        }
-
-        private void connect_signals () {
             loading.connect ((loading) => {
                 is_loading = loading;
             });
@@ -161,6 +153,9 @@ namespace Files.View {
             button_press_event.connect (on_button_press_event);
         }
 
+        ~ViewContainer () {
+            debug ("ViewContainer destruct");
+        }
 
         private void disconnect_signals () {
             disconnect_slot_signals (view);

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -42,6 +42,8 @@ namespace Files.View {
                 _window.folder_deleted.connect (on_folder_deleted);
                 _window.connect_content_signals (this);
                 _window.loading_uri (slot.location.get_uri ());
+                directory_is_loading (slot.location);
+                slot.initialize_directory ();
             }
         }
 
@@ -237,8 +239,6 @@ namespace Files.View {
             view.selection_changed.connect (on_slot_selection_changed);
             view.directory_loaded.connect (on_slot_directory_loaded);
 
-            directory_is_loading (loc);
-            slot.initialize_directory ();
             show_all ();
 
             /* NOTE: slot is created inactive to avoid bug during restoring multiple tabs

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -93,6 +93,39 @@ namespace Files.View {
             }
         }
 
+        public Gtk.Widget? content {
+            set {
+                if (content_item != null) {
+                    remove (content_item);
+                }
+
+                content_item = value;
+
+                if (content_item != null) {
+                    add (content_item);
+                    content_item.show_all ();
+                }
+            }
+            get {
+                return content_item;
+            }
+        }
+
+        // Either the path or a special name or fallback if invalid
+        // Window will use as little as possible to distinguish tabs
+        private string label = "";
+        public string tab_name {
+            private set {
+                if (label != value) { /* Do not signal if no change */
+                    label = value;
+                    tab_name_changed (value);
+                }
+            }
+            get {
+                return label;
+            }
+        }
+
         public bool is_loading {get; private set; default = false;}
 
         private View.OverlayBar overlay_statusbar;
@@ -152,39 +185,6 @@ namespace Files.View {
         public void close () {
             disconnect_signals ();
             view.close ();
-        }
-
-        public Gtk.Widget? content {
-            set {
-                if (content_item != null) {
-                    remove (content_item);
-                }
-
-                content_item = value;
-
-                if (content_item != null) {
-                    add (content_item);
-                    content_item.show_all ();
-                }
-            }
-            get {
-                return content_item;
-            }
-        }
-
-        // Either the path or a special name or fallback if invalid
-        // Window will use as little as possible to distinguish tabs
-        private string label = "";
-        public string tab_name {
-            private set {
-                if (label != value) { /* Do not signal if no change */
-                    label = value;
-                    tab_name_changed (value);
-                }
-            }
-            get {
-                return label;
-            }
         }
 
         public bool go_up () {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -313,9 +313,10 @@ namespace Files.View {
             refresh_slot_info (slot.location);
         }
 
-        private void open_location (GLib.File loc,
-                                    Files.OpenFlag flag = Files.OpenFlag.NEW_ROOT) {
-
+        private void open_location (
+            GLib.File loc,
+            Files.OpenFlag flag = Files.OpenFlag.NEW_ROOT
+        ) {
             switch ((Files.OpenFlag)flag) {
                 case Files.OpenFlag.NEW_TAB:
                 case Files.OpenFlag.NEW_WINDOW:
@@ -333,7 +334,10 @@ namespace Files.View {
             }
         }
 
-        private void on_slot_new_container_request (GLib.File loc, Files.OpenFlag flag = Files.OpenFlag.NEW_ROOT) {
+        private void on_slot_new_container_request (
+            GLib.File loc,
+            Files.OpenFlag flag = Files.OpenFlag.NEW_ROOT
+        ) {
             open_location (loc, flag);
         }
 
@@ -496,10 +500,11 @@ namespace Files.View {
             }
         }
 
-        public void focus_location (GLib.File? loc,
-                                    bool no_path_change = false,
-                                    bool unselect_others = false) {
-
+        public void focus_location (
+            GLib.File? loc,
+            bool no_path_change = false,
+            bool unselect_others = false
+        ) {
             /* This function navigates to another folder if necessary if
              * select_in_current_only is not set to true.
              */
@@ -543,8 +548,10 @@ namespace Files.View {
             }
         }
 
-        public void focus_location_if_in_current_directory (GLib.File? loc,
-                                                            bool unselect_others = false) {
+        public void focus_location_if_in_current_directory (
+            GLib.File? loc,
+            bool unselect_others = false
+        ) {
             focus_location (loc, true, unselect_others);
         }
 

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -366,27 +366,48 @@ namespace Files.View {
                     if (!dir.is_trash) {
                         content = new DirectoryNotFound (slot.directory, this);
                     } else {
-                        content = new View.Welcome (_("This Folder Does Not Exist"),
-                                                    _("You cannot create a folder here."));
+                        content = new Welcome (
+                            _("This Folder Does Not Exist"),
+                            _("You cannot create a folder here.")
+                        );
                     }
                 } else if (!dir.network_available) {
-                    content = new View.Welcome (_("The network is unavailable"),
-                                                _("A working network is needed to reach this folder") + "\n\n" +
-                                                dir.last_error_message);
+                    content = new Welcome (
+                        _("The network is unavailable"),
+                        "%s\n\n%s".printf (
+                            _("A working network is needed to reach this folder"),
+                            dir.last_error_message
+                        )
+                    );
                 } else if (dir.permission_denied) {
-                    content = new View.Welcome (_("This Folder Does Not Belong to You"),
-                                                _("You don't have permission to view this folder."));
+                    content = new Welcome (
+                        _("This Folder Does Not Belong to You"),
+                        _("You don't have permission to view this folder.")
+                    );
                 } else if (!dir.file.is_connected) {
-                    content = new View.Welcome (_("Unable to Mount Folder"),
-                                                _("Could not connect to the server for this folder.") + "\n\n" +
-                                                dir.last_error_message);
+                    content = new Welcome (
+                        _("Unable to Mount Folder"),
+                        "%s\n\n%s".printf (
+                            _("Could not connect to the server for this folder."),
+                            dir.last_error_message
+                        )
+                    );
                 } else if (slot.directory.state == Directory.State.TIMED_OUT) {
-                    content = new View.Welcome (_("Unable to Display Folder Contents"),
-                                                _("The operation timed out.") + "\n\n" + dir.last_error_message);
+                    content = new Welcome (
+                        _("Unable to Display Folder Contents"),
+                        "%s\n\n%s".printf (
+                            _("The operation timed out."),
+                            dir.last_error_message
+                        )
+                    );
                 } else {
-                    content = new View.Welcome (_("Unable to Show Folder"),
-                                                _("The server for this folder could not be located.") + "\n\n" +
-                                                dir.last_error_message);
+                    content = new Welcome (
+                        _("Unable to Show Folder"),
+                        "%s\n\n%s".printf (
+                            _("The server for this folder could not be located."),
+                            dir.last_error_message
+                        )
+                    );
                 }
             /* Now deal with cases where file (s) within the loaded folder has to be selected */
             } else if (selected_locations != null) {
@@ -396,8 +417,10 @@ namespace Files.View {
                 if (dir.selected_file.query_exists ()) {
                     focus_location_if_in_current_directory (dir.selected_file);
                 } else {
-                    content = new View.Welcome (_("File not Found"),
-                                                _("The file selected no longer exists."));
+                    content = new Welcome (
+                        _("File not Found"),
+                        _("The file selected no longer exists.")
+                    );
                     can_show_folder = false;
                 }
             } else {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -260,23 +260,21 @@ namespace Files.View {
         **/
         public void change_view_mode (ViewMode mode, GLib.File? loc = null) {
             var aslot = get_current_slot ();
-            if (aslot == null) {
+            if (aslot == null || mode == view_mode) {
                 return;
             }
 
-            if (mode != view_mode) {
-                aslot.close ();
-                view_mode = mode;
-                loading (false);
-                store_selection ();
-                /* Make sure async loading and thumbnailing are cancelled and signal handlers disconnected */
-                disconnect_slot_signals (view);
-                add_view (mode, loc ?? location);
-                /* Slot is created inactive so we activate now since we must be the current tab
-                 * to have received a change mode instruction */
-                set_active_state (true);
-                /* Do not update top menu (or record uri) unless folder loads successfully */
-            }
+            aslot.close ();
+            view_mode = mode;
+            loading (false);
+            store_selection ();
+            /* Make sure async loading and thumbnailing are cancelled and signal handlers disconnected */
+            disconnect_slot_signals (view);
+            add_view (mode, loc ?? location);
+            /* Slot is created inactive so we activate now since we must be the current tab
+             * to have received a change mode instruction */
+            set_active_state (true);
+            /* Do not update top menu (or record uri) unless folder loads successfully */
         }
 
         private void connect_slot_signals (Files.AbstractSlot aslot) {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -144,6 +144,7 @@ namespace Files.View {
             loading.connect ((loading) => {
                 is_loading = loading;
             });
+            button_press_event.connect (on_button_press_event);
         }
 
         ~ViewContainer () {
@@ -571,6 +572,38 @@ namespace Files.View {
 
         private void on_slot_selection_changed (GLib.List<unowned Files.File> files) {
             overlay_statusbar.selection_changed (files);
+        }
+
+        private bool on_button_press_event (Gdk.EventButton event) {
+            Gdk.ModifierType state;
+            event.get_state (out state);
+            uint button;
+            event.get_button (out button);
+            var mods = state & Gtk.accelerator_get_default_mod_mask ();
+            bool result = false;
+            switch (button) {
+                /* Extra mouse button actions */
+                case 6:
+                case 8:
+                    if (mods == 0) {
+                        result = true;
+                        go_back ();
+                    }
+                    break;
+
+                case 7:
+                case 9:
+                    if (mods == 0) {
+                        result = true;
+                        go_forward ();
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+
+            return result;
         }
     }
 }

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -246,7 +246,12 @@ namespace Files.View {
                 no_show_all = true
             };
 
-            connect_slot_signals (this.view);
+            view.active.connect (on_slot_active);
+            view.path_changed.connect (on_slot_path_changed);
+            view.new_container_request.connect (on_slot_new_container_request);
+            view.selection_changed.connect (on_slot_selection_changed);
+            view.directory_loaded.connect (on_slot_directory_loaded);
+
             directory_is_loading (loc);
             slot.initialize_directory ();
             show_all ();
@@ -277,13 +282,6 @@ namespace Files.View {
             /* Do not update top menu (or record uri) unless folder loads successfully */
         }
 
-        private void connect_slot_signals (Files.AbstractSlot aslot) {
-            aslot.active.connect (on_slot_active);
-            aslot.path_changed.connect (on_slot_path_changed);
-            aslot.new_container_request.connect (on_slot_new_container_request);
-            aslot.selection_changed.connect (on_slot_selection_changed);
-            aslot.directory_loaded.connect (on_slot_directory_loaded);
-        }
 
         private void disconnect_slot_signals (Files.AbstractSlot aslot) {
             aslot.active.disconnect (on_slot_active);

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -193,11 +193,9 @@ namespace Files.View {
         }
 
         private void on_folder_deleted (GLib.File deleted) {
-            if (deleted.equal (this.location)) {
-                if (!go_up ()) {
-                    close ();
-                    window.remove_content (this);
-                }
+            if (deleted.equal (this.location) && !go_up ()) {
+                close ();
+                window.remove_content (this);
             }
         }
 

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -145,7 +145,6 @@ namespace Files.View {
 
         construct {
             browser = new Browser ();
-            set_events (Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
             loading.connect ((loading) => {
                 is_loading = loading;
             });

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -156,9 +156,8 @@ namespace Files.View {
             button_controller.pressed.connect ((n_press, x, y) => {
                 Gdk.ModifierType state;
                 Gtk.get_current_event_state (out state);
-                var button = button_controller.get_button ();
                 var mods = state & Gtk.accelerator_get_default_mod_mask ();
-                switch (button) {
+                switch (button_controller.button) {
                     /* Extra mouse button actions */
                     case 6:
                     case 8:

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -33,13 +33,14 @@ namespace Files.View {
                 return _window;
             }
 
-            set construct {
+            set {
                 if (_window != null) {
                     disconnect_window_signals ();
                 }
 
                 _window = value;
                 _window.folder_deleted.connect (on_folder_deleted);
+                _window.connect_content_signals (this);
             }
         }
 
@@ -136,13 +137,8 @@ namespace Files.View {
         public signal void loading (bool is_loading);
         public signal void active ();
 
-        /* Initial location now set by Window.make_tab after connecting signals */
-        public ViewContainer (View.Window win) {
-            Object (
-                window: win
-            );
-        }
-
+        /* Initial location now set by Window.make_tab after connecting signals.
+         * Window property set when tab is attached to a tab_view (See Window.vala) */
         construct {
             browser = new Browser ();
             loading.connect ((loading) => {
@@ -157,6 +153,7 @@ namespace Files.View {
         private void disconnect_window_signals () {
             if (window != null) {
                 window.folder_deleted.disconnect (on_folder_deleted);
+                window.disconnect_content_signals (this);
             }
         }
 

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -157,11 +157,6 @@ namespace Files.View {
             debug ("ViewContainer destruct");
         }
 
-        private void disconnect_signals () {
-            disconnect_slot_signals (view);
-            disconnect_window_signals ();
-        }
-
         private void disconnect_window_signals () {
             if (window != null) {
                 window.folder_deleted.disconnect (on_folder_deleted);
@@ -178,7 +173,8 @@ namespace Files.View {
         }
 
         public void close () {
-            disconnect_signals ();
+            disconnect_slot_signals (view);
+            disconnect_window_signals ();
             view.close ();
         }
 

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -150,7 +150,37 @@ namespace Files.View {
                 is_loading = loading;
             });
 
-            button_press_event.connect (on_button_press_event);
+            var button_controller = new Gtk.GestureMultiPress (this) {
+                button = 0,
+                propagation_phase = CAPTURE
+            };
+            button_controller.pressed.connect ((n_press, x, y) => {
+                Gdk.ModifierType state;
+                Gtk.get_current_event_state (out state);
+                var button = button_controller.get_button ();
+                var mods = state & Gtk.accelerator_get_default_mod_mask ();
+                switch (button) {
+                    /* Extra mouse button actions */
+                    case 6:
+                    case 8:
+                        if (mods == 0) {
+                            button_controller.set_state (CLAIMED);
+                            go_back ();
+                        }
+                        break;
+
+                    case 7:
+                    case 9:
+                        if (mods == 0) {
+                            button_controller.set_state (CLAIMED);
+                            go_forward ();
+                        }
+                        break;
+
+                    default:
+                        break;
+                }
+            });
         }
 
         ~ViewContainer () {
@@ -572,38 +602,6 @@ namespace Files.View {
 
         private void on_slot_selection_changed (GLib.List<unowned Files.File> files) {
             overlay_statusbar.selection_changed (files);
-        }
-
-        private bool on_button_press_event (Gdk.EventButton event) {
-            Gdk.ModifierType state;
-            event.get_state (out state);
-            uint button;
-            event.get_button (out button);
-            var mods = state & Gtk.accelerator_get_default_mod_mask ();
-            bool result = false;
-            switch (button) {
-                /* Extra mouse button actions */
-                case 6:
-                case 8:
-                    if (mods == 0) {
-                        result = true;
-                        go_back ();
-                    }
-                    break;
-
-                case 7:
-                case 9:
-                    if (mods == 0) {
-                        result = true;
-                        go_forward ();
-                    }
-                    break;
-
-                default:
-                    break;
-            }
-
-            return result;
         }
     }
 }

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -33,13 +33,13 @@ namespace Files.View {
                 return _window;
             }
 
-            set {
+            set construct {
                 if (_window != null) {
                     disconnect_window_signals ();
                 }
 
                 _window = value;
-                connect_window_signals ();
+                _window.folder_deleted.connect (on_folder_deleted);
             }
         }
 
@@ -105,9 +105,13 @@ namespace Files.View {
 
         /* Initial location now set by Window.make_tab after connecting signals */
         public ViewContainer (View.Window win) {
-            window = win;
-            browser = new Browser ();
+            Object (
+                window: win
+            );
+        }
 
+        construct {
+            browser = new Browser ();
             set_events (Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
             connect_signals ();
         }
@@ -124,11 +128,6 @@ namespace Files.View {
             button_press_event.connect (on_button_press_event);
         }
 
-        private void connect_window_signals () {
-            if (window != null) {
-                window.folder_deleted.connect (on_folder_deleted);
-            }
-        }
 
         private void disconnect_signals () {
             disconnect_slot_signals (view);

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -159,7 +159,7 @@ namespace Files.View {
             }
         }
 
-        private void on_folder_deleted (GLib.File deleted) {
+        private void on_folder_deleted (GLib.File deleted) requires (window != null) {
             if (deleted.equal (this.location) && !go_up ()) {
                 close ();
                 window.remove_content (this);
@@ -283,7 +283,7 @@ namespace Files.View {
         private void open_location (
             GLib.File loc,
             Files.OpenFlag flag = Files.OpenFlag.NEW_ROOT
-        ) {
+        ) requires (window != null) {
             switch ((Files.OpenFlag)flag) {
                 case Files.OpenFlag.NEW_TAB:
                 case Files.OpenFlag.NEW_WINDOW:

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -283,7 +283,6 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         /*/
         /* Connect and abstract signals to local ones
         /*/
-
         view_switcher.action.activate.connect ((id) => {
             switch ((ViewMode)(id.get_uint32 ())) {
                 case ViewMode.ICON:
@@ -347,9 +346,6 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
             return false;
         });
-
-
-
 
         //TODO Rewrite for Gtk4
         window_state_event.connect ((event) => {
@@ -797,10 +793,9 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     private void add_window (GLib.File location = default_location, ViewMode mode = default_mode) {
-        with (new Window (marlin_app)) {
-            add_tab (location, real_mode (mode), false);
-            present ();
-        }
+        var new_window = new Window (marlin_app);
+        new_window.add_tab (location, real_mode (mode), false);
+        new_window.present ();
     }
 
     private void undo_actions_set_insensitive () {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -610,7 +610,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
         mode = real_mode (mode);
         var content = new View.ViewContainer ();
-        connect_content_signals (content);
+
         if (!location.equal (_location)) {
             content.add_view (mode, location, {_location});
         } else {
@@ -619,6 +619,8 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
         var page = tab_view.append (content);
         tab_view.selected_page = page;
+
+        connect_content_signals (content);
 
         return true;
     }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -349,47 +349,6 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         });
 
 
-        var button_controller = new Gtk.GestureMultiPress (this) {
-            button = 0,
-            propagation_phase = CAPTURE
-        };
-
-        button_controller.pressed.connect ((n_press, x, y) => {
-            Gdk.ModifierType state;
-            Gtk.get_current_event_state (out state);
-            var mods = state & Gtk.accelerator_get_default_mod_mask ();
-            switch (button_controller.button) {
-                case 0:
-                    if ((mods & Gdk.ModifierType.MOD1_MASK) > 0) {
-                        button_controller.set_state (CLAIMED);
-                        if ((mods & Gdk.ModifierType.SHIFT_MASK) > 0) {
-                            current_container.go_forward ();
-                        } else {
-                             current_container.go_back ();
-                        }
-                    }
-                    break;
-                /* Extra mouse button actions */
-                case 6:
-                case 8:
-                    if (mods == 0) {
-                        button_controller.set_state (CLAIMED);
-                        current_container.go_back ();
-                    }
-                    break;
-
-                case 7:
-                case 9:
-                    if (mods == 0) {
-                        button_controller.set_state (CLAIMED);
-                        current_container.go_forward ();
-                    }
-                    break;
-
-                default:
-                    break;
-            }
-        });
 
 
         //TODO Rewrite for Gtk4

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1209,6 +1209,10 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     private void save_active_tab_position () {
+        if (tab_view.selected_page == null) {
+            return;
+        }
+
         Files.app_settings.set_int (
             "active-tab-position",
             tab_view.get_page_position (tab_view.selected_page)

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -22,6 +22,8 @@
 */
 
 public class Files.View.Window : Hdy.ApplicationWindow {
+    static uint window_id = 0;
+
     const GLib.ActionEntry [] WIN_ENTRIES = {
         {"new-window", action_new_window},
         {"refresh", action_reload},
@@ -98,11 +100,11 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     public signal void folder_deleted (GLib.File location);
     public signal void free_space_change ();
 
-    public Window (Files.Application application) {
+    public Window (Files.Application _application) {
         Object (
-            application: application,
-            marlin_app: application,
-            window_number: application.window_count
+            application: (Gtk.Application)_application,
+            marlin_app: _application,
+            window_number: Files.View.Window.window_id++
         );
     }
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -347,6 +347,49 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         });
 
 
+        var button_controller = new Gtk.GestureMultiPress (this) {
+            button = 0,
+            propagation_phase = CAPTURE
+        };
+
+        button_controller.pressed.connect ((n_press, x, y) => {
+            Gdk.ModifierType state;
+            Gtk.get_current_event_state (out state);
+            var mods = state & Gtk.accelerator_get_default_mod_mask ();
+            switch (button_controller.button) {
+                case 0:
+                    if ((mods & Gdk.ModifierType.MOD1_MASK) > 0) {
+                        button_controller.set_state (CLAIMED);
+                        if ((mods & Gdk.ModifierType.SHIFT_MASK) > 0) {
+                            current_container.go_forward ();
+                        } else {
+                             current_container.go_back ();
+                        }
+                    }
+                    break;
+                /* Extra mouse button actions */
+                case 6:
+                case 8:
+                    if (mods == 0) {
+                        button_controller.set_state (CLAIMED);
+                        current_container.go_back ();
+                    }
+                    break;
+
+                case 7:
+                case 9:
+                    if (mods == 0) {
+                        button_controller.set_state (CLAIMED);
+                        current_container.go_forward ();
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        });
+
+
         //TODO Rewrite for Gtk4
         window_state_event.connect ((event) => {
             if (Gdk.WindowState.ICONIFIED in event.changed_mask) {


### PR DESCRIPTION
Fixes #2376

Gtk4 Prep:
 - Use event controller
 - No set_events ()

Cleanup:
 - Modernise construction style
 - Modernise layout, reduce line length
 - Merge single use functions