### PR TITLE
Fix pathbar flicker

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -536,7 +536,6 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         loading_uri (current_container.uri);
         current_container.set_active_state (true, false); /* changing tab should not cause animated scrolling */
         sidebar.sync_uri (current_container.uri);
-        location_bar.sensitive = !current_container.is_frozen;
         save_active_tab_position ();
     }
 


### PR DESCRIPTION
Fixes #1062 

There does not seem to be any essential reason to change the sensitivity of the pathbar while navigating especially since it only occurs with some method of navigation. It causes a visible flicker.

The ability to make the pathbar insensitive is retained in case it is needed for something else.
