### PR TITLE
Improve thumbnailing Part3: Refresh thumbnail after edit

### DIFF
--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -989,6 +989,11 @@ public class Files.Directory : Object {
     }
 
     private void real_directory_changed (GLib.File _file, GLib.File? other_file, FileMonitorEvent event) {
+        // Ignore events from transient streams
+        if (_file.get_basename ().has_prefix (".goutputstream")) {
+            return;
+        }
+
         switch (event) {
             case FileMonitorEvent.CREATED:
                 Files.FileChanges.queue_file_added (_file, false);

--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -999,12 +999,13 @@ public class Files.Directory : Object {
             case FileMonitorEvent.CHANGED:
                 // e.g. When data streamed into file
             case FileMonitorEvent.ATTRIBUTE_CHANGED: /* test  last to avoid unnecessary action when file renamed */
-                // e.g. changed permissions
+                // // e.g. changed permissions
                 Files.FileChanges.queue_file_changed (_file);
                 break;
             case FileMonitorEvent.CHANGES_DONE_HINT:
                 // TODO Check for unexpected regressions caused by not refreshing file info here. It should already
                 // have been done if requried by one of the set of changes so doing it again is inefficient.
+                Files.FileChanges.queue_file_changed (_file);
                 break;
             case FileMonitorEvent.MOVED:
                 break;

--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -1004,12 +1004,12 @@ public class Files.Directory : Object {
             case FileMonitorEvent.CHANGED:
                 // e.g. When data streamed into file
             case FileMonitorEvent.ATTRIBUTE_CHANGED: /* test  last to avoid unnecessary action when file renamed */
-                // // e.g. changed permissions
+                // e.g. changed permissions
                 Files.FileChanges.queue_file_changed (_file);
                 break;
             case FileMonitorEvent.CHANGES_DONE_HINT:
                 // TODO Check for unexpected regressions caused by not refreshing file info here. It should already
-                // have been done if requried by one of the set of changes so doing it again is inefficient.
+                // have been done if required by one of the set of changes so doing it again is inefficient.
                 Files.FileChanges.queue_file_changed (_file);
                 break;
             case FileMonitorEvent.MOVED:

--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -98,7 +98,8 @@ public class Files.File : GLib.Object {
             _thumbnail_path = value;
         }
     }
-    private bool thumbnail_loaded = false;
+
+    public bool thumbnail_loaded = false;
     public bool is_mounted = true;
     public bool exists = true;
     public uint32 uid;

--- a/libcore/File.vala
+++ b/libcore/File.vala
@@ -683,16 +683,10 @@ public class Files.File : GLib.Object {
                 var md5_hash = GLib.Checksum.compute_for_string (GLib.ChecksumType.MD5, uri);
                 var base_name = "%s.png".printf (md5_hash);
 
-                /* Use $XDG_CACHE_HOME specified thumbnail directory instead of hard coding */
-                unowned string folder_size = "normal";
-                if (pix_size * pix_scale > 128) {
-                    folder_size = "large";
-                }
-
                 thumbnail_path = GLib.Path.build_filename (
                     GLib.Environment.get_user_cache_dir (),
                     "thumbnails",
-                    folder_size,
+                    "large",
                     base_name
                 );
             } else if (thumbnail_loaded) {

--- a/libcore/FileChanges.vala
+++ b/libcore/FileChanges.vala
@@ -52,7 +52,15 @@ namespace Files.FileChanges {
     private static void queue_add_common (owned Change new_item) {
         unowned GLib.Queue<Change> queue = get_queue ();
         queue_mutex.@lock ();
-        queue.push_head ((owned) new_item);
+        unowned var last_item = queue.peek_head ();
+        // Ignore sequential duplicate events
+        if (last_item == null ||
+            !(last_item.from.equal (new_item.from)) ||
+            last_item.kind != new_item.kind) {
+
+            queue.push_head ((owned) new_item);
+        }
+
         queue_mutex.unlock ();
     }
 

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1402,6 +1402,8 @@ namespace Files {
         }
 
         private void on_directory_file_icon_changed (Directory dir, Files.File file) {
+            file.thumbnail_loaded = false;
+
             if (is_frozen) {
                 return;
             }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -300,6 +300,7 @@ namespace Files {
                 if (req == thumbnail_request) {
                     thumbnail_request = -1;
                 }
+
                 draw_when_idle ();
             });
 
@@ -2713,13 +2714,13 @@ namespace Files {
             assert (slot is Files.AbstractSlot && slot.directory != null);
 
             /* Check all known conditions preventing thumbnailing at earliest possible stage */
-            if (thumbnail_source_id != 0 ||
-                !slot.directory.can_open_files ||
+            if (!slot.directory.can_open_files ||
                 slot.directory.is_loading ()) {
 
                     return;
             }
 
+            /* Restart the timeout.
             /* Do not cancel existing requests to avoid missing thumbnails */
             cancel_timeout (ref thumbnail_source_id);
             /* In order to improve performance of the Icon View when there are a large number of files,
@@ -2800,9 +2801,10 @@ namespace Files {
                  */
                 if (actually_visible > 0 && thumbnail_source_id > 0) {
                     thumbnailer.queue_files (visible_files, out thumbnail_request);
-                } else {
-                    draw_when_idle ();
                 }
+
+                //Need to redraw anyway so that standard icons are rendered.
+                draw_when_idle ();
 
                 thumbnail_source_id = 0;
 
@@ -2812,8 +2814,8 @@ namespace Files {
 
         // Called on individual files when added or changed as well as on all visible files
         // by schedule_thumbnail_color_tag_timeout.
-        private void update_icon_and_plugins (Files.File file) {
-            if (file != null && !file.is_gone) {
+        private void update_icon_and_plugins (Files.File file) requires (file != null) {
+            if (!file.is_gone) {
                 // Only update thumbnail if it is going to be shown
                 if ((slot.directory.is_network && show_remote_thumbnails) ||
                     (!slot.directory.is_network && show_local_thumbnails)) {


### PR DESCRIPTION
#Fixes #2327
Cherry-picked from #2340 

* React to CHANGES_DONE_HINT monitor event.
* Invalidate loaded thumbnail after changed
* Ignore duplicate and transient events
* Only use large thumbnails (consequent to recent change)