### PR TITLE
Window: do not capture keyevents when view is renaming

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -336,9 +336,11 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         };
 
         key_controller.key_pressed.connect ((keyval, keycode, state) => {
+            // Handle key press events when directoryview has focus except when it must retain
+            // focus because e.g.renaming
             var focus_widget = get_focus ();
-            if (focus_widget != null && current_container != null &&
-                focus_widget.is_ancestor (current_container)) {
+            if (current_container != null && !current_container.locked_focus &&
+                focus_widget != null && focus_widget.is_ancestor (current_container)) {
 
                 var mods = state & Gtk.accelerator_get_default_mod_mask ();
                 /* Use find function instead of view interactive search */


### PR DESCRIPTION
Fixes #2397 

Fixes another unfortunate side-effect of having the Window override the native key handling of Gtk.TreeView (in order to get desired search behaviour), which requires it to handle events in the `CAPTURE` phase.  The window now checks that the focus is not locked on the view before handling key presses.

