### PR TITLE
Use Popover for SearchResults: Part 2

### DIFF
--- a/libcore/Widgets/BasicBreadcrumbsEntry.vala
+++ b/libcore/Widgets/BasicBreadcrumbsEntry.vala
@@ -39,7 +39,19 @@ namespace Files.View.Chrome {
             }
         }
 
-        public bool hide_breadcrumbs { get; set; default = false; }
+        private bool _hide_breadcrumbs = false;
+        public bool hide_breadcrumbs {
+            get {
+                return _hide_breadcrumbs;
+            }
+
+            set {
+                _hide_breadcrumbs = value;
+                if (!hide_breadcrumbs) {
+                    set_entry_text ("");
+                }
+            }
+        }
         public const double MINIMUM_LOCATION_BAR_ENTRY_WIDTH = 16;
         public const double MINIMUM_BREADCRUMB_WIDTH = 12;
         public const int ICON_WIDTH = 32;

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -45,7 +45,18 @@ namespace Files.View.Chrome {
             }
         } // Candidate completion (placeholder)
 
-        public bool search_mode = false; // Used to suppress activate events while searching
+        public new bool hide_breadcrumbs {
+            get {
+                return base.hide_breadcrumbs || search_mode;
+            }
+
+            set {
+                base.hide_breadcrumbs = value;
+            }
+        }
+
+        // Used to suppress various events while searching
+        public bool search_mode { set; get; default = false; }
 
         /** Drag and drop support **/
         protected const Gdk.DragAction FILE_DRAG_ACTIONS = (Gdk.DragAction.COPY |
@@ -106,9 +117,14 @@ namespace Files.View.Chrome {
         }
 
         public override void reset () {
-            base.reset ();
-            completion_text = "";
-            current_completion_dir = null; // Do not cancel as this could interfere with a loading tab
+            if (search_mode) {
+                return;
+            } else {
+                base.reset ();
+                completion_text = "";
+                // Do not cancel as this could interfere with a loading tab
+                current_completion_dir = null;
+            }
         }
 
     /** Search related functions **/

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -123,11 +123,16 @@ namespace Files.View.Chrome {
         }
 
         protected override bool after_bread_focus_out_event (Gdk.EventFocus event) {
-            base.after_bread_focus_out_event (event);
-            search_mode = false;
-            show_refresh_icon ();
-            focus_out_event (event);
-            check_home ();
+            if (search_results.is_active) {
+                bread.hide_breadcrumbs = true;
+            } else {
+                base.after_bread_focus_out_event (event);
+                search_mode = false;
+                show_refresh_icon ();
+                focus_out_event (event);
+                check_home ();
+            }
+
             return true;
         }
         protected override bool after_bread_focus_in_event (Gdk.EventFocus event) {

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -83,6 +83,7 @@ namespace Files.View.Chrome {
             gof.ensure_query_info ();
 
             path_change_request (gof.get_target_location ().get_uri ());
+            on_search_results_exit ();
         }
         private void on_search_results_file_activated (GLib.File file) {
             AppInfo? app = MimeActions.get_default_application_for_glib_file (file);
@@ -102,6 +103,7 @@ namespace Files.View.Chrome {
 
         private void on_search_results_exit (bool exit_navigate = true) {
             /* Search result widget ensures it has closed and released grab */
+            search_results.is_active = false;
             bread.reset_im_context ();
             if (focus_timeout_id > 0) {
                 GLib.Source.remove (focus_timeout_id);

--- a/src/View/Widgets/SearchResults.vala
+++ b/src/View/Widgets/SearchResults.vala
@@ -100,6 +100,15 @@ namespace Files.View.Chrome {
         const int DELAY_ADDING_RESULTS = 150;
 
         public bool working { get; private set; default = false; }
+        public bool is_active {
+            get {
+                return search_term != "";
+            }
+
+            set {
+                search_term = "";
+            }
+        }
 
         private new Gtk.Widget parent;
         protected int n_results { get; private set; default = 0; }
@@ -151,7 +160,6 @@ namespace Files.View.Chrome {
         }
 
         construct {
-
             relative_to = delegate_widget;
             position = Gtk.PositionType.BOTTOM;
             // Gtk4 can remove the arrow with:


### PR DESCRIPTION
This fixes breadcrumb behaviour after converting the search window to a popover.


Fixing the issues with `main` with a Gtk.Window search window under Wayland proved problematic so probably not worth the effort if the popover branch is going to be merged.  Using a Popover should be window manager agnostic.