### PR TITLE
Set no_show_all on empty_label to avoid unintended display

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -310,7 +310,7 @@ namespace Files {
                 wrap = true
             };
             empty_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
-            empty_label.show_all ();
+            empty_label.no_show_all = true;
 
             overlay = new Gtk.Overlay () {
                 hexpand = true,


### PR DESCRIPTION
Following #2567, the empty label appears unexpectedly in the ColumnView.  This is a quick fix for Gtk3, it should be unnecessary in Gtk4