### PR TITLE
AbstractMountableRow: use add_with_action_name directly

### DIFF
--- a/libcore/PopupMenuBuilder.vala
+++ b/libcore/PopupMenuBuilder.vala
@@ -68,19 +68,6 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.MenuItem.with_label (_("Rename")), cb);
     }
 
-    public void add_unmount () {
-        add_with_action_name (_("_Unmount"), "mountable.unmount");
-    }
-
-    public void add_drive_property () {
-        add_with_action_name (_("Properties"), "mountable.properties");
-    }
-
-    public void add_eject_drive () {
-        // Do we need different text for USB sticks and optical drives?
-        add_with_action_name (_("Eject Media"), "mountable.eject");
-    }
-
     public void add_safely_remove () {
         // Do we need different text for USB sticks and optical drives?
         add_with_action_name (_("Safely Remove"), "mountable.safely-remove");
@@ -121,7 +108,7 @@ public class PopupMenuBuilder : Object {
         return add_item (new Gtk.SeparatorMenuItem ());
     }
 
-    private void add_with_action_name (string label, string action_name) {
+    public void add_with_action_name (string label, string action_name) {
         var menu_item = new Gtk.MenuItem.with_mnemonic (label);
         menu_item.set_detailed_action_name (
             Action.print_detailed_name (action_name, null)

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -265,12 +265,12 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
             }
 
             if (mount.can_unmount ()) {
-                menu_builder.add_unmount ();
+                menu_builder.add_with_action_name (_("_Unmount"), "mountable.unmount");
             }
         }
 
         menu_builder.add_separator ();
-        menu_builder.add_drive_property (); // This will mount if necessary
+        menu_builder.add_with_action_name (_("Properties"), "mountable.properties"); // This will mount if necessary
     }
 
     protected async bool get_filesystem_space_for_root (File root, Cancellable? update_cancellable) {

--- a/src/View/Sidebar/VolumeRow.vala
+++ b/src/View/Sidebar/VolumeRow.vala
@@ -176,7 +176,8 @@ public class Sidebar.VolumeRow : Sidebar.AbstractMountableRow, SidebarItemInterf
             menu_builder.add_safely_remove ();
         } else if (mount == null && drive.can_eject ()) {
             menu_builder.add_separator ();
-            menu_builder.add_eject_drive ();
+            // Do we need different text for USB sticks and optical drives?
+            menu_builder.add_with_action_name (_("Eject Media"), "mountable.eject");
         }
     }
 


### PR DESCRIPTION
Get rid of a few functions that are only used once. The action names don't exist in the library anyways, so I think this makes more sense?