### PR TITLE
Revert "Separate afc fix; use for abstractmountable"

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -413,13 +413,8 @@ namespace Files.FileUtils {
             new_path = new_path.slice (Files.ROOT_FS_URI.length, new_path.length);
         }
 
-        return new_path;
-    }
-
-    // Removes the unwanted `:3` from some Apple device addresses without full sanitizing
-    public string fix_afc_uri (string uri) {
-        if (Uri.parse_scheme (uri).has_prefix ("afc")) {
-            var colon_parts = uri.split (":", 3);
+        if (scheme.has_prefix ("afc")) {
+            var colon_parts = new_path.split (":", 3);
             if (colon_parts.length > 2) {
                 /* It may be enough to only process device addresses but we deal with all afc uris in case.
                  * We have to assume the true device name does not contain any colons */
@@ -427,17 +422,15 @@ namespace Files.FileUtils {
                 var device_name_end = separator_parts[0];
                 if (uint64.try_parse (device_name_end)) {
                     /* Device ends in e.g. `:3`. Need to strip this suffix to successfully browse */
-                    var fixed_uri = string.join (":", colon_parts[0], colon_parts[1]);
+                    new_path = string.join (":", colon_parts[0], colon_parts[1]);
                     if (separator_parts.length > 1) {
-                        fixed_uri = string.join (Path.DIR_SEPARATOR_S, fixed_uri, separator_parts[1]);
+                        new_path = string.join (Path.DIR_SEPARATOR_S, new_path, separator_parts[1]);
                     }
-
-                    return fixed_uri;
                 }
             }
         }
 
-        return uri;
+        return new_path;
     }
 
     /** Splits the path into a protocol ending in '://"  and a path beginning "/". **/

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -93,7 +93,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
                          string? _uuid) {
         Object (
             custom_name: name,
-            uri: Files.FileUtils.fix_afc_uri (uri),
+            uri: uri,
             gicon: gicon,
             list: list,
             pinned: pinned,


### PR DESCRIPTION
This reverts commit 265c691793a6ba2dbd5118f0856b6d1f088d8116.

This commit was part of an unfinished PR which somehow got incorporated into main.

The relevant PR is in progress at #2654 
