### PR TITLE
Fix filechooser regression for SAVE and SAVE_AS action

### DIFF
--- a/filechooser-portal/FileChooserDialog.vala
+++ b/filechooser-portal/FileChooserDialog.vala
@@ -380,7 +380,7 @@ public class Files.FileChooserDialog : Hdy.Window, Xdp.Request {
             entry_parent.remove (gtk_entry);
             validated_entry = new Granite.ValidatedEntry ();
             validated_entry.set_placeholder_text (_("Enter new filename"));
-            validated_entry.bind_property ("text", gtk_entry, "text", BindingFlags.SYNC_CREATE);
+            validated_entry.bind_property ("text", gtk_entry, "text", SYNC_CREATE | BIDIRECTIONAL);
             validated_entry.bind_property ("text-length", accept_button, "sensitive", BindingFlags.SYNC_CREATE);
 
             //Mirror the validated entry to the original entry to ensure behaviour unaffected


### PR DESCRIPTION
Following replacement of the native entry for a Granite.ValidatedEntry, the save and save_as actions no longer work because the chooser is still looking for the original entry for details.

This is fixed by syncing the validated entry content and activate action to the original entry and keeping a reference to the original entry.  Pre-existing or auto-filled text in the gtk entry is mirrored to the validated entry.

Not very elegant but works.  Looking for a better way...

Also fixes #2591