### PR TITLE
PropertiesWindow: redesign permisssions

### DIFF
--- a/data/files.gresource.xml
+++ b/data/files.gresource.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/io/elementary/files/">
+    <file alias="Application.css" compressed="true">styles/Application.css</file>
     <file alias="ColorButton.css" compressed="true">styles/ColorButton.css</file>
     <file alias="DiskRenderer.css" compressed="true">styles/DiskRenderer.css</file>
     <file alias="SidebarExpander.css" compressed="true">styles/SidebarExpander.css</file>
+  </gresource>
+  <gresource prefix="/io/elementary/files/icons">
+    <file alias="scalable/status/permission-execute-prevent-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/permission-execute-prevent.svg</file>
+    <file alias="scalable/status/permission-execute-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/permission-execute.svg</file>
+    <file alias="scalable/status/permission-read-prevent-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/permission-read-prevent.svg</file>
+    <file alias="scalable/status/permission-read-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/permission-read.svg</file>
+    <file alias="scalable/status/permission-write-prevent-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/permission-write-prevent.svg</file>
+    <file alias="scalable/status/permission-write-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/permission-write.svg</file>
   </gresource>
 </gresources>

--- a/data/icons/permission-execute-prevent.svg
+++ b/data/icons/permission-execute-prevent.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="16"
+   height="16"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path1"
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;font-variation-settings:normal;opacity:0.5;vector-effect:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M 4.34375 2.0019531 C 4.280841 1.9993892 4.2174186 2.0012137 4.1542969 2.0078125 C 3.498018 2.0765392 3.0000519 2.6224741 3 3.2734375 L 3 3.7011719 L 10.353516 11.054688 L 14.404297 8.9765625 C 15.198995 8.5678403 15.198995 7.4458316 14.404297 7.0371094 L 4.8867188 2.1445312 C 4.7178468 2.0577302 4.5324769 2.0096449 4.34375 2.0019531 z M 3 5.4667969 L 3.0039062 12.722656 C 3.0043425 13.679887 4.0338429 14.295761 4.8945312 13.853516 L 9.1875 11.652344 L 3 5.4667969 z " />
+  <rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.992001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     id="rect2480-1-6"
+     width="1.248"
+     height="19.799999"
+     x="-0.6257652"
+     y="1.416185"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-45)" />
+</svg>

--- a/data/icons/permission-execute.svg
+++ b/data/icons/permission-execute.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="16"
+   height="16"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path1"
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 4.1542969,2.0070909 C 3.4980174,2.0758177 3.0000519,2.6218544 3,3.2728185 l 0.00391,9.4505085 c 4.363e-4,0.957232 1.0299357,1.572911 1.8906249,1.130665 L 14.404297,8.9763101 c 0.794699,-0.4087226 0.794699,-1.5303874 0,-1.93911 L 4.8867187,2.1440828 C 4.6615559,2.0283479 4.4067842,1.9806956 4.1542969,2.0070909 Z" />
+</svg>

--- a/data/icons/permission-read-prevent.svg
+++ b/data/icons/permission-read-prevent.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg8"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <path
+     id="rect1405-1"
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;opacity:0.5;stop-opacity:1"
+     d="M 8 2 C 6.0787207 2 4.3215777 2.6786075 2.9453125 3.640625 L 4.8574219 5.5527344 A 3.9999998 3.9999998 0 0 1 8 4 A 3.9999998 3.9999998 0 0 1 12 8 A 3.9999998 3.9999998 0 0 1 10.458984 11.154297 L 12.197266 12.892578 C 14.481725 11.637972 16 9.5649546 16 8 C 16 5.6 12.432 2 8 2 z M 1.9667969 4.4277344 C 0.74202545 5.5651659 -5.3935644e-16 6.9069295 0 8 C 0 10.399999 3.5680001 14 8 14 C 9.0579889 14 10.065546 13.794217 10.988281 13.449219 L 9.3144531 11.775391 A 3.9999998 3.9999998 0 0 1 8 12 A 3.9999998 3.9999998 0 0 1 4 8 A 3.9999998 3.9999998 0 0 1 4.2363281 6.6972656 L 1.9667969 4.4277344 z M 8 6 A 2 2 0 0 0 6.2832031 6.9785156 L 9.0214844 9.7167969 A 2 2 0 0 0 10 8 A 2 2 0 0 0 8 6 z M 6.0761719 8.5371094 A 2 2 0 0 0 7.4628906 9.9238281 L 6.0761719 8.5371094 z " />
+  <rect
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.992001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect2480"
+     width="1.248"
+     height="19.799999"
+     x="-0.62576789"
+     y="1.4161836"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-45)" />
+</svg>

--- a/data/icons/permission-read.svg
+++ b/data/icons/permission-read.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg8"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <path
+     id="rect1405-1-3"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.992;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="M 8,2 C 3.5680001,2 0,5.6 0,8 c 0,2.399999 3.5680001,6 8,6 4.432,0 8,-3.600001 8,-6 C 16,5.6 12.432,2 8,2 Z M 8,4 A 3.9999998,3.9999998 0 0 1 12,8 3.9999998,3.9999998 0 0 1 8,12 3.9999998,3.9999998 0 0 1 4,8 3.9999998,3.9999998 0 0 1 8,4 Z M 8,6 A 2,2 0 0 0 6,8 2,2 0 0 0 8,10 2,2 0 0 0 10,8 2,2 0 0 0 8,6 Z" />
+</svg>

--- a/data/icons/permission-write-prevent.svg
+++ b/data/icons/permission-write-prevent.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <path
+     id="path1"
+     style="font-variation-settings:normal;opacity:0.5;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="M 12.212891 1 A 0.83 0.83 0 0 0 11.623047 1.2460938 L 10.716797 2.1582031 L 13.841797 5.2832031 L 14.751953 4.3769531 C 15.081953 4.0469535 15.081953 3.5272653 14.751953 3.1972656 L 12.802734 1.2460938 A 0.83 0.83 0 0 0 12.212891 1 z M 9.6582031 3.2207031 L 6.0878906 6.7910156 L 9.2089844 9.9121094 L 12.777344 6.34375 L 9.6582031 3.2207031 z M 5.2050781 7.6738281 L 0.9921875 11.888672 L 0.9921875 15.007812 L 4.1132812 15.007812 L 8.3261719 10.794922 L 5.2050781 7.6738281 z M 2 12 L 3 12 L 3 13 L 4 13 L 4 14 L 2 14 L 2 12 z " />
+  <rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.992001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     id="rect2480-1-6"
+     width="1.248"
+     height="19.799999"
+     x="-0.6257652"
+     y="1.416185"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-45)" />
+</svg>

--- a/data/icons/permission-write.svg
+++ b/data/icons/permission-write.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     transform="translate(-533 11)"
+     id="g1"
+     style="fill:#555761">
+    <path
+       d="M545.213-10a.83.83 0 0 0-.59.246l-.906.912 3.125 3.125.91-.906c.33-.33.33-.85 0-1.18l-1.95-1.95a.83.83 0 0 0-.589-.247zm-2.555 2.22L533.992.888v3.119h3.121l8.665-8.664zM535 1h1v1h1v1h-2z"
+       fill="#666"
+       id="path1"
+       style="fill:#555761" />
+  </g>
+</svg>

--- a/data/styles/Application.css
+++ b/data/styles/Application.css
@@ -1,0 +1,34 @@
+/*FIXME: Remove list styles in Gtk4*/
+list.rich-list > row {
+    padding: 6px;
+    min-height: 32px;
+}
+
+list.rich-list label {
+    margin: 0 6px;
+}
+
+list.rich-list button.toggle {
+    margin: 3px 0;
+}
+
+list:not(.horizontal) row.separator,
+list.separators:not(.horizontal) > row:not(.separator) + row:not(.separator) {
+    border-top: 1px solid @menu_separator;
+}
+
+list.boxed-list {
+    border-radius: 6px;
+    box-shadow: 0 1px 3px alpha(black, 0.1);
+}
+
+list.boxed-list > row:first-child {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+}
+
+list.boxed-list > row:last-child {
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    border-bottom-width: 0;
+}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -152,6 +152,11 @@ public class Files.Application : Gtk.Application {
         QuicklistHandler.get_singleton ();
 #endif
 
+        var app_provider = new Gtk.CssProvider ();
+        app_provider.load_from_resource ("/io/elementary/files/Application.css");
+
+        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), app_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
         var granite_settings = Granite.Settings.get_default ();
         var gtk_settings = Gtk.Settings.get_default ();
 

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -996,9 +996,9 @@ public class Files.View.PropertiesWindow : AbstractPropertiesDialog {
             perm_grid.attach (owner_user_choice, 1, 0);
             perm_grid.attach (group_combo_label, 0, 1);
             perm_grid.attach (group_combo, 1, 1);
-            perm_grid.attach (l_perm, 0, 2);
-            perm_grid.attach (perm_code, 1, 2);
-            perm_grid.attach (permission_box, 0, 3, 2);
+            perm_grid.attach (permission_box, 0, 2, 2);
+            perm_grid.attach (l_perm, 0, 3);
+            perm_grid.attach (perm_code, 1, 3);
 
             update_perm_grid_toggle_states (goffile.permissions);
 

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -964,13 +964,8 @@ public class Files.View.PropertiesWindow : AbstractPropertiesDialog {
             var group_combo = create_group_choice ();
             group_combo.margin_bottom = 12;
 
-            var owner_label = make_key_label (_("Owner:"));
             perm_button_user = create_perm_choice (Permissions.Type.USER);
-
-            var group_label = make_key_label (_("Group:"));
             perm_button_group = create_perm_choice (Permissions.Type.GROUP);
-
-            var other_label = make_key_label (_("Everyone:"));
             perm_button_other = create_perm_choice (Permissions.Type.OTHER);
 
             perm_code = new Gtk.Entry ();
@@ -981,23 +976,29 @@ public class Files.View.PropertiesWindow : AbstractPropertiesDialog {
             l_perm.halign = Gtk.Align.START;
             l_perm.use_markup = true;
 
+            var permission_box = new Gtk.ListBox () {
+                selection_mode = NONE
+            };
+            // FIXME: use constants in Gtk4
+            permission_box.get_style_context ().add_class ("frame");
+            permission_box.get_style_context ().add_class ("rich-list");
+            permission_box.get_style_context ().add_class ("boxed-list");
+            permission_box.get_style_context ().add_class ("separators");
+            permission_box.add (perm_button_user);
+            permission_box.add (perm_button_group);
+            permission_box.add (perm_button_other);
+
             perm_grid = new Gtk.Grid () {
                 column_spacing = 6,
-                row_spacing = 6,
-                halign = Gtk.Align.CENTER
+                row_spacing = 6
             };
-            perm_grid.attach (owner_user_label, 0, 1, 1, 1);
-            perm_grid.attach (owner_user_choice, 1, 1, 2, 1);
-            perm_grid.attach (group_combo_label, 0, 2, 1, 1);
-            perm_grid.attach (group_combo, 1, 2, 2, 1);
-            perm_grid.attach (owner_label, 0, 3, 1, 1);
-            perm_grid.attach (perm_button_user, 1, 3, 2, 1);
-            perm_grid.attach (group_label, 0, 4, 1, 1);
-            perm_grid.attach (perm_button_group, 1, 4, 2, 1);
-            perm_grid.attach (other_label, 0, 5, 1, 1);
-            perm_grid.attach (perm_button_other, 1, 5, 2, 1);
-            perm_grid.attach (l_perm, 1, 6, 1, 1);
-            perm_grid.attach (perm_code, 2, 6, 1, 1);
+            perm_grid.attach (owner_user_label, 0, 0);
+            perm_grid.attach (owner_user_choice, 1, 0);
+            perm_grid.attach (group_combo_label, 0, 1);
+            perm_grid.attach (group_combo, 1, 1);
+            perm_grid.attach (l_perm, 0, 2);
+            perm_grid.attach (perm_code, 1, 2);
+            perm_grid.attach (permission_box, 0, 3, 2);
 
             update_perm_grid_toggle_states (goffile.permissions);
 

--- a/src/Utils/Permissions.vala
+++ b/src/Utils/Permissions.vala
@@ -21,7 +21,19 @@ namespace Permissions {
     public enum Type {
         USER,
         GROUP,
-        OTHER
+        OTHER;
+
+        public string to_string () {
+            switch (this) {
+                case USER:
+                    return _("Owner");
+                case GROUP:
+                    return _("Group");
+                default:
+                case OTHER:
+                    return _("Everyone");
+            }
+        }
     }
 
     public enum Value {

--- a/src/View/Widgets/PermissionButton.vala
+++ b/src/View/Widgets/PermissionButton.vala
@@ -17,10 +17,10 @@
 * Boston, MA 02110-1335 USA.
 */
 
-public class PermissionButton : Gtk.Grid {
-    public Gtk.ToggleButton btn_read;
-    public Gtk.ToggleButton btn_write;
-    public Gtk.ToggleButton btn_exe;
+public class PermissionButton : Gtk.ListBoxRow {
+    public Gtk.ToggleButton btn_read { get; private set; }
+    public Gtk.ToggleButton btn_write { get; private set; }
+    public Gtk.ToggleButton btn_exe { get; private set; }
 
     public Permissions.Type permission_type { get; construct; }
 
@@ -30,47 +30,81 @@ public class PermissionButton : Gtk.Grid {
         { Posix.S_IROTH, Posix.S_IWOTH, Posix.S_IXOTH }
     };
 
+    private static Gtk.SizeGroup label_sizegroup;
+
     public PermissionButton (Permissions.Type permission_type) {
         Object (permission_type: permission_type);
     }
 
+    static construct {
+        label_sizegroup = new Gtk.SizeGroup (HORIZONTAL);
+    }
+
     construct {
-        btn_read = new Gtk.ToggleButton.with_label (_("Read"));
+        var label = new Gtk.Label (permission_type.to_string ()) {
+            xalign = 0
+        };
+
+        label_sizegroup.add_widget (label);
+
+        btn_read = new Gtk.ToggleButton () {
+            hexpand = true,
+            image = new Gtk.Image.from_icon_name ("permission-read-symbolic", BUTTON),
+            tooltip_text = _("Read")
+        };
         btn_read.set_data ("permissiontype", permission_type);
         btn_read.set_data ("permissionvalue", Permissions.Value.READ);
 
-        btn_write = new Gtk.ToggleButton.with_label (_("Write"));
+        btn_write = new Gtk.ToggleButton () {
+            hexpand = true,
+            image = new Gtk.Image.from_icon_name ("permission-write-symbolic", BUTTON),
+            tooltip_text = _("Write")
+        };
         btn_write.set_data ("permissiontype", permission_type);
         btn_write.set_data ("permissionvalue", Permissions.Value.WRITE);
 
-        btn_exe = new Gtk.ToggleButton.with_label (_("Execute"));
+        btn_exe = new Gtk.ToggleButton () {
+            hexpand = true,
+            image = new Gtk.Image.from_icon_name ("permission-execute-symbolic", BUTTON),
+            tooltip_text = _("Execute")
+        };
         btn_exe.set_data ("permissiontype", permission_type);
         btn_exe.set_data ("permissionvalue", Permissions.Value.EXE);
 
-        column_homogeneous = true;
-        get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-        add (btn_read);
-        add (btn_write);
-        add (btn_exe);
+        var box = new Gtk.Box (HORIZONTAL, 6);
+        box.add (label);
+        box.add (btn_read);
+        box.add (btn_write);
+        box.add (btn_exe);
+
+        child = box;
+        selectable = false;
+        activatable = false;
     }
 
     public void update_buttons (uint32 permissions) {
         if ((permissions & vfs_perms[permission_type, 0]) != 0) {
             btn_read.active = true;
+            ((Gtk.Image) btn_read.image).icon_name = "permission-read-symbolic";
         } else {
             btn_read.active = false;
+            ((Gtk.Image) btn_read.image).icon_name = "permission-read-prevent-symbolic";
         }
 
         if ((permissions & vfs_perms[permission_type, 1]) != 0) {
             btn_write.active = true;
+            ((Gtk.Image) btn_write.image).icon_name = "permission-write-symbolic";
         } else {
             btn_write.active = false;
+            ((Gtk.Image) btn_write.image).icon_name = "permission-write-prevent-symbolic";
         }
 
         if ((permissions & vfs_perms[permission_type, 2]) != 0) {
             btn_exe.active = true;
+            ((Gtk.Image) btn_exe.image).icon_name = "permission-execute-symbolic";
         } else {
             btn_exe.active = false;
+            ((Gtk.Image) btn_exe.image).icon_name = "permission-execute-prevent-symbolic";
         }
     }
 }


### PR DESCRIPTION
Attemping to address https://github.com/elementary/stylesheet/issues/345

Uses icons that have `\` states and non-linked buttons to try to make it clearer which permissions are selected

## AFTER

![Screenshot from 2024-08-28 13 03 12](https://github.com/user-attachments/assets/8b671471-346c-4be7-82ce-6d34e2570afb)

## BEFORE

![Screenshot from 2024-08-28 13 05 23](https://github.com/user-attachments/assets/c29fcd9c-2476-4e33-a91c-ab815b2b32f3)
