### PR TITLE
[Gtk4Prep] Views: Use EventControllerKey where possible

### DIFF
--- a/src/Utils/KeyUtils.vala
+++ b/src/Utils/KeyUtils.vala
@@ -24,15 +24,14 @@ namespace KeyUtils {
      * to the same position as on a Latin QWERTY keyboard. If the conversion fails, the unprocessed
      * event.keyval is used. */
     //TODO Needs complete rewrite for Gtk4 so leaving some direct access of event struct
-    public static uint map_key (Gdk.EventKey event, out Gdk.ModifierType consumed_mods) {
-        uint original_keyval, keyval;
-        event.get_keyval (out original_keyval);
-        keyval = original_keyval;
+    public static uint map_key (uint original_keyval, uint keycode, out Gdk.ModifierType consumed_mods) {
+        uint keyval = original_keyval;
         consumed_mods = 0;
 
         if (keyval > 127) {
             int eff_grp, level;
-            var display = event.get_device ().get_display ();
+            var event = (Gdk.EventKey)(Gtk.get_current_event ());
+            var display = Gtk.get_current_event_device ().get_display ();
             var keymap = Gdk.Keymap.get_for_display (display);
             if (!keymap.translate_keyboard_state (
                     event.hardware_keycode,

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -235,14 +235,14 @@ namespace Files {
                          */
                         disconnect_tree_signals ();
                         clipboard.changed.disconnect (on_clipboard_changed);
-                        view.key_press_event.disconnect (on_view_key_press_event);
                     } else {
-                        view.key_press_event.connect (on_view_key_press_event);
                         clipboard.changed.connect (on_clipboard_changed);
                         connect_tree_signals ();
 
                         update_menu_actions ();
                     }
+
+                    key_controller.propagation_phase = value ? Gtk.PropagationPhase.NONE : Gtk.PropagationPhase.BUBBLE;
                 }
             }
 
@@ -277,6 +277,8 @@ namespace Files {
         protected static DndHandler dnd_handler = new DndHandler ();
 
         protected unowned Gtk.RecentManager recent;
+
+        protected Gtk.EventControllerKey key_controller;
 
         public signal void path_change_request (GLib.File location, Files.OpenFlag flag, bool new_root);
         public signal void selection_changed (GLib.List<Files.File> gof_file);
@@ -326,13 +328,18 @@ namespace Files {
 
                 view.motion_notify_event.connect (on_motion_notify_event);
                 view.leave_notify_event.connect (on_leave_notify_event);
-                view.key_press_event.connect (on_view_key_press_event);
                 view.button_press_event.connect (on_view_button_press_event);
                 view.button_release_event.connect (on_view_button_release_event);
                 view.draw.connect (on_view_draw);
                 view.realize.connect (() => {
                    schedule_thumbnail_color_tag_timeout ();
                 });
+
+                key_controller = new Gtk.EventControllerKey (view) {
+                    propagation_phase = BUBBLE
+                };
+
+                key_controller.key_pressed.connect (on_view_key_press_event);
             }
 
             freeze_tree (); /* speed up loading of icon view. Thawed when directory loaded */
@@ -2982,20 +2989,20 @@ namespace Files {
         }
 
 /** Keyboard event handling **/
-        protected virtual bool on_view_key_press_event (Gdk.EventKey event) {
+        protected virtual bool on_view_key_press_event (uint original_keyval, uint keycode, Gdk.ModifierType state) {
             if (is_frozen) {
                 return true;
             }
 
-            if (event.is_modifier == 1) {
+            var event = Gtk.get_current_event ();
+            if (((Gdk.EventKey)event).is_modifier == 1) {
                 return true;
             }
 
             cancel_hover ();
 
-            Gdk.ModifierType consumed_mods, state;
-            var keyval = KeyUtils.map_key (event, out consumed_mods);
-            event.get_state (out state);
+            Gdk.ModifierType consumed_mods;
+            var keyval = KeyUtils.map_key (original_keyval, keycode, out consumed_mods);
 
             var mods = (state & ~consumed_mods) & Gtk.accelerator_get_default_mod_mask ();
             bool no_mods = (mods == 0);

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -365,7 +365,7 @@ namespace Files {
             }
         }
 
-        /* Override base class in order to disable the Gtk.TreeView local search functionality */
+        /* Override Gtk.TreeView default key press signal handler in order to disable the local search functionality */
         public override bool key_press_event (Gdk.EventKey event) {
             /* We still need the base class to handle cursor keys first */
             uint keyval;
@@ -382,11 +382,11 @@ namespace Files {
                 case Gdk.Key.Home:
                 case Gdk.Key.End:
 
-                    return base.key_press_event (event);
+                    return base.key_press_event (event); // Handled by Gtk.TreeView
 
                 default:
 
-                    return false; // Pass event to Window handler.
+                    return Gdk.EVENT_PROPAGATE; // Handled by AbstractDirectoryView or Window
             }
         }
     }

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -73,31 +73,28 @@ namespace Files {
             return tree as Gtk.Widget;
         }
 
-        protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            Gdk.ModifierType state;
-            event.get_state (out state);
+        /* Handle back and forward cursor keys differently */
+        public override bool key_press_event (Gdk.EventKey event) {
             uint keyval;
             event.get_keyval (out keyval);
-            var mods = state & Gtk.accelerator_get_default_mod_mask ();
+            var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
             bool no_mods = (mods == 0);
-
             switch (keyval) {
-                /* Do not emit alert sound on left and right cursor keys in Miller View */
                 case Gdk.Key.Left:
                 case Gdk.Key.Right:
                 case Gdk.Key.BackSpace:
                     if (no_mods) {
                         /* Pass event to MillerView */
-                        slot.colpane.key_press_event (event);
-                        return true;
+                        return ((Files.View.Miller)(slot.ctab.view)).on_miller_key_pressed (event);
                     }
+
                     break;
 
                 default:
                     break;
             }
 
-            return base.on_view_key_press_event (event);
+            return key_controller.handle_event (event);
         }
 
         protected override bool handle_primary_button_click (Gdk.Event event, Gtk.TreePath? path) {

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -154,15 +154,10 @@ namespace Files {
             }
         }
 
-        protected override bool on_view_key_press_event (Gdk.EventKey event) {
-            Gdk.ModifierType state;
-            event.get_state (out state);
+        protected override bool on_view_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {
             bool control_pressed = ((state & Gdk.ModifierType.CONTROL_MASK) != 0);
             bool shift_pressed = ((state & Gdk.ModifierType.SHIFT_MASK) != 0);
-
             if (!control_pressed && !shift_pressed) {
-                uint keyval;
-                event.get_keyval (out keyval);
                 switch (keyval) {
                     case Gdk.Key.Right:
                         Gtk.TreePath? path = null;
@@ -193,7 +188,7 @@ namespace Files {
                 }
             }
 
-            return base.on_view_key_press_event (event);
+            return base.on_view_key_press_event (keyval, keycode, state);
         }
 
         protected override Gtk.Widget? create_view () {

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -258,7 +258,6 @@ namespace Files.View {
             slot.new_container_request.connect (on_new_container_request);
             slot.size_change.connect (update_total_width);
             slot.folder_deleted.connect (on_slot_folder_deleted);
-            slot.colpane.key_press_event.connect (on_key_pressed);
             slot.path_changed.connect (on_slot_path_changed);
             slot.directory_loaded.connect (on_slot_directory_loaded);
             slot.hpane.notify["position"].connect (update_total_width);
@@ -272,7 +271,6 @@ namespace Files.View {
             slot.new_container_request.disconnect (on_new_container_request);
             slot.size_change.disconnect (update_total_width);
             slot.folder_deleted.disconnect (on_slot_folder_deleted);
-            slot.colpane.key_press_event.disconnect (on_key_pressed);
             slot.path_changed.disconnect (on_slot_path_changed);
             slot.directory_loaded.disconnect (on_slot_directory_loaded);
         }
@@ -360,7 +358,8 @@ namespace Files.View {
             }
         }
 
-        private bool on_key_pressed (Gtk.Widget box, Gdk.EventKey event) {
+        // Called by ColumnView
+        public bool on_miller_key_pressed (Gdk.EventKey event) {
             /* Only handle unmodified keys */
             Gdk.ModifierType state;
             event.get_state (out state);


### PR DESCRIPTION
An EventControllerKey is added to AbstractDirectoryView.

It was still necessary to handle `Gdk.EventKey` in some places, in particular to override the native behaviour of Gtk.TreeView.  This will become unnecessary on porting to Gtk4.