### PR TITLE
Do not unquote dropped and pasted uris from uri_list

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -23,13 +23,8 @@ namespace Files.FileUtils {
         var result = new GLib.List<GLib.File> ();
         var uri_list = GLib.Uri.list_extract_uris (escaped_uris);
         foreach (unowned string uri in uri_list) {
-            try {
-                var unquoted_uri = Shell.unquote (uri); // Extracted uri may be quoted
-                // We require that this function be called with escaped uris
-                result.append (GLib.File.new_for_uri (unquoted_uri));
-            } catch (Error e) {
-                warning ("Error when unquoting %s. %s", uri, e.message);
-            }
+            // We can assume that uris received do not need to be unquoted
+            result.append (GLib.File.new_for_uri (uri));
         }
 
         return result;


### PR DESCRIPTION
Fixes #2637

Simplest fix for the linked issue.  

Files not longer quotes uris for dropping into apps like Terminal - the destination must do any quoting themselves. We can assume other apps behave similarly and we do not need to unquote received uris. 

Note that since a single quote is one of the characters in `GLib.RESERVED_CHARS_SUBCOMPONENT_DELIMITERS` it does not get escaped in uris when files are being drag/dropped - but that is not changed by this PR.

Reviewers should confirm that under no circumstances do we need to unquote.