### PR TITLE
Ensure scroll controller only active when `<Control>` pressed

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3194,13 +3194,12 @@ namespace Files {
         }
 
         protected virtual void on_scroll_event (double dx, double dy) {
-            Gdk.ModifierType state;
-            Gtk.get_current_event_state (out state);
-
             if (is_frozen) {
                 return;
             }
 
+            Gdk.ModifierType state;
+            Gtk.get_current_event_state (out state);
             if ((state & Gdk.ModifierType.CONTROL_MASK) > 0) {
                 /* try to emulate a normal scrolling event by summing deltas.
                  * step size of 0.5 chosen to match sensitivity */

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3197,7 +3197,11 @@ namespace Files {
             Gdk.ModifierType state;
             Gtk.get_current_event_state (out state);
 
-            if (!is_frozen && (state & Gdk.ModifierType.CONTROL_MASK) > 0) {
+            if (is_frozen) {
+                return;
+            }
+
+            if ((state & Gdk.ModifierType.CONTROL_MASK) > 0) {
                 /* try to emulate a normal scrolling event by summing deltas.
                  * step size of 0.5 chosen to match sensitivity */
                 total_delta_y += dy;
@@ -3209,9 +3213,10 @@ namespace Files {
                     total_delta_y = 0;
                     zoom_in ();
                 }
+            } else {
+                // In case "key-released" signal was missed
+                scroll_controller.flags = NONE;
             }
-
-
         }
 
     /** name renderer signals */


### PR DESCRIPTION
Fixes #2512 

The issue was caused by the dialog thrown when permanently deleting an item using the keyboard causing the "key-release" signal being swallowed. This resulted in the scroll controller that handles zooming remaining active and blocking the native scroll handler.

This is all because of a "feature" of the Gtk3 scroll controller which always swallows scroll events so needs to be switched on and off to avoid blocking the native scroll controller.  This should become unnecessary in Gtk4.

This PR makes the zoom scroll handler turn itself off if it gets triggered unexpectedly.