### PR TITLE
Gtk.StyleContext, Gtk.StyleClass avoid and replace where possible

### DIFF
--- a/filechooser-portal/FileChooserDialog.vala
+++ b/filechooser-portal/FileChooserDialog.vala
@@ -100,14 +100,14 @@ public class Files.FileChooserDialog : Adw.Window, Xdp.Request {
             tooltip_markup = _("Next"),
             sensitive = false
         };
-        next_button.add_css_class (Gtk.STYLE_CLASS_FLAT);
+        next_button.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         header = new Adw.HeaderBar () {
         // header = new Hdy.HeaderBar () { 
             // custom_title = location_bar,
             // title = title
         };
-        header.add_css_class (Gtk.STYLE_CLASS_FLAT);
+        header.add_css_class (Granite.STYLE_CLASS_FLAT);
         // header.pack_start (previous_button);
         // header.pack_start (next_button);
 

--- a/filechooser-portal/FileChooserDialog.vala
+++ b/filechooser-portal/FileChooserDialog.vala
@@ -93,21 +93,21 @@ public class Files.FileChooserDialog : Adw.Window, Xdp.Request {
             tooltip_markup = _("Previous"),
             sensitive = false
         };
-        // previous_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        previous_button.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         // var next_button = new Gtk.Button.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR) {
         var next_button = new Gtk.Button.from_icon_name ("go-next-symbolic") {
             tooltip_markup = _("Next"),
             sensitive = false
         };
-        // next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        next_button.add_css_class (Gtk.STYLE_CLASS_FLAT);
 
         header = new Adw.HeaderBar () {
         // header = new Hdy.HeaderBar () { 
             // custom_title = location_bar,
             // title = title
         };
-        // header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        header.add_css_class (Gtk.STYLE_CLASS_FLAT);
         // header.pack_start (previous_button);
         // header.pack_start (next_button);
 
@@ -120,7 +120,7 @@ public class Files.FileChooserDialog : Adw.Window, Xdp.Request {
             use_underline = true,
             // can_default = true
         };
-        // accept_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+        accept_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
 
         filter_box = new Gtk.ComboBoxText ();
 

--- a/filechooser-portal/Main.vala
+++ b/filechooser-portal/Main.vala
@@ -474,7 +474,7 @@ public class Files.FileChooserPortal : Object {
             };
 
         var replace_button = replace_dialog.add_button (_("Replace"), Gtk.ResponseType.YES);
-        // replace_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+        replace_button.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
         return replace_dialog;
     }

--- a/libcore/ConnectServerDialog.vala
+++ b/libcore/ConnectServerDialog.vala
@@ -106,8 +106,9 @@ public class PF.ConnectServerDialog : Granite.Dialog {
             message_type = Gtk.MessageType.INFO,
             revealed = false
         };
-        // info_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FRAME);
-        // info_bar.get_content_area ().add (info_label);
+
+        info_bar.add_css_class (Granite.STYLE_CLASS_FRAME);
+        info_bar.add_child (info_label);
 
         var server_header_label = new Granite.HeaderLabel (_("Server Details"));
 
@@ -210,14 +211,14 @@ public class PF.ConnectServerDialog : Granite.Dialog {
              // can_default = true,
              // no_show_all = true
          };
-        // connect_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+        connect_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
         connect_button.clicked.connect (on_connect_clicked);
 
         continue_button = new Gtk.Button.with_label (_("Continue")) {
             // can_default = true,
             // no_show_all = true
         };
-        // continue_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+        continue_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
         continue_button.clicked.connect (on_continue_clicked);
 
         var button_box = new Gtk.Box (HORIZONTAL, 6) {

--- a/libcore/FileConflictDialog.vala
+++ b/libcore/FileConflictDialog.vala
@@ -185,7 +185,7 @@ public class Files.FileConflictDialog : Granite.MessageDialog {
         add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
 
         replace_button = (Gtk.Button) add_button (_("Replace"), ResponseType.REPLACE);
-        // replace_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+        replace_button.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
         var comparison_grid = new Gtk.Grid () {
             column_spacing = 6,

--- a/libcore/FileOperations/CommonJob.vala
+++ b/libcore/FileOperations/CommonJob.vala
@@ -487,7 +487,7 @@ public class Files.FileOperations.CommonJob {
             foreach (unowned string title in buttons) {
                 unowned Gtk.Widget button = dialog.add_button (title, response_id);
                 if (title == DELETE || title == DELETE_ALL || title == EMPTY_TRASH) {
-                    // button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+                    button.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
                 }
 
                 response_id++;

--- a/libcore/FileOperations/EmptyTrashJob.vala
+++ b/libcore/FileOperations/EmptyTrashJob.vala
@@ -100,7 +100,7 @@ public class Files.FileOperations.EmptyTrashJob : CommonJob {
                 };
 
                 unowned var empty_button = message_dialog.add_button (EMPTY_TRASH, Gtk.ResponseType.YES);
-                // empty_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+                empty_button.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
                 message_dialog.response.connect ((response) => {
                     if (response == Gtk.ResponseType.YES) {

--- a/libcore/Widgets/BasicBreadcrumbsEntry.vala
+++ b/libcore/Widgets/BasicBreadcrumbsEntry.vala
@@ -82,18 +82,21 @@ namespace Files.View.Chrome {
 
         construct {
             truncate_multiline = true;
-            weak Gtk.StyleContext style_context = get_style_context ();
-            style_context.add_class ("pathbar");
+            add_css_class ("pathbar");
 
             var css_provider = new Gtk.CssProvider ();
             try {
                 css_provider.load_from_data (".noradius-button { border-radius: 0; }".data);
-                style_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+                Gtk.StyleContext.add_provider_for_display (
+                    Gdk.Display.get_default (),
+                    css_provider,
+                    Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+                );
             } catch (Error e) {
                 critical ("Unable to style pathbar button: %s", e.message);
             }
 
-            breadcrumb_icons = new BreadcrumbIconList (style_context);
+            breadcrumb_icons = new BreadcrumbIconList (this);
 
             elements = new Gee.ArrayList<BreadcrumbElement> ();
             old_elements = new Gee.ArrayList<BreadcrumbElement> ();
@@ -421,12 +424,10 @@ namespace Files.View.Chrome {
             var l = (int)displayed_breadcrumbs.length (); //can assumed to be limited in length
             var w = displayed_breadcrumbs.first ().data.natural_width;
             if (l > 1) {
-                weak Gtk.StyleContext style_context = get_style_context ();
-                // var padding = style_context.get_padding (style_context.get_state ());
-                // w += (l - 1) * (MINIMUM_BREADCRUMB_WIDTH + padding.left + padding.right);
+                w += (l - 1) * (MINIMUM_BREADCRUMB_WIDTH;
 
                 /* Allow extra space for last breadcrumb */
-                // w += 3 * (MINIMUM_BREADCRUMB_WIDTH + padding.left + padding.right);
+                w += 3 * (MINIMUM_BREADCRUMB_WIDTH);
             }
 
             /* Allow enough space after the breadcrumbs for secondary icon and entry */
@@ -475,7 +476,7 @@ namespace Files.View.Chrome {
         protected BreadcrumbElement? get_element_from_coordinates (double x) {
             double width = get_allocated_width () - ICON_WIDTH;
             double height = get_allocated_height ();
-            var is_rtl = Gtk.StateFlags.DIR_RTL in get_style_context ().get_state ();
+            var is_rtl = get_direction == TextDirection.RTL;
             double x_render = is_rtl ? width : 0;
             foreach (BreadcrumbElement element in elements) {
                 if (element.display) {
@@ -518,10 +519,10 @@ namespace Files.View.Chrome {
             /* Ensure the breadcrumb texts are escaped strings whether or not
              * the parameter newpath was supplied escaped */
             string newpath = FileUtils.escape_uri (Uri.unescape_string (path) ?? path);
-            newelements.add (new BreadcrumbElement (protocol, this, get_style_context ()));
+            newelements.add (new BreadcrumbElement (protocol, this);
             foreach (string dir in newpath.split (Path.DIR_SEPARATOR_S)) {
                 if (dir != "") {
-                    newelements.add (new BreadcrumbElement (dir, this, get_style_context ()));
+                    newelements.add (new BreadcrumbElement (dir, this));
                 }
             }
 
@@ -661,19 +662,17 @@ namespace Files.View.Chrome {
 
         public bool draw (Cairo.Context cr) {
         // public override bool draw (Cairo.Context cr) {
-            weak Gtk.StyleContext style_context = get_style_context ();
             // if (button_context_active == null) {
             //     button_context_active = new Gtk.StyleContext ();
             //     button_context_active.set_path (style_context.get_path ());
             //     button_context_active.set_state (Gtk.StateFlags.ACTIVE);
             // }
-            var is_rtl = Gtk.StateFlags.DIR_RTL in style_context.get_state ();
-            // var padding = style_context.get_padding (style_context.get_state ());
+            var is_rtl = get_direction () == Gtk.TextDirection.RTL;
             // base.draw (cr);
             double height = get_allocated_height ();
             double width = get_allocated_width ();
 
-            int scale = style_context.get_scale ();
+            int scale = get_scale_factor ();
             if (breadcrumb_icons.scale != scale) {
                 breadcrumb_icons.scale = scale;
 
@@ -684,10 +683,7 @@ namespace Files.View.Chrome {
                 set_element_icons (protocol, elements);
             }
 
-            style_context.save ();
-            style_context.set_state (Gtk.StateFlags.ACTIVE);
-            // Gtk.Border border = style_context.get_margin (style_context.get_state ());
-            style_context.restore ();
+            //TODO Set state flags if required
 
             if (!is_focus () && !hide_breadcrumbs) {
                 // double margin = border.top;

--- a/libcore/Widgets/BasicBreadcrumbsEntry.vala
+++ b/libcore/Widgets/BasicBreadcrumbsEntry.vala
@@ -124,9 +124,9 @@ namespace Files.View.Chrome {
             // motion_controller.motion.connect (on_motion_event);
 
             minimum_width = 100;
-            notify["scale-factor"].connect (() => {
-                breadcrumb_icons.scale = scale_factor;
-            });
+            // notify["scale-factor"].connect (() => {
+            //     breadcrumb_icons.scale = scale_factor;
+            // });
         }
 
     /** Navigatable Interface **/
@@ -424,7 +424,7 @@ namespace Files.View.Chrome {
             var l = (int)displayed_breadcrumbs.length (); //can assumed to be limited in length
             var w = displayed_breadcrumbs.first ().data.natural_width;
             if (l > 1) {
-                w += (l - 1) * (MINIMUM_BREADCRUMB_WIDTH;
+                w += (l - 1) * (MINIMUM_BREADCRUMB_WIDTH);
 
                 /* Allow extra space for last breadcrumb */
                 w += 3 * (MINIMUM_BREADCRUMB_WIDTH);
@@ -476,7 +476,7 @@ namespace Files.View.Chrome {
         protected BreadcrumbElement? get_element_from_coordinates (double x) {
             double width = get_allocated_width () - ICON_WIDTH;
             double height = get_allocated_height ();
-            var is_rtl = get_direction == TextDirection.RTL;
+            var is_rtl = get_direction () == Gtk.TextDirection.RTL;
             double x_render = is_rtl ? width : 0;
             foreach (BreadcrumbElement element in elements) {
                 if (element.display) {
@@ -519,7 +519,7 @@ namespace Files.View.Chrome {
             /* Ensure the breadcrumb texts are escaped strings whether or not
              * the parameter newpath was supplied escaped */
             string newpath = FileUtils.escape_uri (Uri.unescape_string (path) ?? path);
-            newelements.add (new BreadcrumbElement (protocol, this);
+            newelements.add (new BreadcrumbElement (protocol, this));
             foreach (string dir in newpath.split (Path.DIR_SEPARATOR_S)) {
                 if (dir != "") {
                     newelements.add (new BreadcrumbElement (dir, this));
@@ -673,15 +673,15 @@ namespace Files.View.Chrome {
             double width = get_allocated_width ();
 
             int scale = get_scale_factor ();
-            if (breadcrumb_icons.scale != scale) {
-                breadcrumb_icons.scale = scale;
+            // if (breadcrumb_icons.scale != scale) {
+            //     breadcrumb_icons.scale = scale;
 
-                string protocol = "";
-                if (elements.size > 0) {
-                    protocol = elements[0].text;
-                }
-                set_element_icons (protocol, elements);
-            }
+            //     string protocol = "";
+            //     if (elements.size > 0) {
+            //         protocol = elements[0].text;
+            //     }
+            //     set_element_icons (protocol, elements);
+            // }
 
             //TODO Set state flags if required
 

--- a/libcore/Widgets/BreadcrumbElement.vala
+++ b/libcore/Widgets/BreadcrumbElement.vala
@@ -68,7 +68,7 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
     private Pango.Layout layout;
     private Gtk.Widget widget;
 
-    public BreadcrumbElement (string text_, Gtk.Widget widget_, Gtk.StyleContext button_context) {
+    public BreadcrumbElement (string text_, Gtk.Widget widget_) {
         text = text_;
         widget = widget_;
         // padding = button_context.get_padding (button_context.get_state ());
@@ -185,8 +185,8 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
             cr.close_path ();
 
             cr.clip ();
-            button_context.render_background (cr, left_x, y, width + height + 2 * line_width, height);
-            button_context.render_frame (cr, 0, y, widget.get_allocated_width (), height);
+            // button_context.render_background (cr, left_x, y, width + height + 2 * line_width, height);
+            // button_context.render_frame (cr, 0, y, widget.get_allocated_width (), height);
             cr.restore ();
         }
 
@@ -222,7 +222,7 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
         }
 
         /* Get icon pixbuf and fade if appropriate */
-        Gdk.Pixbuf? icon_to_draw = icon_info != null ? icon_info.render_icon (button_context) : null;
+        Gdk.Pixbuf? icon_to_draw = icon_info != null ? icon_info.render_icon (widget) : null;
         if (icon_to_draw != null && (state & Gtk.StateFlags.BACKDROP) > 0) {
             icon_to_draw = PF.PixbufUtils.lucent (icon_to_draw, 50);
         }
@@ -235,8 +235,8 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
         if (is_rtl) {
             if (icon_to_draw == null) {
                 if (room_for_text) {
-                    button_context.render_layout (cr, x - width,
-                                                  y_half_height - text_half_height, layout);
+                    // button_context.render_layout (cr, x - width,
+                                                  // y_half_height - text_half_height, layout);
                 }
             } else {
                 if (room_for_icon) {
@@ -250,8 +250,8 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
                 }
                 if (text_is_displayed && room_for_text) {
                     /* text_width already includes icon_width */
-                    button_context.render_layout (cr, x - width,
-                                                  y_half_height - text_half_height, layout);
+                    // button_context.render_layout (cr, x - width,
+                                                  // y_half_height - text_half_height, layout);
                 }
             }
         } else {
@@ -260,8 +260,8 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
 
             if (icon_to_draw == null) {
                 if (room_for_text) {
-                    button_context.render_layout (cr, x,
-                                                  y_half_height - text_half_height, layout);
+                    // button_context.render_layout (cr, x,
+                    //                               y_half_height - text_half_height, layout);
                 }
             } else {
                 if (room_for_icon) {
@@ -274,8 +274,8 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
                     cr.restore ();
                 }
                 if (text_is_displayed && room_for_text && x > 0) {
-                    button_context.render_layout (cr, x + iw,
-                                                  y_half_height - text_half_height, layout);
+                    // button_context.render_layout (cr, x + iw,
+                                                  // y_half_height - text_half_height, layout);
                 }
             }
 
@@ -306,10 +306,10 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
             cr.rectangle (0, -height / 2 + line_width, -height, height - 2 * line_width);
             cr.clip ();
             cr.rotate (Math.PI_4);
-            button_context.save ();
-            button_context.add_class ("noradius-button");
-            button_context.render_frame (cr, -height / 2, -height / 2, height, height);
-            button_context.restore ();
+            // button_context.save ();
+            // button_context.add_class ("noradius-button");
+            // button_context.render_frame (cr, -height / 2, -height / 2, height, height);
+            // button_context.restore ();
             cr.restore ();
         } else {
             cr.save ();
@@ -317,10 +317,10 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
             cr.rectangle (0, -height / 2 + line_width, height, height - 2 * line_width);
             cr.clip ();
             cr.rotate (Math.PI_4);
-            button_context.save ();
-            button_context.add_class ("noradius-button");
-            button_context.render_frame (cr, -height / 2, -height / 2, height, height);
-            button_context.restore ();
+            // button_context.save ();
+            // button_context.add_class ("noradius-button");
+            // button_context.render_frame (cr, -height / 2, -height / 2, height, height);
+            // button_context.restore ();
             cr.restore ();
         }
 
@@ -331,7 +331,7 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
             x += half_height;
         }
 
-        button_context.restore ();
+        // button_context.restore ();
         return x;
     }
 

--- a/libcore/Widgets/BreadcrumbElement.vala
+++ b/libcore/Widgets/BreadcrumbElement.vala
@@ -97,16 +97,15 @@ public class Files.View.Chrome.BreadcrumbElement : Object {
         return mask;
     }
 
+    //TODO Rewrite using snapshot
     public double draw (Cairo.Context cr, double x, double y, double height, Gtk.Widget widget) {
-        weak Gtk.StyleContext button_context = widget.get_style_context ();
-        var state = button_context.get_state ();
+        var state = widget.get_state_flags ();
+        var orig_state = state;
         var is_rtl = Gtk.StateFlags.DIR_RTL in state;
         var scale = widget.scale_factor;
 
-        button_context.save ();
         if (pressed) {
-            state |= Gtk.StateFlags.ACTIVE;
-            button_context.set_state (state);
+            widget.set_state_flags (Gtk.StateFlags.ACTIVE, false);
         }
 
         // padding = button_context.get_padding (state);

--- a/libcore/Widgets/BreadcrumbIconList.vala
+++ b/libcore/Widgets/BreadcrumbIconList.vala
@@ -52,11 +52,11 @@ namespace Files.View.Chrome {
             text_displayed = mount.get_name ();
         }
 
-        public Gdk.Pixbuf? render_icon (Gtk.StyleContext context) {
+        public Gdk.Pixbuf? render_icon (Gtk.Widget widget) {
             // var theme = Gtk.IconTheme.get_default ();
             Gdk.Pixbuf? icon = null;
             // Gtk.IconInfo? gtk_icon_info = null;
-            var scale = context.get_scale ();
+            var scale = widget.get_scale_factor ();
 
             if (gicon == null) {
                 gicon = new ThemedIcon.with_default_fallbacks ("image-missing");
@@ -93,18 +93,18 @@ namespace Files.View.Chrome {
 
     public class BreadcrumbIconList : Object {
         private Gee.ArrayList<BreadcrumbIconInfo> icon_info_list;
-        public unowned Gtk.StyleContext context { get; construct; }
+        public Gtk.Widget widget { get; construct; }
 
-        public BreadcrumbIconList (Gtk.StyleContext context) {
-            Object (context: context);
+        public BreadcrumbIconList (Gtk.Widget widget) {
+            Object (widget: widget);
         }
 
         public int scale {
             get {
-                return context.get_scale ();
+                return widget.get_scale_factor ();
             }
             set {
-                context.set_scale (value);
+                widget.set_scale_factor (value);
             }
         }
 
@@ -162,8 +162,8 @@ namespace Files.View.Chrome {
         }
 
         public void add_mounted_volumes () {
-            context.save ();
-            context.set_state (Gtk.StateFlags.NORMAL);
+            var flags = widget.get_state_flags ();
+            widget.set_state_flags (Gtk.StateFlags.NORMAL, false);
 
             /* Add every mounted volume in our BreadcrumbIcon in order to load them properly in the pathbar if needed */
             var volume_monitor = VolumeMonitor.get ();
@@ -176,7 +176,7 @@ namespace Files.View.Chrome {
                 }
             });
 
-            context.restore ();
+            widget.set_state_flags (flags, true);
         }
 
         public void truncate_to_length (int new_length) {

--- a/libcore/Widgets/BreadcrumbIconList.vala
+++ b/libcore/Widgets/BreadcrumbIconList.vala
@@ -103,9 +103,9 @@ namespace Files.View.Chrome {
             get {
                 return widget.get_scale_factor ();
             }
-            set {
-                widget.set_scale_factor (value);
-            }
+            // set {
+            //     widget.set_scale_factor (value);
+            // }
         }
 
         construct {

--- a/libcore/Widgets/ViewSwitcher.vala
+++ b/libcore/Widgets/ViewSwitcher.vala
@@ -30,7 +30,7 @@ namespace Files.View.Chrome {
         }
 
         construct {
-            // get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+            add_css_class (Granite.STYLE_CLASS_LINKED);
 
             /* Grid View item */
             var id = (uint32)ViewMode.ICON;

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -147,6 +147,11 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
         static construct {
             css_provider = new Gtk.CssProvider ();
             css_provider.load_from_resource ("io/elementary/files/ColorButton.css");
+            Gtk.StyleContext.add_provider_for_display (
+                Gdk.Display.get_default (),
+                css_provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            );
         }
 
         public ColorButton (string color_name) {
@@ -154,10 +159,8 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
         }
 
         construct {
-            var style_context = get_style_context ();
-            style_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-            style_context.add_class (Granite.STYLE_CLASS_COLOR_BUTTON);
-            style_context.add_class (color_name);
+            add_css_class (Granite.STYLE_CLASS_COLOR_BUTTON);
+            add_css_class (color_name);
         }
     }
 
@@ -200,9 +203,7 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
     //             var css_provider = new Gtk.CssProvider ();
     //             css_provider.load_from_data (css, -1);
 
-    //             var style_context = get_style_context ();
-    //             style_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-    //             style_context.add_class ("nohover");
+    //             add_css_class ("nohover");
     //         } catch (GLib.Error e) {
     //             warning ("Failed to parse css style : %s", e.message);
     //         }

--- a/plugins/pantheon-files-ctags/plugin.vala
+++ b/plugins/pantheon-files-ctags/plugin.vala
@@ -238,7 +238,7 @@ public class Files.Plugins.CTags : Files.Plugins.Base {
     //             return true;
     //         }
 
-    //         if (Gtk.StateFlags.DIR_RTL in get_style_context ().get_state ()) {
+            // if (Gtk.TextDirection.RTL in get_direction ())
     //             var width = get_allocated_width ();
     //             int x = width - 27;
     //             for (int i = 0; i < Files.Preferences.TAGS_COLORS.length; i++) {

--- a/plugins/pantheon-files-trash/plugin.vala
+++ b/plugins/pantheon-files-trash/plugin.vala
@@ -58,8 +58,7 @@ public class Files.Plugins.Trash : Files.Plugins.Base {
             /* Only add actionbar once */
             if (actionbar == null) {
                 actionbar = new Gtk.ActionBar ();
-                // actionbar.get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);
-
+                //TODO Consider if css style to replace inline-toolbar needed
                 restore_button = new Gtk.Button.with_label (_(RESTORE_ALL)) {
                     valign = Gtk.Align.CENTER
                 };
@@ -69,7 +68,7 @@ public class Files.Plugins.Trash : Files.Plugins.Base {
                     margin_start = 0
                 };
 
-                // delete_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+                delete_button.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
                 var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
                 size_group.add_widget (restore_button);

--- a/src/Dialogs/AbstractPropertiesDialog.vala
+++ b/src/Dialogs/AbstractPropertiesDialog.vala
@@ -75,7 +75,7 @@ protected abstract class Files.View.AbstractPropertiesDialog : Granite.Dialog {
     }
 
     protected void create_header_title () {
-        header_title.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+        header_title.add_css_class (Granite.STYLE_CLASS_H2_LABEL);
         header_title.hexpand = true;
         header_title.margin_top = 6;
         header_title.valign = CENTER;
@@ -138,7 +138,7 @@ protected abstract class Files.View.AbstractPropertiesDialog : Granite.Dialog {
             storage_levelbar.add_offset_value (Gtk.LEVEL_BAR_OFFSET_LOW, 0.6 * fs_capacity);
             storage_levelbar.add_offset_value (Gtk.LEVEL_BAR_OFFSET_HIGH, 0.9 * fs_capacity);
             storage_levelbar.add_offset_value (Gtk.LEVEL_BAR_OFFSET_FULL, fs_capacity);
-            storage_levelbar.get_style_context ().add_class ("inverted");
+            storage_levelbar.add_css_class ("inverted");
 
             var storage_label = new Gtk.Label (
                 _("%s free out of %s").printf (format_size (fs_capacity - fs_used + fs_reserved), format_size (fs_capacity))

--- a/src/Dialogs/BulkRenamer/RenamerDialog.vala
+++ b/src/Dialogs/BulkRenamer/RenamerDialog.vala
@@ -70,7 +70,7 @@ public class Files.RenamerDialog : Granite.Dialog {
         var cancel_button = add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
 
         var rename_button = add_button (_("Rename"), Gtk.ResponseType.APPLY);
-        // rename_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+        rename_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
         renamer.bind_property (
             "can-rename", rename_button, "sensitive", DEFAULT | SYNC_CREATE
         );
@@ -145,10 +145,10 @@ public class Files.RenamerDialog : Granite.Dialog {
         // modify_basename_toggle.set_mode (false);
 
         var toggle_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-        // toggle_box.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-        // toggle_box.add (original_basename_toggle);
-        // toggle_box.add (new_basename_toggle);
-        // toggle_box.add (modify_basename_toggle);
+        toggle_box.add_css_class (Granite.STYLE_CLASS_LINKED);
+        // toggle_box.append (original_basename_toggle);
+        // toggle_box.append (new_basename_toggle);
+        // toggle_box.append (modify_basename_toggle);
 
         var basename_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
             halign = Gtk.Align.CENTER,
@@ -327,7 +327,7 @@ public class Files.RenamerDialog : Granite.Dialog {
         renamer.modifier_chain.add (mod);
 
         var apply_button = new Gtk.Button.with_label (_("Apply"));
-        // apply_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+        apply_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
 
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));
 
@@ -337,7 +337,7 @@ public class Files.RenamerDialog : Granite.Dialog {
         button_box.pack_start (delete_button);
         button_box.pack_end (apply_button);
         button_box.pack_end (cancel_button);
-        // button_box.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button_box.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         var edit_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
         // edit_box.pack_start (mod.get_modifier_widget ());

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -969,10 +969,10 @@ public class Files.View.PropertiesWindow : AbstractPropertiesDialog {
             selection_mode = NONE
         };
         // FIXME: use constants in Gtk4
-        permission_box.get_style_context ().add_class ("frame");
-        permission_box.get_style_context ().add_class ("rich-list");
-        permission_box.get_style_context ().add_class ("boxed-list");
-        permission_box.get_style_context ().add_class ("separators");
+        permission_box.add_css_class (Granite.STYLE_CLASS_FRAME);
+        permission_box.add_css_class (Granite.STYLE_CLASS_RICH_LIST);
+        permission_box.add_css_class ("boxed-list");
+        permission_box.add_css_class ("separators");
         permission_box.insert (perm_button_user, -1);
         permission_box.insert (perm_button_group, -1);
         permission_box.insert (perm_button_other, -1);

--- a/src/IconRenderer.vala
+++ b/src/IconRenderer.vala
@@ -179,8 +179,8 @@ namespace Files {
         //     }
 
         //     if (file.is_image ()) {
-        //         style_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
-        //         style_context.add_class (Granite.STYLE_CLASS_CARD);
+        //         widget.get_parent ().add_css_class (Granite.STYLE_CLASS_CHECKERBOARD);
+        //         widget.get_parent ().add_css_class (Granite.STYLE_CLASS_CARD);
         //     }
 
         //     cr.scale (1.0 / icon_scale, 1.0 / icon_scale);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -3285,9 +3285,9 @@ namespace Files {
             if (slot.directory.is_empty ()) {
                 Pango.Layout layout = create_pango_layout (null);
 
-                if (!style_context.has_class (Granite.STYLE_CLASS_H2_LABEL)) {
-                    style_context.add_class (Granite.STYLE_CLASS_H2_LABEL);
-                    // style_context.add_class (Gtk.STYLE_CLASS_VIEW);
+                if (!has_css_class (Granite.STYLE_CLASS_H2_LABEL)) {
+                    add_css_class (Granite.STYLE_CLASS_H2_LABEL);
+                    add_css_class (Granite.STYLE_CLASS_VIEW);
                 }
 
                 layout.set_markup (slot.get_empty_message (), -1);

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -682,10 +682,9 @@ namespace Files {
         }
 
         public void change_directory (Directory old_dir, Directory new_dir) {
-            var style_context = get_style_context ();
-            if (style_context.has_class (Granite.STYLE_CLASS_H2_LABEL)) {
-                style_context.remove_class (Granite.STYLE_CLASS_H2_LABEL);
-                // style_context.remove_class (Gtk.STYLE_CLASS_VIEW);
+            if (has_css_class (Granite.STYLE_CLASS_H2_LABEL)) {
+                remove_css_class (Granite.STYLE_CLASS_H2_LABEL);
+                remove_css_class (Granite.STYLE_CLASS_VIEW);
             }
 
             cancel ();
@@ -3281,7 +3280,7 @@ namespace Files {
         public virtual bool on_view_draw (Cairo.Context cr) {
             /* If folder is empty, draw the empty message in the middle of the view
              * otherwise pass on event */
-            var style_context = get_style_context ();
+            // var style_context = get_style_context ();
             if (slot.directory.is_empty ()) {
                 Pango.Layout layout = create_pango_layout (null);
 
@@ -3300,12 +3299,12 @@ namespace Files {
 
                 double x = (double) get_allocated_width () / 2 - width / 2;
                 double y = (double) get_allocated_height () / 2 - height / 2;
-                get_style_context ().render_layout (cr, x, y, layout);
+                // get_style_context ().render_layout (cr, x, y, layout);
 
                 return true;
-            } else if (style_context.has_class (Granite.STYLE_CLASS_H2_LABEL)) {
-                style_context.remove_class (Granite.STYLE_CLASS_H2_LABEL);
-                // style_context.remove_class (Gtk.STYLE_CLASS_VIEW);
+            } else if (has_css_class (Granite.STYLE_CLASS_H2_LABEL)) {
+                remove_css_class (Granite.STYLE_CLASS_H2_LABEL);
+                remove_css_class (Granite.STYLE_CLASS_VIEW);
             }
 
             return false;

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -106,6 +106,11 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         volume_monitor = VolumeMonitor.@get ();
         devicerow_provider = new Gtk.CssProvider ();
         devicerow_provider.load_from_resource ("/io/elementary/files/DiskRenderer.css");
+        Gtk.StyleContext.add_provider_for_display (
+            Gdk.Display.get_default (),
+            devicerow_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        );
     }
 
     construct {
@@ -144,10 +149,8 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
         storage_levelbar.add_offset_value (Gtk.LEVEL_BAR_OFFSET_HIGH, 0.95);
         storage_levelbar.add_offset_value (Gtk.LEVEL_BAR_OFFSET_FULL, 1);
 
-        unowned var storage_style_context = storage_levelbar.get_style_context ();
-        // storage_style_context.add_class (Gtk.STYLE_CLASS_FLAT);
-        storage_style_context.add_class ("inverted");
-        storage_style_context.add_provider (devicerow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        storage_levelbar.add_css_class (Granite.STYLE_CLASS_FLAT);
+        storage_levelbar.add_css_class ("inverted");
 
         icon_label_grid.attach (storage_levelbar, 1, 1);
 

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -119,7 +119,11 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
             tooltip_text = (can_eject ? _("Eject '%s'") : _("Unmount '%s'")).printf (custom_name)
         };
 
-        unmount_eject_button.get_style_context ().add_provider (devicerow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        Gtk.StyleContext.add_provider_for_display (
+            Gdk.Display.get_default (),
+            devicerow_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        );
 
         working_spinner = new Gtk.Spinner ();
 

--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -576,12 +576,13 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
         // });
     }
 
+    //TODO Review correct style class
     protected void highlight (bool show) {
-        // if (show && !get_style_context ().has_class (Gtk.STYLE_CLASS_HIGHLIGHT)) {
-        //     get_style_context ().add_class (Gtk.STYLE_CLASS_HIGHLIGHT);
-        // } else if (!show && get_style_context ().has_class (Gtk.STYLE_CLASS_HIGHLIGHT)) {
-        //     get_style_context ().remove_class (Gtk.STYLE_CLASS_HIGHLIGHT);
-        // }
+        if (show && !has_css_class (Granite.STYLE_CLASS_ACCENT)) {
+            add_css_class (Granite.STYLE_CLASS_ACCENT);
+        } else if (!show && has_css_class (Granite.STYLE_CLASS_ACCENT)) {
+            remove_css_class (Granite.STYLE_CLASS_ACCENT);
+        }
     }
 
     private void reset_drag_drop () {

--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -83,12 +83,12 @@ public class Sidebar.SidebarWindow : Gtk.Box, Files.SidebarInterface {
         };
 
         var action_bar = new Gtk.ActionBar ();
-        // action_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        // action_bar.add (connect_server_button);
+        action_bar.add_css_class (Granite.STYLE_CLASS_FLAT);
+        action_bar.pack_start (connect_server_button);
 
         orientation = Gtk.Orientation.VERTICAL;
         width_request = Files.app_settings.get_int ("minimum-sidebar-width");
-        // get_style_context ().add_class (Gtk.STYLE_CLASS_SIDEBAR);
+        add_css_class (Granite.STYLE_CLASS_SIDEBAR);
         // add (scrolled_window);
 
         //For now hide action bar when admin. This might need revisiting if other actions are added
@@ -245,6 +245,11 @@ public class Sidebar.SidebarWindow : Gtk.Box, Files.SidebarInterface {
         static construct {
             expander_provider = new Gtk.CssProvider ();
             expander_provider.load_from_resource ("/io/elementary/files/SidebarExpander.css");
+            Gtk.StyleContext.add_provider_for_display (
+                Gdk.Display.get_default (),
+                expander_provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            );
         }
 
         construct {
@@ -254,10 +259,7 @@ public class Sidebar.SidebarWindow : Gtk.Box, Files.SidebarInterface {
             };
 
             var arrow = new Gtk.Spinner ();
-
-            unowned Gtk.StyleContext arrow_style_context = arrow.get_style_context ();
-            // arrow_style_context.add_class (Gtk.STYLE_CLASS_ARROW);
-            arrow_style_context.add_provider (expander_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            arrow.add_css_class ("arrow");
 
             var box = new Gtk.Box (HORIZONTAL, 0);
             // box.add (title);
@@ -265,10 +267,8 @@ public class Sidebar.SidebarWindow : Gtk.Box, Files.SidebarInterface {
 
             child = box;
 
-            unowned Gtk.StyleContext style_context = get_style_context ();
-            style_context.add_class (Granite.STYLE_CLASS_H4_LABEL);
-            // style_context.add_class (Gtk.STYLE_CLASS_EXPANDER);
-            style_context.add_provider (expander_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            add_css_class (Granite.STYLE_CLASS_H4_LABEL);
+            add_css_class ("expander");
         }
     }
 }

--- a/src/View/Widgets/AppMenu.vala
+++ b/src/View/Widgets/AppMenu.vala
@@ -53,10 +53,11 @@ public class Files.AppMenu : Gtk.Popover {
             margin_bottom = 6,
             margin_start = 12
         };
-        // icon_size_box.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-        // icon_size_box.add (zoom_out_button);
-        // icon_size_box.add (zoom_default_button);
-        // icon_size_box.add (zoom_in_button);
+
+        icon_size_box.add_css_class (Granite.STYLE_CLASS_LINKED);
+        icon_size_box.append (zoom_out_button);
+        icon_size_box.append (zoom_default_button);
+        icon_size_box.append (zoom_in_button);
 
         var undo_redo_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
             homogeneous = true,
@@ -64,7 +65,7 @@ public class Files.AppMenu : Gtk.Popover {
             margin_bottom = 12,
             margin_start = 12
         };
-        // undo_redo_box.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+        undo_redo_box.add_css_class (Granite.STYLE_CLASS_LINKED);
 
         // undo_button = new Gtk.Button.from_icon_name ("edit-undo-symbolic", Gtk.IconSize.MENU) {
         undo_button = new Gtk.Button.from_icon_name ("edit-undo-symbolic") {
@@ -100,21 +101,18 @@ public class Files.AppMenu : Gtk.Popover {
         var show_hidden_button = new Gtk.CheckButton () {
             action_name = "win.show-hidden"
         };
-        // show_hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
-        // show_hidden_button.add (new Granite.AccelLabel (
-        //     _("Hidden Files"),
-        //     "<Ctrl>h"
-        // ));
+
+        show_hidden_button.add_css_class (Granite.STYLE_CLASS_MENUITEM);
 
         var show_local_thumbnails = new Gtk.CheckButton.with_label (_("Local Thumbnails")) {
             action_name = "win.show-local-thumbnails"
         };
-        // show_local_thumbnails.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
+        show_local_thumbnails.add_css_class (Granite.STYLE_CLASS_MENUITEM);
 
         var show_remote_thumbnails = new Gtk.CheckButton.with_label (_("Remote Thumbnails")) {
             action_name = "win.show-remote-thumbnails"
         };
-        // show_remote_thumbnails.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
+        show_remote_thumbnails.add_css_class (Granite.STYLE_CLASS_MENUITEM);
 
         var menu_box = new Gtk.Box (VERTICAL, 0) {
             margin_bottom = 6

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -36,7 +36,7 @@ namespace Files.View.Chrome {
                 if (!value) {
                     bread.set_primary_icon_name (null);
                 } else {
-                    bread.get_style_context ().remove_class ("spin");
+                    remove_css_class ("spin");
                     bread.set_primary_icon_name (Files.ICON_PATHBAR_PRIMARY_FIND_SYMBOLIC);
                     hide_navigate_icon ();
                 }
@@ -206,7 +206,7 @@ namespace Files.View.Chrome {
             return txt.contains (Path.DIR_SEPARATOR_S) || txt.contains (":");
         }
         protected void show_refresh_icon () {
-            bread.get_style_context ().remove_class ("spin");
+            bread.remove_css_class ("spin");
             bread.action_icon_name = Files.ICON_PATHBAR_SECONDARY_REFRESH_SYMBOLIC;
             bread.set_action_icon_tooltip (Granite.markup_accel_tooltip ({"F5", "<Ctrl>R"}, _("Reload this folder")));
         }
@@ -226,7 +226,7 @@ namespace Files.View.Chrome {
         }
 
         private void hide_working_icon () {
-            bread.get_style_context ().remove_class ("spin");
+            bread.remove_css_class ("spin");
             bread.action_icon_name = null;
         }
 

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -222,7 +222,7 @@ namespace Files.View.Chrome {
         private void show_working_icon () {
             bread.action_icon_name = Files.ICON_PATHBAR_SECONDARY_WORKING_SYMBOLIC;
             bread.set_action_icon_tooltip (_("Searching…"));
-            bread.get_style_context ().add_class ("spin");
+            bread.add_css_class ("spin");
         }
 
         private void hide_working_icon () {

--- a/src/View/Widgets/ProgressInfoWidget.vala
+++ b/src/View/Widgets/ProgressInfoWidget.vala
@@ -64,7 +64,7 @@ public class Files.Progress.InfoWidget : Gtk.Grid {
             tooltip_text = _("Cancel")
         };
 
-        // button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         column_spacing = 6;
         attach (status, 0, 0, 2);

--- a/src/View/Widgets/SearchResults.vala
+++ b/src/View/Widgets/SearchResults.vala
@@ -182,7 +182,7 @@ namespace Files.View.Chrome {
                 propagate_natural_height = true,
             };
 
-            get_style_context ().add_class ("completion-popup");
+            add_css_class ("completion-popup");
 
             var column = new Gtk.TreeViewColumn () {
                 sizing = Gtk.TreeViewColumnSizing.FIXED

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -192,12 +192,12 @@ public class Files.View.Window : Adw.ApplicationWindow {
         button_back = new View.Chrome.ButtonWithMenu ("go-previous-symbolic");
 
         button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
-        // button_back.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button_back.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         button_forward = new View.Chrome.ButtonWithMenu ("go-next-symbolic");
 
         button_forward.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Right"}, _("Next"));
-        // button_forward.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button_forward.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         view_switcher = new Chrome.ViewSwitcher ((SimpleAction)lookup_action ("view-mode")) {
             margin_end = 20


### PR DESCRIPTION
Simple avoidance/replacement of stylecontext use.

Style providers added to display instead of widgets. May need changes to css files and css names later.

Rendering will be addressed separately.