### PR TITLE
PropertiesWindow: Use "iso" format for datetimes

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -593,9 +593,8 @@ namespace Files.FileUtils {
         return new_location;
     }
 
-    public string get_formatted_time_attribute_from_info (GLib.FileInfo info, string attr) {
+    public string get_formatted_time_attribute_from_info (GLib.FileInfo info, string attr, string? dateformatmode = null) {
         DateTime? dt = null;
-
         switch (attr) {
             case FileAttribute.TIME_MODIFIED:
             case FileAttribute.TIME_CREATED:
@@ -623,15 +622,22 @@ namespace Files.FileUtils {
                 break;
         }
 
-        return get_formatted_date_time (dt);
+        return get_formatted_date_time (dt, dateformatmode);
     }
 
-    public string get_formatted_date_time (DateTime? dt) {
+    public string get_formatted_date_time (DateTime? dt, string? dateformatmode = null ) {
         if (dt == null) {
             return "";
         }
 
-        switch (Files.Preferences.get_default ().date_format.down ()) {
+        string format;
+        if (dateformatmode == null) {
+            format = Files.Preferences.get_default ().date_format.down ();
+        } else {
+            format = dateformatmode;
+        }
+
+         switch (format) {
             case "locale":
                 return dt.format ("%c");
             case "iso" :

--- a/src/Dialogs/PropertiesWindow.vala
+++ b/src/Dialogs/PropertiesWindow.vala
@@ -557,9 +557,13 @@ public class Files.View.PropertiesWindow : AbstractPropertiesDialog {
         int n = 4;
 
         if (only_one) {
+            // Use the most detailed format for showing date-times
             /* Note most Linux filesystem do not store file creation time */
-            var time_created = FileUtils.get_formatted_time_attribute_from_info (file.info,
-                                                                                 FileAttribute.TIME_CREATED);
+            var time_created = FileUtils.get_formatted_time_attribute_from_info (
+                file.info,
+                FileAttribute.TIME_CREATED,
+                "iso"
+            );
             if (time_created != "") {
                 var key_label = make_key_label (_("Created:"));
                 var value_label = make_value_label (time_created);
@@ -568,8 +572,11 @@ public class Files.View.PropertiesWindow : AbstractPropertiesDialog {
                 n++;
             }
 
-            var time_modified = FileUtils.get_formatted_time_attribute_from_info (file.info,
-                                                                                  FileAttribute.TIME_MODIFIED);
+            var time_modified = FileUtils.get_formatted_time_attribute_from_info (
+                file.info,
+                FileAttribute.TIME_MODIFIED,
+                "iso"
+            );
 
             if (time_modified != "") {
                 var key_label = make_key_label (_("Modified:"));


### PR DESCRIPTION
Fixes #2608 

 - [x] Modify the relevant FileUtils formatting function to allow overriding the default settings
 - [x] Request "iso" formatting for datetimes shown in PropertiesWindow 

