### PR TITLE
Show context menu on all areas of sidebar

### DIFF
--- a/src/View/Sidebar/BookmarkRow.vala
+++ b/src/View/Sidebar/BookmarkRow.vala
@@ -160,11 +160,13 @@ public class Sidebar.BookmarkRow : Gtk.ListBoxRow, SidebarItemInterface {
         content_grid = new Gtk.Grid ();
         content_grid.attach (icon_label_grid, 0, 0);
 
-        add (content_grid);
+        var event_box = new Gtk.EventBox ();
+        event_box.add (content_grid);
+        add (event_box);
         show_all ();
 
         key_controller = new Gtk.EventControllerKey (this) {
-            propagation_phase = BUBBLE
+            propagation_phase = CAPTURE
         };
         key_controller.key_pressed.connect (on_key_press_event);
 


### PR DESCRIPTION
Fixes #2574 

There's some weirdness going after converting to an eventcontroller to handle button clicks.  Only some children of the content grid are responsive and no obvious reason was found.  A simple but temporary solution is to insert an EventBox as the immediate child of the row.  This will need to be removed on porting to Gtk4 but hopefully event controllers will work better in Gtk4 and the fix will no longer be needed :crossed_fingers: 


 