### PR TITLE
PopupMenuBuilder: use GLib.Action for MountableRow

### DIFF
--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -80,20 +80,24 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.MenuItem.with_mnemonic (_("Properties")), cb);
     }
 
-    public PopupMenuBuilder add_eject_drive (string detailed_action_name) {
+    public void add_eject_drive (uint32 id) {
         // Do we need different text for USB sticks and optical drives?
         var menu_item = new Gtk.MenuItem.with_mnemonic (_("Eject Media"));
-        menu_item.set_detailed_action_name (detailed_action_name);
+        menu_item.set_detailed_action_name (
+            Action.print_detailed_name ("device.eject", new Variant.uint32 (id))
+        );
 
-        return add_item (menu_item);
+        add_item (menu_item);
     }
 
-    public PopupMenuBuilder add_safely_remove (string detailed_action_name) {
+    public void add_safely_remove (uint32 id) {
         // Do we need different text for USB sticks and optical drives?
         var menu_item = new Gtk.MenuItem.with_mnemonic (_("Safely Remove"));
-        menu_item.set_detailed_action_name (detailed_action_name);
+        menu_item.set_detailed_action_name (
+            Action.print_detailed_name ("device.safely-remove", new Variant.uint32 (id))
+        );
 
-        return add_item (menu_item);
+        add_item (menu_item);
     }
 
     public PopupMenuBuilder add_bookmark (MenuitemCallback cb) {

--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -22,8 +22,10 @@ public class PopupMenuBuilder : Object {
     Gtk.MenuItem[] menu_items = {};
     public uint n_items { get { return menu_items.length; }}
 
-    public Gtk.Menu build () {
-        var popupmenu = new Gtk.Menu ();
+    public Gtk.Menu build (Gtk.Widget attach_widget) {
+        var popupmenu = new Gtk.Menu () {
+            attach_widget = attach_widget
+        };
         foreach (var menu_item in menu_items) {
             popupmenu.append (menu_item);
         }
@@ -78,14 +80,20 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.MenuItem.with_mnemonic (_("Properties")), cb);
     }
 
-    public PopupMenuBuilder add_eject_drive (MenuitemCallback cb) {
+    public PopupMenuBuilder add_eject_drive (string detailed_action_name) {
         // Do we need different text for USB sticks and optical drives?
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("Eject Media")), cb);
+        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Eject Media"));
+        menu_item.set_detailed_action_name (detailed_action_name);
+
+        return add_item (menu_item);
     }
 
-    public PopupMenuBuilder add_safely_remove (MenuitemCallback cb) {
+    public PopupMenuBuilder add_safely_remove (string detailed_action_name) {
         // Do we need different text for USB sticks and optical drives?
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("Safely Remove")), cb);
+        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Safely Remove"));
+        menu_item.set_detailed_action_name (detailed_action_name);
+
+        return add_item (menu_item);
     }
 
     public PopupMenuBuilder add_bookmark (MenuitemCallback cb) {

--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -81,8 +81,13 @@ public class PopupMenuBuilder : Object {
         add_item (menu_item);
     }
 
-    public PopupMenuBuilder add_drive_property (MenuitemCallback cb) {
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("Properties")), cb);
+    public void add_drive_property (uint32 id) {
+        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Properties"));
+        menu_item.set_detailed_action_name (
+            Action.print_detailed_name ("device.properties", new Variant.uint32 (id))
+        );
+
+        add_item (menu_item);
     }
 
     public void add_eject_drive (uint32 id) {

--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -68,22 +68,22 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.MenuItem.with_label (_("Rename")), cb);
     }
 
-    public void add_unmount (uint32 id) {
-        add_with_action_name (_("_Unmount"), "mountable.unmount", id);
+    public void add_unmount () {
+        add_with_action_name (_("_Unmount"), "mountable.unmount");
     }
 
-    public void add_drive_property (uint32 id) {
-        add_with_action_name (_("Properties"), "mountable.properties", id);
+    public void add_drive_property () {
+        add_with_action_name (_("Properties"), "mountable.properties");
     }
 
-    public void add_eject_drive (uint32 id) {
+    public void add_eject_drive () {
         // Do we need different text for USB sticks and optical drives?
-        add_with_action_name (_("Eject Media"), "mountable.eject", id);
+        add_with_action_name (_("Eject Media"), "mountable.eject");
     }
 
-    public void add_safely_remove (uint32 id) {
+    public void add_safely_remove () {
         // Do we need different text for USB sticks and optical drives?
-        add_with_action_name (_("Safely Remove"), "mountable.safely-remove", id);
+        add_with_action_name (_("Safely Remove"), "mountable.safely-remove");
     }
 
     public PopupMenuBuilder add_bookmark (MenuitemCallback cb) {
@@ -121,10 +121,10 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.SeparatorMenuItem ());
     }
 
-    private void add_with_action_name (string label, string action_name, uint32 id) {
+    private void add_with_action_name (string label, string action_name) {
         var menu_item = new Gtk.MenuItem.with_mnemonic (label);
         menu_item.set_detailed_action_name (
-            Action.print_detailed_name (action_name, new Variant.uint32 (id))
+            Action.print_detailed_name (action_name, null)
         );
 
         menu_item.show ();

--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -69,21 +69,21 @@ public class PopupMenuBuilder : Object {
     }
 
     public void add_unmount (uint32 id) {
-        add_item_with_action (_("_Unmount"), "device.unmount", id);
+        add_with_action_name (_("_Unmount"), "device.unmount", id);
     }
 
     public void add_drive_property (uint32 id) {
-        add_item_with_action (_("Properties"), "device.properties", id);
+        add_with_action_name (_("Properties"), "device.properties", id);
     }
 
     public void add_eject_drive (uint32 id) {
         // Do we need different text for USB sticks and optical drives?
-        add_item_with_action (_("Eject Media"), "device.eject", id);
+        add_with_action_name (_("Eject Media"), "device.eject", id);
     }
 
     public void add_safely_remove (uint32 id) {
         // Do we need different text for USB sticks and optical drives?
-        add_item_with_action (_("Safely Remove"), "device.safely-remove", id);
+        add_with_action_name (_("Safely Remove"), "device.safely-remove", id);
     }
 
     public PopupMenuBuilder add_bookmark (MenuitemCallback cb) {
@@ -121,7 +121,7 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.SeparatorMenuItem ());
     }
 
-    private void add_item_with_action (string label, string action_name, uint32 id) {
+    private void add_with_action_name (string label, string action_name, uint32 id) {
         var menu_item = new Gtk.MenuItem.with_mnemonic (label);
         menu_item.set_detailed_action_name (
             Action.print_detailed_name (action_name, new Variant.uint32 (id))

--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -69,21 +69,21 @@ public class PopupMenuBuilder : Object {
     }
 
     public void add_unmount (uint32 id) {
-        add_with_action_name (_("_Unmount"), "device.unmount", id);
+        add_with_action_name (_("_Unmount"), "mountable.unmount", id);
     }
 
     public void add_drive_property (uint32 id) {
-        add_with_action_name (_("Properties"), "device.properties", id);
+        add_with_action_name (_("Properties"), "mountable.properties", id);
     }
 
     public void add_eject_drive (uint32 id) {
         // Do we need different text for USB sticks and optical drives?
-        add_with_action_name (_("Eject Media"), "device.eject", id);
+        add_with_action_name (_("Eject Media"), "mountable.eject", id);
     }
 
     public void add_safely_remove (uint32 id) {
         // Do we need different text for USB sticks and optical drives?
-        add_with_action_name (_("Safely Remove"), "device.safely-remove", id);
+        add_with_action_name (_("Safely Remove"), "mountable.safely-remove", id);
     }
 
     public PopupMenuBuilder add_bookmark (MenuitemCallback cb) {

--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -72,8 +72,13 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.MenuItem.with_mnemonic (_("_Mount")), cb);
     }
 
-    public PopupMenuBuilder add_unmount (MenuitemCallback cb) {
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("_Unmount")), cb);
+    public void add_unmount (uint32 id) {
+        var menu_item = new Gtk.MenuItem.with_mnemonic (_("_Unmount"));
+        menu_item.set_detailed_action_name (
+            Action.print_detailed_name ("device.unmount", new Variant.uint32 (id))
+        );
+
+        add_item (menu_item);
     }
 
     public PopupMenuBuilder add_drive_property (MenuitemCallback cb) {

--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -68,46 +68,22 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.MenuItem.with_label (_("Rename")), cb);
     }
 
-    public PopupMenuBuilder add_mount (MenuitemCallback cb) {
-        return add_item (new Gtk.MenuItem.with_mnemonic (_("_Mount")), cb);
-    }
-
     public void add_unmount (uint32 id) {
-        var menu_item = new Gtk.MenuItem.with_mnemonic (_("_Unmount"));
-        menu_item.set_detailed_action_name (
-            Action.print_detailed_name ("device.unmount", new Variant.uint32 (id))
-        );
-
-        add_item (menu_item);
+        add_item_with_action (_("_Unmount"), "device.unmount", id);
     }
 
     public void add_drive_property (uint32 id) {
-        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Properties"));
-        menu_item.set_detailed_action_name (
-            Action.print_detailed_name ("device.properties", new Variant.uint32 (id))
-        );
-
-        add_item (menu_item);
+        add_item_with_action (_("Properties"), "device.properties", id);
     }
 
     public void add_eject_drive (uint32 id) {
         // Do we need different text for USB sticks and optical drives?
-        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Eject Media"));
-        menu_item.set_detailed_action_name (
-            Action.print_detailed_name ("device.eject", new Variant.uint32 (id))
-        );
-
-        add_item (menu_item);
+        add_item_with_action (_("Eject Media"), "device.eject", id);
     }
 
     public void add_safely_remove (uint32 id) {
         // Do we need different text for USB sticks and optical drives?
-        var menu_item = new Gtk.MenuItem.with_mnemonic (_("Safely Remove"));
-        menu_item.set_detailed_action_name (
-            Action.print_detailed_name ("device.safely-remove", new Variant.uint32 (id))
-        );
-
-        add_item (menu_item);
+        add_item_with_action (_("Safely Remove"), "device.safely-remove", id);
     }
 
     public PopupMenuBuilder add_bookmark (MenuitemCallback cb) {
@@ -143,6 +119,16 @@ public class PopupMenuBuilder : Object {
 
     public PopupMenuBuilder add_separator () {
         return add_item (new Gtk.SeparatorMenuItem ());
+    }
+
+    private void add_item_with_action (string label, string action_name, uint32 id) {
+        var menu_item = new Gtk.MenuItem.with_mnemonic (label);
+        menu_item.set_detailed_action_name (
+            Action.print_detailed_name (action_name, new Variant.uint32 (id))
+        );
+
+        menu_item.show ();
+        menu_items += menu_item;
     }
 
     public PopupMenuBuilder add_item (Gtk.MenuItem menu_item, MenuitemCallback? cb = null) {

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -167,22 +167,16 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         update_visibilities ();
 
         var safely_remove_action = new SimpleAction ("safely-remove", null);
-        safely_remove_action.activate.connect (() => {
-            safely_remove_drive.begin ();
-        });
+        safely_remove_action.activate.connect (() => safely_remove_drive.begin ());
 
         var eject_action = new SimpleAction ("eject", null);
-        eject_action.activate.connect (() => {
-            eject_drive.begin ();
-        });
+        eject_action.activate.connect (() => eject_drive.begin ());
 
         var properties_action = new SimpleAction ("properties", null);
         properties_action.activate.connect (show_mount_info);
 
         var unmount_action = new SimpleAction ("unmount", null);
-        unmount_action.activate.connect (() => {
-            unmount_mount.begin ();
-        });
+        unmount_action.activate.connect (() => unmount_mount.begin ());
 
         var action_group = new SimpleActionGroup ();
         action_group.add_action (safely_remove_action);

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -179,7 +179,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         working = item.show_spinner;
     }
 
-    protected async bool unmount_mount () {
+    public async bool unmount_mount () {
         if (working || !valid || permanent) {
             return false;
         }
@@ -245,7 +245,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
             }
 
             if (mount.can_unmount ()) {
-                menu_builder.add_unmount (() => {unmount_mount.begin ();});
+                menu_builder.add_unmount (id);
             }
         }
 

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -165,6 +165,46 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         add_mountable_tooltip.begin ();
 
         update_visibilities ();
+
+        var safely_remove_action = new SimpleAction ("safely-remove", new VariantType ("u"));
+        safely_remove_action.activate.connect ((param) => {
+            var row = SidebarItemInterface.get_item (param.get_uint32 ());
+            if (row != null && row is AbstractMountableRow) {
+                ((AbstractMountableRow) row).safely_remove_drive.begin ();
+            }
+        });
+
+        var eject_action = new SimpleAction ("eject", new VariantType ("u"));
+        eject_action.activate.connect ((param) => {
+            var row = SidebarItemInterface.get_item (param.get_uint32 ());
+            if (row != null && row is AbstractMountableRow) {
+                ((AbstractMountableRow) row).eject_drive.begin ();
+            }
+        });
+
+        var properties_action = new SimpleAction ("properties", new VariantType ("u"));
+        properties_action.activate.connect ((param) => {
+            var row = SidebarItemInterface.get_item (param.get_uint32 ());
+            if (row != null && row is AbstractMountableRow) {
+                ((AbstractMountableRow) row).show_mount_info ();
+            }
+        });
+
+        var unmount_action = new SimpleAction ("unmount", new VariantType ("u"));
+        unmount_action.activate.connect ((param) => {
+            var row = SidebarItemInterface.get_item (param.get_uint32 ());
+            if (row != null && row is AbstractMountableRow) {
+                ((AbstractMountableRow) row).unmount_mount.begin ();
+            }
+        });
+
+        var action_group = new SimpleActionGroup ();
+        action_group.add_action (safely_remove_action);
+        action_group.add_action (eject_action);
+        action_group.add_action (properties_action);
+        action_group.add_action (unmount_action);
+
+        insert_action_group ("mountable", action_group);
     }
 
     protected void update_visibilities () {
@@ -179,7 +219,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         working = item.show_spinner;
     }
 
-    public async bool unmount_mount () {
+    protected async bool unmount_mount () {
         if (working || !valid || permanent) {
             return false;
         }
@@ -203,7 +243,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         return success;
     }
 
-    public async void safely_remove_drive () {
+    protected async void safely_remove_drive () {
         if (working || !valid || drive == null) {
             return;
         }
@@ -218,7 +258,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         update_visibilities ();
     }
 
-    public async void eject_drive () {
+    protected async void eject_drive () {
         if (working || !valid || drive == null) {
             return;
         }
@@ -341,7 +381,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
 
     protected virtual void on_mount_removed (Mount removed_mount) {}
     protected virtual void on_mount_added (Mount added_mount) {}
-    public virtual void show_mount_info () {}
+    protected virtual void show_mount_info () {}
     protected virtual async bool get_filesystem_space (Cancellable? update_cancellable) {
         return false;
     }

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -166,36 +166,22 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
 
         update_visibilities ();
 
-        var safely_remove_action = new SimpleAction ("safely-remove", new VariantType ("u"));
-        safely_remove_action.activate.connect ((param) => {
-            var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null && row is AbstractMountableRow) {
-                ((AbstractMountableRow) row).safely_remove_drive.begin ();
-            }
+        var safely_remove_action = new SimpleAction ("safely-remove", null);
+        safely_remove_action.activate.connect (() => {
+            safely_remove_drive.begin ();
         });
 
-        var eject_action = new SimpleAction ("eject", new VariantType ("u"));
-        eject_action.activate.connect ((param) => {
-            var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null && row is AbstractMountableRow) {
-                ((AbstractMountableRow) row).eject_drive.begin ();
-            }
+        var eject_action = new SimpleAction ("eject", null);
+        eject_action.activate.connect (() => {
+            eject_drive.begin ();
         });
 
-        var properties_action = new SimpleAction ("properties", new VariantType ("u"));
-        properties_action.activate.connect ((param) => {
-            var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null && row is AbstractMountableRow) {
-                ((AbstractMountableRow) row).show_mount_info ();
-            }
-        });
+        var properties_action = new SimpleAction ("properties", null);
+        properties_action.activate.connect (show_mount_info);
 
-        var unmount_action = new SimpleAction ("unmount", new VariantType ("u"));
-        unmount_action.activate.connect ((param) => {
-            var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null && row is AbstractMountableRow) {
-                ((AbstractMountableRow) row).unmount_mount.begin ();
-            }
+        var unmount_action = new SimpleAction ("unmount", null);
+        unmount_action.activate.connect (() => {
+            unmount_mount.begin ();
         });
 
         var action_group = new SimpleActionGroup ();
@@ -285,12 +271,12 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
             }
 
             if (mount.can_unmount ()) {
-                menu_builder.add_unmount (id);
+                menu_builder.add_unmount ();
             }
         }
 
         menu_builder.add_separator ();
-        menu_builder.add_drive_property (id); // This will mount if necessary
+        menu_builder.add_drive_property (); // This will mount if necessary
     }
 
     protected async bool get_filesystem_space_for_root (File root, Cancellable? update_cancellable) {

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -210,8 +210,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
 
         debug ("Eject/stop drive %s: can_eject %s, can_stop %s, can start %s, can start degraded %s, media_removable %s, drive removable %s",
             drive.get_name (), drive.can_eject ().to_string (), drive.can_stop ().to_string (), drive.can_start ().to_string (),
-            drive.can_start_degraded ().to_string (), drive.is_media_removable ().to_string (), drive.is_removable ().to_string ()
-        );
+            drive.can_start_degraded ().to_string (), drive.is_media_removable ().to_string (), drive.is_removable ().to_string ());
 
         working = true;
         yield Files.FileOperations.safely_remove_drive (drive, Files.get_active_window ());

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -203,14 +203,15 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         return success;
     }
 
-    protected async void safely_remove_drive (Drive drive) {
-        if (working || !valid) {
+    public async void safely_remove_drive () {
+        if (working || !valid || drive == null) {
             return;
         }
 
         debug ("Eject/stop drive %s: can_eject %s, can_stop %s, can start %s, can start degraded %s, media_removable %s, drive removable %s",
             drive.get_name (), drive.can_eject ().to_string (), drive.can_stop ().to_string (), drive.can_start ().to_string (),
-            drive.can_start_degraded ().to_string (), drive.is_media_removable ().to_string (), drive.is_removable ().to_string ());
+            drive.can_start_degraded ().to_string (), drive.is_media_removable ().to_string (), drive.is_removable ().to_string ()
+        );
 
         working = true;
         yield Files.FileOperations.safely_remove_drive (drive, Files.get_active_window ());
@@ -218,8 +219,8 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         update_visibilities ();
     }
 
-    protected async void eject_drive (Drive drive) {
-        if (working || !valid) {
+    public async void eject_drive () {
+        if (working || !valid || drive == null) {
             return;
         }
         working = true;

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -249,9 +249,8 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
             }
         }
 
-        menu_builder
-            .add_separator ()
-            .add_drive_property (() => {show_mount_info ();}); // This will mount if necessary
+        menu_builder.add_separator ();
+        menu_builder.add_drive_property (id); // This will mount if necessary
     }
 
     protected async bool get_filesystem_space_for_root (File root, Cancellable? update_cancellable) {
@@ -342,7 +341,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
 
     protected virtual void on_mount_removed (Mount removed_mount) {}
     protected virtual void on_mount_added (Mount added_mount) {}
-    protected virtual void show_mount_info () {}
+    public virtual void show_mount_info () {}
     protected virtual async bool get_filesystem_space (Cancellable? update_cancellable) {
         return false;
     }

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -296,7 +296,7 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
                 .popup_at_pointer (null);
         } else {
             menu_builder
-                .build (parent)
+                .build (this)
                 .popup_at_pointer (null);
         }
     }

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -296,7 +296,7 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
                 .popup_at_pointer (null);
         } else {
             menu_builder
-                .build ()
+                .build (parent)
                 .popup_at_pointer (null);
         }
     }

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -41,22 +41,31 @@ public class Sidebar.DeviceListBox : Gtk.Box, Sidebar.SidebarListInterface {
         var safely_remove_action = new SimpleAction ("safely-remove", new VariantType ("u"));
         safely_remove_action.activate.connect ((param) => {
             var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null) {
-                ((AbstractMountableRow)row).safely_remove_drive.begin ();
+            if (row != null && row is AbstractMountableRow) {
+                ((AbstractMountableRow) row).safely_remove_drive.begin ();
             }
         });
 
         var eject_action = new SimpleAction ("eject", new VariantType ("u"));
         eject_action.activate.connect ((param) => {
             var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null) {
-                ((AbstractMountableRow)row).eject_drive.begin ();
+            if (row != null && row is AbstractMountableRow) {
+                ((AbstractMountableRow) row).eject_drive.begin ();
+            }
+        });
+
+        var unmount_action = new SimpleAction ("unmount", new VariantType ("u"));
+        unmount_action.activate.connect ((param) => {
+            var row = SidebarItemInterface.get_item (param.get_uint32 ());
+            if (row != null && row is AbstractMountableRow) {
+                ((AbstractMountableRow) row).unmount_mount.begin ();
             }
         });
 
         var device_action_group = new SimpleActionGroup ();
         device_action_group.add_action (safely_remove_action);
         device_action_group.add_action (eject_action);
+        device_action_group.add_action (unmount_action);
 
         insert_action_group ("device", device_action_group);
 

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -38,46 +38,6 @@ public class Sidebar.DeviceListBox : Gtk.Box, Sidebar.SidebarListInterface {
 
         add (list_box);
 
-        var safely_remove_action = new SimpleAction ("safely-remove", new VariantType ("u"));
-        safely_remove_action.activate.connect ((param) => {
-            var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null && row is AbstractMountableRow) {
-                ((AbstractMountableRow) row).safely_remove_drive.begin ();
-            }
-        });
-
-        var eject_action = new SimpleAction ("eject", new VariantType ("u"));
-        eject_action.activate.connect ((param) => {
-            var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null && row is AbstractMountableRow) {
-                ((AbstractMountableRow) row).eject_drive.begin ();
-            }
-        });
-
-        var properties_action = new SimpleAction ("properties", new VariantType ("u"));
-        properties_action.activate.connect ((param) => {
-            var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null && row is AbstractMountableRow) {
-                ((AbstractMountableRow) row).show_mount_info ();
-            }
-        });
-
-        var unmount_action = new SimpleAction ("unmount", new VariantType ("u"));
-        unmount_action.activate.connect ((param) => {
-            var row = SidebarItemInterface.get_item (param.get_uint32 ());
-            if (row != null && row is AbstractMountableRow) {
-                ((AbstractMountableRow) row).unmount_mount.begin ();
-            }
-        });
-
-        var device_action_group = new SimpleActionGroup ();
-        device_action_group.add_action (safely_remove_action);
-        device_action_group.add_action (eject_action);
-        device_action_group.add_action (properties_action);
-        device_action_group.add_action (unmount_action);
-
-        insert_action_group ("device", device_action_group);
-
         volume_monitor = VolumeMonitor.@get ();
         volume_monitor.drive_connected.connect (bookmark_drive);
         volume_monitor.mount_added.connect (bookmark_mount_without_volume);

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -38,6 +38,28 @@ public class Sidebar.DeviceListBox : Gtk.Box, Sidebar.SidebarListInterface {
 
         add (list_box);
 
+        var safely_remove_action = new SimpleAction ("safely-remove", new VariantType ("u"));
+        safely_remove_action.activate.connect ((param) => {
+            var row = SidebarItemInterface.get_item (param.get_uint32 ());
+            if (row != null) {
+                ((AbstractMountableRow)row).safely_remove_drive.begin ();
+            }
+        });
+
+        var eject_action = new SimpleAction ("eject", new VariantType ("u"));
+        eject_action.activate.connect ((param) => {
+            var row = SidebarItemInterface.get_item (param.get_uint32 ());
+            if (row != null) {
+                ((AbstractMountableRow)row).eject_drive.begin ();
+            }
+        });
+
+        var device_action_group = new SimpleActionGroup ();
+        device_action_group.add_action (safely_remove_action);
+        device_action_group.add_action (eject_action);
+
+        insert_action_group ("device", device_action_group);
+
         volume_monitor = VolumeMonitor.@get ();
         volume_monitor.drive_connected.connect (bookmark_drive);
         volume_monitor.mount_added.connect (bookmark_mount_without_volume);

--- a/src/View/Sidebar/DeviceListBox.vala
+++ b/src/View/Sidebar/DeviceListBox.vala
@@ -54,6 +54,14 @@ public class Sidebar.DeviceListBox : Gtk.Box, Sidebar.SidebarListInterface {
             }
         });
 
+        var properties_action = new SimpleAction ("properties", new VariantType ("u"));
+        properties_action.activate.connect ((param) => {
+            var row = SidebarItemInterface.get_item (param.get_uint32 ());
+            if (row != null && row is AbstractMountableRow) {
+                ((AbstractMountableRow) row).show_mount_info ();
+            }
+        });
+
         var unmount_action = new SimpleAction ("unmount", new VariantType ("u"));
         unmount_action.activate.connect ((param) => {
             var row = SidebarItemInterface.get_item (param.get_uint32 ());
@@ -65,6 +73,7 @@ public class Sidebar.DeviceListBox : Gtk.Box, Sidebar.SidebarListInterface {
         var device_action_group = new SimpleActionGroup ();
         device_action_group.add_action (safely_remove_action);
         device_action_group.add_action (eject_action);
+        device_action_group.add_action (properties_action);
         device_action_group.add_action (unmount_action);
 
         insert_action_group ("device", device_action_group);

--- a/src/View/Sidebar/DriveRow.vala
+++ b/src/View/Sidebar/DriveRow.vala
@@ -125,9 +125,7 @@ public class Sidebar.DriveRow : Sidebar.AbstractMountableRow, SidebarItemInterfa
         var sort_key = drive.get_sort_key ();
         if (sort_key != null && sort_key.contains ("hotplug")) {
             var menu_builder = new PopupMenuBuilder ();
-            menu_builder.add_safely_remove (
-                Action.print_detailed_name ("device.safely-remove", new Variant.uint32 (id))
-            );
+            menu_builder.add_safely_remove (id);
 
             menu_builder.build (parent).popup_at_pointer (null);
         }

--- a/src/View/Sidebar/DriveRow.vala
+++ b/src/View/Sidebar/DriveRow.vala
@@ -125,7 +125,7 @@ public class Sidebar.DriveRow : Sidebar.AbstractMountableRow, SidebarItemInterfa
         var sort_key = drive.get_sort_key ();
         if (sort_key != null && sort_key.contains ("hotplug")) {
             var menu_builder = new PopupMenuBuilder ();
-            menu_builder.add_safely_remove (id);
+            menu_builder.add_safely_remove ();
 
             menu_builder.build (this).popup_at_pointer (null);
         }

--- a/src/View/Sidebar/DriveRow.vala
+++ b/src/View/Sidebar/DriveRow.vala
@@ -127,7 +127,7 @@ public class Sidebar.DriveRow : Sidebar.AbstractMountableRow, SidebarItemInterfa
             var menu_builder = new PopupMenuBuilder ();
             menu_builder.add_safely_remove (id);
 
-            menu_builder.build (parent).popup_at_pointer (null);
+            menu_builder.build (this).popup_at_pointer (null);
         }
     }
 }

--- a/src/View/Sidebar/DriveRow.vala
+++ b/src/View/Sidebar/DriveRow.vala
@@ -124,14 +124,12 @@ public class Sidebar.DriveRow : Sidebar.AbstractMountableRow, SidebarItemInterfa
         // usable actions.  In future, actions like "Format" might be added.
         var sort_key = drive.get_sort_key ();
         if (sort_key != null && sort_key.contains ("hotplug")) {
-             var menu_builder = new PopupMenuBuilder ()
-            .add_safely_remove (() => {
-                safely_remove_drive.begin (drive);
-            });
+            var menu_builder = new PopupMenuBuilder ();
+            menu_builder.add_safely_remove (
+                Action.print_detailed_name ("device.safely-remove", new Variant.uint32 (id))
+            );
 
-            menu_builder
-            .build ()
-            .popup_at_pointer (null);
+            menu_builder.build (parent).popup_at_pointer (null);
         }
     }
 }

--- a/src/View/Sidebar/VolumeRow.vala
+++ b/src/View/Sidebar/VolumeRow.vala
@@ -172,15 +172,11 @@ public class Sidebar.VolumeRow : Sidebar.AbstractMountableRow, SidebarItemInterf
 
         var sort_key = drive.get_sort_key ();
         if (sort_key != null && sort_key.contains ("hotplug")) {
-            menu_builder
-                .add_separator ()
-                .add_safely_remove (Action.print_detailed_name ("device.safely-remove", new Variant.uint32 (id))
-            );
+            menu_builder.add_separator ();
+            menu_builder.add_safely_remove (id);
         } else if (mount == null && drive.can_eject ()) {
-            menu_builder
-                .add_separator ()
-                .add_eject_drive (Action.print_detailed_name ("device.eject", new Variant.uint32 (id))
-            );
+            menu_builder.add_separator ();
+            menu_builder.add_eject_drive (id);
         }
     }
 

--- a/src/View/Sidebar/VolumeRow.vala
+++ b/src/View/Sidebar/VolumeRow.vala
@@ -174,15 +174,13 @@ public class Sidebar.VolumeRow : Sidebar.AbstractMountableRow, SidebarItemInterf
         if (sort_key != null && sort_key.contains ("hotplug")) {
             menu_builder
                 .add_separator ()
-                .add_safely_remove (() => {
-                    safely_remove_drive.begin (volume.get_drive ());
-                });
+                .add_safely_remove (Action.print_detailed_name ("device.safely-remove", new Variant.uint32 (id))
+            );
         } else if (mount == null && drive.can_eject ()) {
             menu_builder
                 .add_separator ()
-                .add_eject_drive (() => {
-                    eject_drive.begin (volume.get_drive ());
-                });
+                .add_eject_drive (Action.print_detailed_name ("device.eject", new Variant.uint32 (id))
+            );
         }
     }
 

--- a/src/View/Sidebar/VolumeRow.vala
+++ b/src/View/Sidebar/VolumeRow.vala
@@ -173,10 +173,10 @@ public class Sidebar.VolumeRow : Sidebar.AbstractMountableRow, SidebarItemInterf
         var sort_key = drive.get_sort_key ();
         if (sort_key != null && sort_key.contains ("hotplug")) {
             menu_builder.add_separator ();
-            menu_builder.add_safely_remove (id);
+            menu_builder.add_safely_remove ();
         } else if (mount == null && drive.can_eject ()) {
             menu_builder.add_separator ();
-            menu_builder.add_eject_drive (id);
+            menu_builder.add_eject_drive ();
         }
     }
 


### PR DESCRIPTION
Initial work to start porting PopupMenuBuilder to use GLib.Actions. Based on work in https://github.com/elementary/files/pull/2082

Remove unused `add_mount`