### PR TITLE
Jeremypw/gtkprep/abstract editable label cleanup

### DIFF
--- a/src/TextRenderer.vala
+++ b/src/TextRenderer.vala
@@ -82,11 +82,11 @@ namespace Files {
         public TextRenderer (ViewMode viewmode) {
             if (viewmode == ViewMode.ICON) {
                 entry = new MultiLineEditableLabel ();
-                entry.set_justify (Gtk.Justification.CENTER);
+                entry.xalign = 0.5f;
                 is_list_view = false;
             } else {
                 entry = new SingleLineEditableLabel ();
-                entry.set_justify (Gtk.Justification.LEFT);
+                entry.xalign = 0.0f;
                 is_list_view = true;
             }
 

--- a/src/TextRenderer.vala
+++ b/src/TextRenderer.vala
@@ -220,7 +220,7 @@ namespace Files {
             }
 
 
-            entry.set_text (text);
+            entry.set_initial_text (text);
             entry.set_line_wrap_mode (wrap_mode);
             entry.set_size_request (wrap_width, -1);
             entry.set_position (-1);
@@ -293,7 +293,7 @@ namespace Files {
             entry.hide ();
 
             if (!cancelled) {
-                string text = entry.get_text ();
+                string text = entry.text;
                 string path = entry.get_data ("marlin-text-renderer-path");
                 edited (path, text);
             }

--- a/src/View/Widgets/AbstractEditableLabel.vala
+++ b/src/View/Widgets/AbstractEditableLabel.vala
@@ -20,7 +20,6 @@ namespace Files {
     public abstract class AbstractEditableLabel : Gtk.Frame, Gtk.Editable, Gtk.CellEditable {
         public virtual void set_line_wrap (bool wrap) {}
         public virtual void set_line_wrap_mode (Pango.WrapMode mode) {}
-        public virtual void set_justify (Gtk.Justification jtype) {}
         public virtual void set_padding (int xpad, int ypad) {}
         public abstract new void set_size_request (int width, int height);
 

--- a/src/View/Widgets/AbstractEditableLabel.vala
+++ b/src/View/Widgets/AbstractEditableLabel.vala
@@ -18,14 +18,26 @@
 
 namespace Files {
     public abstract class AbstractEditableLabel : Gtk.Frame, Gtk.Editable, Gtk.CellEditable {
+        public virtual void set_line_wrap (bool wrap) {}
+        public virtual void set_line_wrap_mode (Pango.WrapMode mode) {}
+        public virtual void set_justify (Gtk.Justification jtype) {}
+        public virtual void set_padding (int xpad, int ypad) {}
+        public abstract new void set_size_request (int width, int height);
+
         public bool editing_canceled { get; set; }
-        public string original_name;
+        public string original_name { get; private set; }
+
         private Gtk.EventControllerKey key_controller;
 
         protected void connect_editable_widget (Gtk.Widget editable_widget) {
             key_controller = new Gtk.EventControllerKey (editable_widget);
             key_controller.key_pressed.connect (on_key_press_event);
             editable_widget.button_press_event.connect_after (() => { return true; });
+        }
+
+        public virtual void set_initial_text (string initial_text) {
+            text = initial_text;
+            original_name = initial_text;
         }
 
         protected virtual bool on_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {
@@ -51,7 +63,7 @@ namespace Files {
                 case Gdk.Key.z:
                     /* Undo with Ctrl-Z only */
                     if (only_control_pressed) {
-                        set_text (original_name);
+                        text = original_name;
                         return true;
                     }
                     break;
@@ -69,24 +81,27 @@ namespace Files {
             editing_done ();
         }
 
-        public virtual void set_text (string text) {
-            original_name = text;
-        }
-
-        public virtual void set_line_wrap (bool wrap) {}
-        public virtual void set_line_wrap_mode (Pango.WrapMode mode) {}
-        public virtual void set_justify (Gtk.Justification jtype) {}
-        public virtual void set_padding (int xpad, int ypad) {}
-
-        public abstract new void set_size_request (int width, int height);
-        public abstract string get_text ();
-        public abstract void select_region (int start_pos, int end_pos);
+        /** Gtk3 Editable interface **/
         public abstract void do_delete_text (int start_pos, int end_pos);
         public abstract void do_insert_text (string new_text, int new_text_length, ref int position);
         public abstract string get_chars (int start_pos, int end_pos);
         public abstract int get_position ();
         public abstract bool get_selection_bounds (out int start_pos, out int end_pos);
+        public abstract void select_region (int start_pos, int end_pos);
         public abstract void set_position (int position);
+
+        /** Gtk4 Editable interface **/
+        public string text { get; set; }
+        public int cursor_position { get; }
+        public bool editable { get; set; }
+        public bool enable_undo { get; set; }
+        public int max_width_chars { get; set; }
+        public int selection_bound { get; }
+        public int width_chars { get; set; }
+        public float xalign { get; set;}
+        public virtual unowned Gtk.Editable? get_delegate () { return null; }
+        /** Uncomment for Gtk4 port **/
+        // public virtual unowned string get_text () { return ""; }
 
         /** CellEditable interface */
         public virtual void start_editing (Gdk.Event? event) {}

--- a/src/View/Widgets/MultiLineEditableLabel.vala
+++ b/src/View/Widgets/MultiLineEditableLabel.vala
@@ -30,6 +30,20 @@ namespace Files {
             add (scrolled_window);
 
             bind_property ("text", textview.get_buffer (), "text", BindingFlags.BIDIRECTIONAL);
+            // Currently this widget is always center aligned but allow for other values nevertheless
+            notify["xalign"].connect (() => {
+                switch ((int) (xalign * 2.0)) {
+                    case 0:
+                        textview.justification = LEFT;
+                        break;
+                    case 1:
+                        textview.justification = CENTER;
+                        break;
+                    default:
+                        textview.justification = RIGHT;
+                        break;
+                }
+            });
         }
 
         public override void set_line_wrap (bool wrap) {
@@ -57,10 +71,6 @@ namespace Files {
                 default:
                     break;
             }
-        }
-
-        public override void set_justify (Gtk.Justification jtype) {
-            textview.justification = jtype;
         }
 
         public override void set_padding (int xpad, int ypad) {

--- a/src/View/Widgets/MultiLineEditableLabel.vala
+++ b/src/View/Widgets/MultiLineEditableLabel.vala
@@ -19,7 +19,7 @@
 namespace Files {
     public class MultiLineEditableLabel : AbstractEditableLabel {
         protected Gtk.ScrolledWindow scrolled_window;
-        public Gtk.TextView textview { get; construct; }
+        private Gtk.TextView textview;
 
         construct {
             textview = new Gtk.TextView ();
@@ -28,11 +28,8 @@ namespace Files {
                 child = textview
             };
             add (scrolled_window);
-        }
 
-        public override void set_text (string text) {
-            textview.get_buffer ().set_text (text);
-            original_name = text;
+            bind_property ("text", textview.get_buffer (), "text", BindingFlags.BIDIRECTIONAL);
         }
 
         public override void set_line_wrap (bool wrap) {
@@ -71,15 +68,6 @@ namespace Files {
             textview.set_margin_end (xpad);
             textview.set_margin_top (ypad);
             textview.set_margin_bottom (ypad);
-        }
-
-        public override string get_text () {
-            var buffer = textview.get_buffer ();
-            Gtk.TextIter? start = null;
-            Gtk.TextIter? end = null;
-            buffer.get_start_iter (out start);
-            buffer.get_end_iter (out end);
-            return buffer.get_text (start, end, false);
         }
 
         /** Gtk.Editable interface */

--- a/src/View/Widgets/SingleLineEditableLabel.vala
+++ b/src/View/Widgets/SingleLineEditableLabel.vala
@@ -18,7 +18,7 @@
 
 namespace Files {
     public class SingleLineEditableLabel : AbstractEditableLabel {
-        protected Gtk.Entry textview;
+        private Gtk.Entry textview;
         private int select_start = 0;
         private int select_end = 0;
 
@@ -26,11 +26,8 @@ namespace Files {
             textview = new Gtk.Entry ();
             connect_editable_widget (textview);
             add (textview);
-        }
 
-        public override void set_text (string text) {
-            textview.set_text (text);
-            original_name = text;
+            bind_property ("text", textview, "text", BindingFlags.BIDIRECTIONAL);
         }
 
         public override void set_justify (Gtk.Justification jtype) {
@@ -51,10 +48,6 @@ namespace Files {
                     textview.set_alignment (0.5f);
                     break;
             }
-        }
-
-        public override string get_text () {
-            return textview.get_text ();
         }
 
         public override bool on_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {

--- a/src/View/Widgets/SingleLineEditableLabel.vala
+++ b/src/View/Widgets/SingleLineEditableLabel.vala
@@ -28,26 +28,7 @@ namespace Files {
             add (textview);
 
             bind_property ("text", textview, "text", BindingFlags.BIDIRECTIONAL);
-        }
-
-        public override void set_justify (Gtk.Justification jtype) {
-            switch (jtype) {
-                case Gtk.Justification.LEFT:
-                    textview.set_alignment (0.0f);
-                    break;
-
-                case Gtk.Justification.CENTER:
-                    textview.set_alignment (0.5f);
-                    break;
-
-                case Gtk.Justification.RIGHT:
-                    textview.set_alignment (1.0f);
-                    break;
-
-                default:
-                    textview.set_alignment (0.5f);
-                    break;
-            }
+            bind_property ("xalign", textview, "xalign", BindingFlags.DEFAULT);
         }
 
         public override bool on_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {


### PR DESCRIPTION
Make code compilable under both Gtk3 and Gtk4 as far as possible.

Implement Gtk4.Editable interface and use where possible under Gtk3.