### PR TITLE
Desktop: update, singlemainwindow

### DIFF
--- a/data/io.elementary.files.desktop.in.in
+++ b/data/io.elementary.files.desktop.in.in
@@ -1,24 +1,29 @@
 [Desktop Entry]
+Version=1.5
+Type=Application
+
 Name=Files
 Comment=Browse your files
-Keywords=folder;manager;explore;disk;filesystem;
-GenericName=File Manager
-Exec=@exec_name@ %U
-#TRANSLATORS This string is an icon name and should not be translated.
-Icon=system-file-manager
-Terminal=false
-StartupNotify=true
-Type=Application
-MimeType=inode/directory;
 Categories=System;
+Keywords=folder;manager;explore;disk;filesystem;
+
+Icon=system-file-manager
+Exec=@exec_name@ %U
+SingleMainWindow=false
+StartupNotify=true
+Terminal=false
+
+MimeType=inode/directory;
+
 X-GNOME-Gettext-Domain=@exec_name@
 X-GNOME-UsesNotifications=true
-Actions=WindowNew;Root;
 
-[Desktop Action WindowNew]
+Actions=new-window;root;
+
+[Desktop Action new-window]
 Name=New Window
 Exec=@exec_name@ -n
 
-[Desktop Action Root]
+[Desktop Action root]
 Name=New Window As Administrator
 Exec=@exec_name@-pkexec


### PR DESCRIPTION
Update to look more like what appstream generator gives us with spaces between sections:

* Add desktop entry version
* Remove GenericName which is never used
* Add SingleMainWindow to hint to the shell this app is multi-window
* Remove comment since `Icon` no longer shows in translation files
* Rename "NewWindow" action to "new-window" as recommended in https://github.com/elementary/dock/issues/77#issuecomment-1821781386