### PR TITLE
LocationBar: Correctly handle `admin://` protocol; show warning

### DIFF
--- a/libcore/Directory.vala
+++ b/libcore/Directory.vala
@@ -92,6 +92,7 @@ public class Files.Directory : Object {
     public bool is_trash {get; private set;}
     public bool is_network {get; private set;}
     public bool is_recent {get; private set;}
+    public bool is_admin {get; private set;}
     public bool is_no_info {get; private set;}
     public bool has_mounts {get; private set;}
     public bool has_trash_dirs {get; private set;}
@@ -170,6 +171,7 @@ public class Files.Directory : Object {
         scheme = location.get_uri_scheme ();
         is_trash = FileUtils.location_is_in_trash (location);
         is_recent = (scheme == "recent");
+        is_admin = (scheme == "admin");
         //Try lifting requirement for info on remote connections
         //TODO Not sure whether the afc protocol (i-phone) is appropriate here. Safer to assume it is.
         is_no_info = ("cdda mtp gphoto2 ssh sftp afp afc dav davs".contains (scheme));

--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -389,7 +389,8 @@ namespace Files.FileUtils {
             /* ROOT_FS, TRASH and RECENT must have 3 separators after protocol, other protocols have 2 */
             if (!scheme.has_prefix (Files.ROOT_FS_URI) &&
                 !scheme.has_prefix (Files.TRASH_URI) &&
-                !scheme.has_prefix (Files.RECENT_URI)) {
+                !scheme.has_prefix (Files.RECENT_URI) &&
+                !scheme.has_prefix (Files.ADMIN_URI)) {
 
                 new_path = new_path.replace ("///", "//");
             }
@@ -1196,6 +1197,7 @@ namespace Files.FileUtils {
 
 namespace Files {
     public const string ROOT_FS_URI = "file://";
+    public const string ADMIN_URI = "admin://";
     public const string TRASH_URI = "trash://";
     public const string NETWORK_URI = "network://";
     public const string RECENT_URI = "recent://";

--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -146,7 +146,7 @@ namespace Files.View.Chrome {
     /****************************/
         public void completion_needed () {
             string? path = this.text;
-            if (path == null || path.length < 1) {
+            if (path == null || path.length < 1 || path.has_prefix ("admin:/")) {
                 return;
             }
 

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -103,7 +103,6 @@ namespace Files.View.Chrome {
 
         private void on_search_results_exit (bool exit_navigate = true) {
             /* Search result widget ensures it has closed and released grab */
-            search_results.is_active = false;
             bread.reset_im_context ();
             if (focus_timeout_id > 0) {
                 GLib.Source.remove (focus_timeout_id);
@@ -251,7 +250,7 @@ namespace Files.View.Chrome {
         private void switch_to_search_mode () {
             search_mode = true;
             hide_navigate_icon ();
-            /* Next line ensures that the pathbar not lose focus when the mouse if over the sidebar,
+            /* Next line ensures that the pathbar not lose focus when the mouse is over the sidebar,
              * which would normally grab the focus */
             after_bread_text_changed (bread.get_entry_text ());
         }

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -21,6 +21,7 @@
 
 namespace Files.View.Chrome {
     public class LocationBar : BasicLocationBar {
+        private Gtk.Revealer admin_revealer;
         private BreadcrumbsEntry bread;
         private SearchResults search_results;
         private GLib.File? search_location = null;
@@ -66,6 +67,24 @@ namespace Files.View.Chrome {
             show_refresh_icon ();
         }
 
+        construct {
+            var admin_image = new Gtk.Image.from_icon_name (
+                "dialog-warning",
+                Gtk.IconSize.LARGE_TOOLBAR) {
+                tooltip_text = _("Caution. Administrative rights will be granted after successful authentication")
+            };
+            admin_revealer = new Gtk.Revealer () {
+                child = admin_image,
+                reveal_child = false,
+                hexpand = false,
+                transition_type = SLIDE_RIGHT
+            };
+
+            add (admin_revealer);
+            notify["displayed-path"].connect (() => {
+                admin_revealer.reveal_child = displayed_path.has_prefix ("admin:/");
+            });
+        }
         private void connect_additional_signals () {
             bread.open_with_request.connect (on_bread_open_with_request);
             search_results.file_selected.connect (on_search_results_file_selected);

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -168,13 +168,15 @@ namespace Files.View.Chrome {
 
             hide_placeholder ();
             if (search_mode) {
-                if (txt.contains (Path.DIR_SEPARATOR_S)) {
+                if (text_is_path (txt)) {
                     switch_to_navigate_mode ();
+                    // Persist current entry
+                    bread.set_entry_text (txt);
                 } else {
                     search_results.search (txt, search_location);
                 }
             } else {
-                if (!txt.contains (Path.DIR_SEPARATOR_S)) {
+                if (!text_is_path (txt)) {
                     switch_to_search_mode ();
                 } else {
                     base.after_bread_text_changed (txt);
@@ -183,6 +185,9 @@ namespace Files.View.Chrome {
             }
         }
 
+        private bool text_is_path (string txt) {
+            return txt.contains (Path.DIR_SEPARATOR_S) || txt.contains (":");
+        }
         protected void show_refresh_icon () {
             bread.get_style_context ().remove_class ("spin");
             bread.action_icon_name = Files.ICON_PATHBAR_SECONDARY_REFRESH_SYMBOLIC;

--- a/src/View/Widgets/SearchResults.vala
+++ b/src/View/Widgets/SearchResults.vala
@@ -91,10 +91,6 @@ namespace Files.View.Chrome {
             get {
                 return search_term != "";
             }
-
-            set {
-                search_term = "";
-            }
         }
 
         private new Gtk.Widget parent;
@@ -321,6 +317,8 @@ namespace Files.View.Chrome {
             }
 
             clear ();
+
+            search_term = "";
         }
 
         private uint search_timeout_id = 0;

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -320,7 +320,12 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
         location_bar.path_change_request.connect ((path, flag) => {
             current_container.is_frozen = false;
-            uri_path_change_request (path, flag);
+            // Put in an Idle so that any resulting authentication dialog
+            // is able to grab focus *after* the view does
+            Idle.add (() => {
+                uri_path_change_request (path, flag);
+                return Source.REMOVE;
+            });
         });
 
         location_bar.focus_file_request.connect ((loc) => {


### PR DESCRIPTION
Fixes #2524 
Fixes #1844
Partially resolves #165 

This PR depends on, and incorporates, #2522.  Without that fix it is not possible to manually enter an `admin://` url.

Further refinements are possible such as supplying menu action/hotkey/bookmark for opening a location as admin without having to type in the pathbar but that will be left for subsequent PRs.
