### PR TITLE
AppChooserDialog: Replace run ()

### DIFF
--- a/src/Dialogs/ChooseAppDialog.vala
+++ b/src/Dialogs/ChooseAppDialog.vala
@@ -53,7 +53,7 @@ class PF.ChooseAppDialog : Object {
         dialog.get_content_area ().add (check_default);
     }
 
-    public AppInfo? get_app_info () {
+    public async AppInfo? get_app_info () {
         AppInfo? app = null;
         dialog.response.connect ((res) => {
             if (res == Gtk.ResponseType.OK) {
@@ -72,11 +72,11 @@ class PF.ChooseAppDialog : Object {
             }
 
             dialog.destroy ();
+            get_app_info.callback (); //Continue after yield statement
         });
 
-        // Need to continue to use run () in Gtk3 in order to get modal dialog - we need to return
-        // the chosen app from this function.
-        dialog.run ();
+        dialog.present ();
+        yield;
         return app;
     }
 }

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -1192,15 +1192,21 @@ public class Files.View.PropertiesWindow : AbstractPropertiesDialog {
                         AppsColumn.APP_INFO, out app);
 
         if (app == null) {
-            var app_chosen = MimeActions.choose_app_for_glib_file (goffile.location, this);
-            if (app_chosen != null) {
-                store_apps.prepend (out iter);
-                store_apps.set (iter,
-                                AppsColumn.APP_INFO, app_chosen,
-                                AppsColumn.LABEL, app_chosen.get_name (),
-                                AppsColumn.ICON, ensure_icon (app_chosen));
-                combo.set_active (0);
-            }
+            MimeActions.choose_app_for_glib_file.begin (
+                goffile.location,
+                this,
+                (obj, res) => {
+                    var app_chosen = MimeActions.choose_app_for_glib_file.end (res);
+                    if (app_chosen != null) {
+                        store_apps.prepend (out iter);
+                        store_apps.set (iter,
+                                        AppsColumn.APP_INFO, app_chosen,
+                                        AppsColumn.LABEL, app_chosen.get_name (),
+                                        AppsColumn.ICON, ensure_icon (app_chosen));
+                        combo.set_active (0);
+                    }
+                }
+            );
         } else {
             try {
                 foreach (var mime in mimes) {

--- a/src/Utils/MimeActions.vala
+++ b/src/Utils/MimeActions.vala
@@ -252,11 +252,11 @@ public class Files.MimeActions {
         return get_default_application_for_file (Files.File.@get (file));
     }
 
-    public static void open_glib_file_request (GLib.File file_to_open, Gtk.Widget parent, AppInfo? app = null) {
+    public static async void open_glib_file_request (GLib.File file_to_open, Gtk.Widget parent, AppInfo? app = null) {
         /* Note: This function should be only called if file_to_open is not an executable or it is not
          * intended to execute it (AbstractDirectoryView takes care of this) */
         if (app == null) {
-            var choice = choose_app_for_glib_file (file_to_open, parent);
+            var choice = yield choose_app_for_glib_file (file_to_open, parent);
             if (choice != null) {
                 launch_glib_file_with_app (file_to_open, parent, choice);
             }
@@ -292,9 +292,9 @@ public class Files.MimeActions {
         }
     }
 
-    public static AppInfo? choose_app_for_glib_file (GLib.File file_to_open, Gtk.Widget parent) {
+    public static async AppInfo? choose_app_for_glib_file (GLib.File file_to_open, Gtk.Widget parent) {
         var chooser = new PF.ChooseAppDialog (Files.get_active_window (), file_to_open);
-        return chooser.get_app_info ();
+        return yield chooser.get_app_info ();
     }
 
      private static void launch_glib_file_with_app (GLib.File file_to_open, Gtk.Widget parent, AppInfo app) {

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -824,7 +824,7 @@ namespace Files {
         /* Open all files through this */
         private void open_file (Files.File file, Gdk.Screen? screen, GLib.AppInfo? app_info) {
             if (can_open_file (file, true)) {
-                MimeActions.open_glib_file_request (file.location, this, app_info);
+                MimeActions.open_glib_file_request.begin (file.location, this, app_info);
             }
         }
 

--- a/src/View/Widgets/LocationBar.vala
+++ b/src/View/Widgets/LocationBar.vala
@@ -106,7 +106,7 @@ namespace Files.View.Chrome {
         }
         private void on_search_results_file_activated (GLib.File file) {
             AppInfo? app = MimeActions.get_default_application_for_glib_file (file);
-            MimeActions.open_glib_file_request (file, this, app);
+            MimeActions.open_glib_file_request.begin (file, this, app);
             on_search_results_exit ();
         }
 
@@ -163,7 +163,7 @@ namespace Files.View.Chrome {
         }
 
         private void on_bread_open_with_request (GLib.File file, AppInfo? app) {
-            Files.MimeActions.open_glib_file_request (file, this, app);
+            Files.MimeActions.open_glib_file_request.begin (file, this, app);
         }
 
         protected override void on_bread_action_icon_press () {


### PR DESCRIPTION
No `dialog.run ()` in Gtk4.  Replace with `present` and make functions async.

There doesn't appear to be a simpler way to have the necessary actions done in or after the response closure runs but I am open to suggestions.  Can be revisited when Gtk.Dialog (which is deprecated) gets replaced.