### PR TITLE
Directory View: Do not end renaming when clicking on editable widget

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -347,7 +347,7 @@ namespace Files {
                 });
 
                 button_controller = new Gtk.GestureMultiPress (view) {
-                    propagation_phase = CAPTURE,
+                    propagation_phase = TARGET,  //Allow editable widget to receive button press event first
                     button = 0
                 };
                 button_controller.pressed.connect (on_view_button_press_event);
@@ -3348,6 +3348,7 @@ namespace Files {
 
         protected virtual void on_view_button_press_event (int n_press, double x, double y) {
             if (renaming) {
+                // Button press occurred outside editable widget - end editing.
                 /* Commit any change if renaming (https://github.com/elementary/files/issues/641) */
                 name_renderer.end_editing (false);
             }


### PR DESCRIPTION
Fixes #2570 

Allow button events to reach editable widget before the view by adjusting the propagation phase of the button controller.