### PR TITLE
FileChooserDialog: show_all dialog contents

### DIFF
--- a/filechooser-portal/FileChooserDialog.vala
+++ b/filechooser-portal/FileChooserDialog.vala
@@ -161,6 +161,8 @@ public class Files.FileChooserDialog : Hdy.Window, Xdp.Request {
         grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
         grid.add (choices_box);
         grid.add (action_box);
+        grid.show_all ();
+
         add (grid);
 
         setup_chooser ();


### PR DESCRIPTION
Fix a regression from #2560 

We still need a show_all here otherwise we get a blank window