### PR TITLE
Gtk4 Prep - Use dialog.response.connect () pattern

### DIFF
--- a/src/Dialogs/ChooseAppDialog.vala
+++ b/src/Dialogs/ChooseAppDialog.vala
@@ -31,9 +31,11 @@ class PF.ChooseAppDialog : Object {
     }
 
     construct {
-        dialog = new Gtk.AppChooserDialog (parent,
-                                             Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                                             file_to_open) {
+        dialog = new Gtk.AppChooserDialog (
+            parent,
+            Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            file_to_open
+        ) {
             deletable = false
         };
 
@@ -49,29 +51,32 @@ class PF.ChooseAppDialog : Object {
         check_default.show ();
 
         dialog.get_content_area ().add (check_default);
-
-        dialog.show ();
     }
 
     public AppInfo? get_app_info () {
         AppInfo? app = null;
-        int response = dialog.run ();
+        dialog.response.connect ((res) => {
+            if (res == Gtk.ResponseType.OK) {
+                app = dialog.get_app_info ();
+                if (check_default.get_active ()) {
+                    try {
+                        var info = file_to_open.query_info (FileAttribute.STANDARD_CONTENT_TYPE,
+                                                            FileQueryInfoFlags.NONE, null);
 
-        if (response == Gtk.ResponseType.OK) {
-            app = dialog.get_app_info ();
-            if (check_default.get_active ()) {
-                try {
-                    var info = file_to_open.query_info (FileAttribute.STANDARD_CONTENT_TYPE,
-                                                        FileQueryInfoFlags.NONE, null);
-
-                    app.set_as_default_for_type (info.get_attribute_string (GLib.FileAttribute.STANDARD_CONTENT_TYPE));
-                }
-                catch (GLib.Error error) {
-                    critical ("Could not set as default: %s", error.message);
+                        app.set_as_default_for_type (info.get_attribute_string (GLib.FileAttribute.STANDARD_CONTENT_TYPE));
+                    }
+                    catch (GLib.Error error) {
+                        critical ("Could not set as default: %s", error.message);
+                    }
                 }
             }
-        }
-        dialog.destroy ();
+
+            dialog.destroy ();
+        });
+
+        // Need to continue to use run () in Gtk3 in order to get modal dialog - we need to return
+        // the chosen app from this function.
+        dialog.run ();
         return app;
     }
 }

--- a/src/View/DirectoryNotFound.vala
+++ b/src/View/DirectoryNotFound.vala
@@ -48,8 +48,8 @@ namespace Files.View {
                             Gtk.ButtonsType.CLOSE
                         );
 
-                        dialog.run ();
-                        dialog.destroy ();
+                        dialog.response.connect (dialog.destroy);
+                        dialog.present ();
                     }
                 }
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1113,15 +1113,18 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         var dialog = new PF.ConnectServerDialog ((Gtk.Window) this);
         string server_uri = "";
 
-        if (dialog.run () == Gtk.ResponseType.OK) {
-            server_uri = dialog.server_uri;
-        }
+        dialog.response.connect ((res) => {
+            if (res == Gtk.ResponseType.OK) {
+                server_uri = dialog.server_uri;
+                if (server_uri != "") {
+                    uri_path_change_request (dialog.server_uri, Files.OpenFlag.DEFAULT);
+                }
+            }
 
-        dialog.destroy ();
+            dialog.destroy ();
+        });
 
-        if (server_uri != "") {
-            uri_path_change_request (dialog.server_uri, Files.OpenFlag.DEFAULT);
-        }
+        dialog.present ();
     }
 
     void show_app_help () {


### PR DESCRIPTION
The dialog response is consistently handled in a closure connected to the `response` signal.

Where possible dialog.present () is also used but it seems that in Gtk3, this does not block the main loop even if the dialog is flagged as modal.  In cases where we need the mainloop to wait for a result from the dialog, `dialog.run ()` is still called.  I assume that in Gtk4, this can be changed to `dialog.present ()` and the `modal` flag will be observed.