### PR TITLE
Prefer elementary sound theme over freedesktop

### DIFF
--- a/libcore/SoundManager.vala
+++ b/libcore/SoundManager.vala
@@ -46,6 +46,7 @@ namespace PF {
             if (ca_context != null) {
                 ca_context.change_props (Canberra.PROP_APPLICATION_NAME, _(PF.Sound.APP_TITLE),
                                          Canberra.PROP_APPLICATION_ID, PF.Sound.APP_ID,
+                                         Canberra.PROP_CANBERRA_XDG_THEME_NAME, PF.Sound.THEME,
                                          Canberra.PROP_APPLICATION_ICON_NAME, PF.Sound.APP_LOGO);
                 ca_context.open ();
             }
@@ -72,7 +73,7 @@ namespace PF {
         const string APP_TITLE = "Files";
         const string APP_ID = "io.elementary.files";
         const string APP_LOGO = "system-file-manager";
-        public const string THEME = "freedesktop";
+        public const string THEME = "elementary";
         public const string DELETE = "trash-empty";
         public const string EMPTY_TRASH = "trash-empty";
     }


### PR DESCRIPTION
Address https://github.com/elementary/triage/issues/98

Preemptive PR so that Files plays the `trash-empty` sound from the elementary sound theme instead of from freedesktop.

Currently the elementary sound theme doesn't have the sound but inherits from freedesktop so there's no change in the sound, until one is added.