### PR TITLE
Revert translatable metainfo for release 7.1.3

### DIFF
--- a/data/files.metainfo.xml.in.in
+++ b/data/files.metainfo.xml.in.in
@@ -66,8 +66,6 @@
       <description>
         <p>Minor updates:</p>
         <ul>
-          <li>Improve safe ejection of drives</li>
-          <li>Fix regression in drag and drop</li>
           <li>Updated translations</li>
         </ul>
       </description>


### PR DESCRIPTION
Take out translatable strings to speed release.