### PR TITLE
[Gtk4Prep] EditableLabel: Use EventControllerKey, cleanup

### DIFF
--- a/src/TextRenderer.vala
+++ b/src/TextRenderer.vala
@@ -82,12 +82,15 @@ namespace Files {
         public TextRenderer (ViewMode viewmode) {
             if (viewmode == ViewMode.ICON) {
                 entry = new MultiLineEditableLabel ();
+                entry.set_justify (Gtk.Justification.CENTER);
                 is_list_view = false;
             } else {
                 entry = new SingleLineEditableLabel ();
+                entry.set_justify (Gtk.Justification.LEFT);
                 is_list_view = true;
             }
 
+            entry.set_line_wrap (true);
             entry.editing_done.connect (on_entry_editing_done);
         }
 
@@ -216,22 +219,9 @@ namespace Files {
                 return null;
             }
 
-            float xalign, yalign;
-            get_alignment (out xalign, out yalign);
 
             entry.set_text (text);
-            entry.set_line_wrap (true);
             entry.set_line_wrap_mode (wrap_mode);
-
-            if (!is_list_view) {
-                entry.set_justify (Gtk.Justification.CENTER);
-                entry.draw_outline = true;
-            } else {
-                entry.set_justify (Gtk.Justification.LEFT);
-                entry.draw_outline = false;
-            }
-
-            entry.yalign = this.yalign;
             entry.set_size_request (wrap_width, -1);
             entry.set_position (-1);
             entry.set_data ("marlin-text-renderer-path", path.dup ());

--- a/src/View/Widgets/AbstractEditableLabel.vala
+++ b/src/View/Widgets/AbstractEditableLabel.vala
@@ -18,27 +18,17 @@
 
 namespace Files {
     public abstract class AbstractEditableLabel : Gtk.Frame, Gtk.Editable, Gtk.CellEditable {
-
         public bool editing_canceled { get; set; }
-        public bool small_size { get; set; }
-        public float yalign {get; set;}
-        public float xalign {get; set;}
         public string original_name;
-        public bool draw_outline {get; set;}
-
-        private Gtk.Widget editable_widget;
         private Gtk.EventControllerKey key_controller;
 
-        protected AbstractEditableLabel () {
-            editable_widget = create_editable_widget ();
-            add (editable_widget);
-            show_all ();
-            get_real_editable ().key_press_event.connect (on_key_press_event);
-            key_controller = new Gtk.EventControllerKey (get_real_editable ());
+        protected void connect_editable_widget (Gtk.Widget editable_widget) {
+            key_controller = new Gtk.EventControllerKey (editable_widget);
             key_controller.key_pressed.connect (on_key_press_event);
+            editable_widget.button_press_event.connect_after (() => { return true; });
         }
 
-        public virtual bool on_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {
+        protected virtual bool on_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {
             var mods = state & Gtk.accelerator_get_default_mod_mask ();
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
             switch (keyval) {
@@ -89,7 +79,6 @@ namespace Files {
         public virtual void set_padding (int xpad, int ypad) {}
 
         public abstract new void set_size_request (int width, int height);
-        public abstract Gtk.Widget create_editable_widget ();
         public abstract string get_text ();
         public abstract void select_region (int start_pos, int end_pos);
         public abstract void do_delete_text (int start_pos, int end_pos);
@@ -98,8 +87,6 @@ namespace Files {
         public abstract int get_position ();
         public abstract bool get_selection_bounds (out int start_pos, out int end_pos);
         public abstract void set_position (int position);
-        public abstract Gtk.Widget get_real_editable ();
-
 
         /** CellEditable interface */
         public virtual void start_editing (Gdk.Event? event) {}

--- a/src/View/Widgets/AbstractEditableLabel.vala
+++ b/src/View/Widgets/AbstractEditableLabel.vala
@@ -27,22 +27,20 @@ namespace Files {
         public bool draw_outline {get; set;}
 
         private Gtk.Widget editable_widget;
+        private Gtk.EventControllerKey key_controller;
 
         protected AbstractEditableLabel () {
             editable_widget = create_editable_widget ();
             add (editable_widget);
             show_all ();
             get_real_editable ().key_press_event.connect (on_key_press_event);
+            key_controller = new Gtk.EventControllerKey (get_real_editable ());
+            key_controller.key_pressed.connect (on_key_press_event);
         }
 
-        public virtual bool on_key_press_event (Gdk.EventKey event) {
-            Gdk.ModifierType state;
-            event.get_state (out state);
-            uint keyval;
-            event.get_keyval (out keyval);
+        public virtual bool on_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {
             var mods = state & Gtk.accelerator_get_default_mod_mask ();
             bool only_control_pressed = (mods == Gdk.ModifierType.CONTROL_MASK);
-
             switch (keyval) {
                 case Gdk.Key.Return:
                 case Gdk.Key.KP_Enter:
@@ -71,6 +69,7 @@ namespace Files {
                 default:
                     break;
             }
+
             return false;
         }
 

--- a/src/View/Widgets/MultiLineEditableLabel.vala
+++ b/src/View/Widgets/MultiLineEditableLabel.vala
@@ -18,26 +18,16 @@
 
 namespace Files {
     public class MultiLineEditableLabel : AbstractEditableLabel {
-
         protected Gtk.ScrolledWindow scrolled_window;
-        protected Gtk.TextView textview;
+        public Gtk.TextView textview { get; construct; }
 
-        public MultiLineEditableLabel () {}
-
-        public override Gtk.Widget create_editable_widget () {
+        construct {
             textview = new Gtk.TextView ();
-            /* Block propagation of button press event as this would cause renaming to end */
-            textview.button_press_event.connect_after (() => { return true; });
-
+            connect_editable_widget (textview);
             scrolled_window = new Gtk.ScrolledWindow (null, null) {
                 child = textview
             };
-
-            return scrolled_window as Gtk.Widget;
-        }
-
-        public override Gtk.Widget get_real_editable () {
-            return textview;
+            add (scrolled_window);
         }
 
         public override void set_text (string text) {
@@ -93,7 +83,6 @@ namespace Files {
         }
 
         /** Gtk.Editable interface */
-
         public override void select_region (int start_pos, int end_pos) {
             textview.grab_focus ();
             var buffer = textview.get_buffer ();
@@ -182,19 +171,17 @@ namespace Files {
 
         public override bool draw (Cairo.Context cr) {
             bool result = base.draw (cr);
-            if (draw_outline) {
-                Gtk.Allocation allocation;
-                Gdk.RGBA color;
-                Gdk.Rectangle outline;
+            Gtk.Allocation allocation;
+            Gdk.RGBA color;
+            Gdk.Rectangle outline;
 
-                get_allocation (out allocation);
-                color = get_style_context ().get_color (get_state_flags ());
-                Gdk.cairo_set_source_rgba (cr, color);
-                cr.set_line_width (1.0);
-                outline = {0, 0, allocation.width, allocation.height};
-                Gdk.cairo_rectangle (cr, outline);
-                cr.stroke ();
-            }
+            get_allocation (out allocation);
+            color = get_style_context ().get_color (get_state_flags ());
+            Gdk.cairo_set_source_rgba (cr, color);
+            cr.set_line_width (1.0);
+            outline = {0, 0, allocation.width, allocation.height};
+            Gdk.cairo_rectangle (cr, outline);
+            cr.stroke ();
             return result;
         }
 

--- a/src/View/Widgets/SingleLineEditableLabel.vala
+++ b/src/View/Widgets/SingleLineEditableLabel.vala
@@ -66,10 +66,8 @@ namespace Files {
             return textview.get_text ();
         }
 
-        public override bool on_key_press_event (Gdk.EventKey event) {
+        public override bool on_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {
             /* Ensure rename cancelled on cursor Up/Down */
-            uint keyval;
-            event.get_keyval (out keyval);
             switch (keyval) {
                 case Gdk.Key.Up:
                 case Gdk.Key.Down:
@@ -80,7 +78,7 @@ namespace Files {
                     break;
             }
 
-            return base.on_key_press_event (event);
+            return base.on_key_press_event (keyval, keycode, state);
         }
 
         /** Gtk.Editable interface */

--- a/src/View/Widgets/SingleLineEditableLabel.vala
+++ b/src/View/Widgets/SingleLineEditableLabel.vala
@@ -18,29 +18,20 @@
 
 namespace Files {
     public class SingleLineEditableLabel : AbstractEditableLabel {
-
         protected Gtk.Entry textview;
         private int select_start = 0;
         private int select_end = 0;
 
-        public SingleLineEditableLabel () {}
-
-        public override Gtk.Widget create_editable_widget () {
+        construct {
             textview = new Gtk.Entry ();
-            /* Block propagation of button press event as this would cause renaming to end */
-            textview.button_press_event.connect_after (() => { return true; });
-            return textview as Gtk.Widget;
-        }
-
-        public override Gtk.Widget get_real_editable () {
-            return textview;
+            connect_editable_widget (textview);
+            add (textview);
         }
 
         public override void set_text (string text) {
             textview.set_text (text);
             original_name = text;
         }
-
 
         public override void set_justify (Gtk.Justification jtype) {
             switch (jtype) {
@@ -82,7 +73,6 @@ namespace Files {
         }
 
         /** Gtk.Editable interface */
-
         public override void select_region (int start_pos, int end_pos) {
             /* Cannot select textview region here because it is not realised yet and the selected region
              * will be overridden when keyboard focus is grabbed after realising. So just remember start and end.


### PR DESCRIPTION
Use EventControllerKey 

Cleanup:
- TextRenderer: Set some EditableLabel properties that do not change after construction in the constructor
 - TextRenderer: Lose alignments that have no effect
 - AbstractEditableLabel: Lose unused or unneeded properties
 - Simplify and DRY construction, lose /merge unneeded functions
 - MultilineEditableLabel - draw_outline is always true