### PR TITLE
Improve thumbnailing Part2: Only generate large thumbnails

### DIFF
--- a/libcore/FileConflictDialog.vala
+++ b/libcore/FileConflictDialog.vala
@@ -72,7 +72,7 @@ public class Files.FileConflictDialog : Granite.MessageDialog {
                                                                    Files.File.IconFlags.USE_THUMBNAILS);
         });
 
-        thumbnailer.queue_file (destination, null, false);
+        thumbnailer.queue_file (destination, null);
         destination_size_label.label = destination.format_size;
         destination_time_label.label = destination.formated_modified;
 

--- a/libcore/Thumbnailer.vala
+++ b/libcore/Thumbnailer.vala
@@ -230,7 +230,7 @@ namespace Files {
                     foreach (var file in files) {
                         // Do not leave in LOADING state
                         file.thumbstate = Files.File.ThumbState.NONE;
-                        file.update_icon ();
+                        file.query_thumbnail_update ();
                     }
                 }
             });
@@ -366,7 +366,7 @@ namespace Files {
                 var goffile = Files.File.get_by_uri (uri);
                 if (goffile.thumbstate == Files.File.ThumbState.LOADING) {
                     goffile.thumbstate = Files.File.ThumbState.NONE;
-                    goffile.update_icon ();
+                    goffile.query_thumbnail_update ();
                 }
             }
 
@@ -382,7 +382,7 @@ namespace Files {
             var goffile = Files.File.get_by_uri (uri);
             if (goffile != null) {
                 goffile.thumbstate = state;
-                goffile.update_icon ();
+                goffile.query_thumbnail_update ();
             }
         }
     }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -124,7 +124,6 @@ namespace Files {
 
         protected ZoomLevel minimum_zoom = ZoomLevel.SMALLEST;
         protected ZoomLevel maximum_zoom = ZoomLevel.LARGEST;
-        protected bool large_thumbnails = false;
 
         /* Used only when acting as drag source */
         double drag_x = 0;
@@ -301,7 +300,6 @@ namespace Files {
                 if (req == thumbnail_request) {
                     thumbnail_request = -1;
                 }
-
                 draw_when_idle ();
             });
 
@@ -1380,7 +1378,7 @@ namespace Files {
                 add_file (file, dir, is_internal); /* Only select files added to view by this app */
                 handle_free_space_change ();
                 Idle.add (() => {
-                    update_thumbnail_info_and_plugins (file);
+                    update_icon_and_plugins (file);
                     return Source.REMOVE;
                 });
             } else {
@@ -1409,11 +1407,11 @@ namespace Files {
 
             model.file_changed (file, dir);
             Idle.add (() => {
-                update_thumbnail_info_and_plugins (file);
+                update_icon_and_plugins (file);
                 if ((!slot.directory.is_network && show_local_thumbnails) ||
                     (show_remote_thumbnails && slot.directory.can_open_files)) {
 
-                    thumbnailer.queue_file (file, null, large_thumbnails);
+                    thumbnailer.queue_file (file, null);
                 }
 
                 return Source.REMOVE;
@@ -1472,14 +1470,6 @@ namespace Files {
 
     /** Handle zoom level change */
         private void on_zoom_level_changed (ZoomLevel zoom) {
-            var size = icon_size * get_scale_factor ();
-
-            if (!large_thumbnails && size > 128 || large_thumbnails && size <= 128) {
-                large_thumbnails = size > 128;
-                slot.refresh_files (); /* Force GOF files to switch between normal and large thumbnails */
-                schedule_thumbnail_color_tag_timeout ();
-            }
-
             model.icon_size = icon_size;
             change_zoom_level ();
         }
@@ -2784,7 +2774,7 @@ namespace Files {
                         file = model.file_for_iter (iter); // Maybe null if dummy row or file being deleted
                         path = model.get_path (iter);
                         if (file != null) {
-                            update_thumbnail_info_and_plugins (file);
+                            update_icon_and_plugins (file);
                             /* Ask thumbnailer only if ThumbState UNKNOWN */
                             if (file.thumbstate == Files.File.ThumbState.UNKNOWN) {
                                 visible_files.prepend (file);
@@ -2809,7 +2799,7 @@ namespace Files {
                     * thumbnails are not hidden by settings
                  */
                 if (actually_visible > 0 && thumbnail_source_id > 0) {
-                    thumbnailer.queue_files (visible_files, out thumbnail_request, large_thumbnails);
+                    thumbnailer.queue_files (visible_files, out thumbnail_request);
                 } else {
                     draw_when_idle ();
                 }
@@ -2822,13 +2812,13 @@ namespace Files {
 
         // Called on individual files when added or changed as well as on all visible files
         // by schedule_thumbnail_color_tag_timeout.
-        private void update_thumbnail_info_and_plugins (Files.File file) {
+        private void update_icon_and_plugins (Files.File file) {
             if (file != null && !file.is_gone) {
                 // Only update thumbnail if it is going to be shown
                 if ((slot.directory.is_network && show_remote_thumbnails) ||
                     (!slot.directory.is_network && show_local_thumbnails)) {
 
-                    file.query_thumbnail_update (); // Ensure thumbstate up to date
+                    file.update_icon ();
                 }
                /* In any case, ensure color-tag info is correct */
                 if (plugins != null) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2818,7 +2818,7 @@ namespace Files {
                 if ((slot.directory.is_network && show_remote_thumbnails) ||
                     (!slot.directory.is_network && show_local_thumbnails)) {
 
-                    file.update_icon ();
+                    file.query_thumbnail_update ();
                 }
                /* In any case, ensure color-tag info is correct */
                 if (plugins != null) {


### PR DESCRIPTION
Cherry-picked and adapted from #2340

Results in smoother zooming to large icons.  No discernible performance impact with modern hardware.
