### PR TITLE
[Gtk4Prep] Views:  Use Gtk.GestureMultiPress

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -189,7 +189,6 @@ namespace Files {
         protected bool on_directory = false;
         protected bool one_or_less = true;
         protected bool should_activate = false;
-        protected bool should_scroll = true;
         protected bool should_deselect = false;
         public bool singleclick_select { get; set; }
         protected bool should_select = false;
@@ -3497,7 +3496,6 @@ namespace Files {
             should_activate = false;
             should_deselect = false;
             should_select = false;
-            should_scroll = true;
 
             /* Handle all selection and deselection explicitly in the following switch statement */
             switch (button) {
@@ -3614,7 +3612,6 @@ namespace Files {
 
                     /* Ensure selected files list and menu actions are updated before context menu shown */
                     update_selected_files_and_menu ();
-                    should_scroll = false; // Miller should not scroll while context menu opening
                     break;
 
                 default:
@@ -3633,8 +3630,9 @@ namespace Files {
                 return;
             }
 
-            slot.active (should_scroll);
             var button = button_controller.get_current_button ();
+            slot.active (button == Gdk.BUTTON_SECONDARY);
+
             /* Only take action if pointer has not moved */
             if (!Gtk.drag_check_threshold (get_child (), (int)drag_x, (int)drag_y, (int)x, (int)y)) {
                 if (should_activate) {

--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -173,7 +173,7 @@ namespace Files {
             return tree.get_visible_range (out start_path, out end_path);
         }
 
-        protected override uint get_event_position_info (Gdk.Event event,
+        protected override uint get_event_position_info (double x, double y,
                                                          out Gtk.TreePath? path,
                                                          bool rubberband = false) {
             Gtk.TreePath? p = null;
@@ -182,13 +182,7 @@ namespace Files {
             int cx, cy, depth;
             path = null;
 
-            var ewindow = event.get_window ();
-            if (ewindow != tree.get_bin_window ()) {
-                return ClickZone.INVALID;
-            }
 
-            double x, y;
-            event.get_coords (out x, out y);
             tree.get_path_at_pos ((int)x, (int)y, out p, out c, out cx, out cy);
             path = p;
             depth = p != null ? p.get_depth () : 0;

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -73,10 +73,10 @@ namespace Files {
 
 
         protected override bool handle_primary_button_click (
-            uint n_press, 
-            Gdk.ModifierType mods, 
+            uint n_press,
+            Gdk.ModifierType mods,
             Gtk.TreePath? path
-        ){
+        ) {
             Files.File? file = null;
             Files.File? selected_folder = null;
             Gtk.TreeIter? iter = null;

--- a/src/View/ColumnView.vala
+++ b/src/View/ColumnView.vala
@@ -71,7 +71,12 @@ namespace Files {
             return tree as Gtk.Widget;
         }
 
-        protected override bool handle_primary_button_click (Gdk.Event event, Gtk.TreePath? path) {
+
+        protected override bool handle_primary_button_click (
+            uint n_press, 
+            Gdk.ModifierType mods, 
+            Gtk.TreePath? path
+        ){
             Files.File? file = null;
             Files.File? selected_folder = null;
             Gtk.TreeIter? iter = null;
@@ -85,14 +90,12 @@ namespace Files {
             }
 
             if (file == null || !file.is_folder ()) {
-                return base.handle_primary_button_click (event, path);
+                return base.handle_primary_button_click (n_press, mods, path);
             }
 
             selected_folder = file;
             bool result = true;
-
-            var type = event.get_event_type ();
-            if (type == Gdk.EventType.BUTTON_PRESS) {
+            if (n_press == 1) {
                 /* Ignore second GDK_BUTTON_PRESS event of double-click */
                 if (awaiting_double_click) {
                     result = true;
@@ -105,7 +108,7 @@ namespace Files {
                         return GLib.Source.REMOVE;
                     });
                 }
-            } else if (type == Gdk.EventType.@2BUTTON_PRESS) {
+            } else if (n_press == 2) {
                 should_activate = false;
                 cancel_await_double_click ();
 
@@ -119,9 +122,9 @@ namespace Files {
             return result;
         }
 
-        protected override bool handle_default_button_click (Gdk.Event event) {
+        protected override bool handle_default_button_click () {
             cancel_await_double_click ();
-            return base.handle_default_button_click (event);
+            return base.handle_default_button_click ();
         }
 
         public override void cancel () {

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -150,15 +150,13 @@ public class Files.IconView : Files.AbstractDirectoryView {
         return tree.get_visible_range (out start_path, out end_path);
     }
 
-    protected override uint get_event_position_info (Gdk.Event event,
+    protected override uint get_event_position_info (double x, double y,
                                                      out Gtk.TreePath? path,
                                                      bool rubberband = false) {
         Gtk.CellRenderer? cell_renderer;
         uint zone;
         path = null;
 
-        double x, y;
-        event.get_coords (out x, out y);
 
         tree.get_item_at_pos ((int)x, (int)y, out path, out cell_renderer);
         zone = (path != null ? ClickZone.BLANK_PATH : ClickZone.BLANK_NO_PATH);


### PR DESCRIPTION
Discontinues support for secondary button dragging for simplicity (avoids a lot of ugly code and probably rarely if ever used - it no longer behaves different from primary anyway).