### PR TITLE
Pad the formatted datetime

### DIFF
--- a/libcore/FileUtils.vala
+++ b/libcore/FileUtils.vala
@@ -700,7 +700,7 @@ namespace Files.FileUtils {
                 break;
         }
 
-        return string.join (" ", dt.format (format_string), " ");
+        return dt.format (format_string);
     }
 
     private bool can_browse_scheme (string scheme) {


### PR DESCRIPTION
Fixes #1538 

BEFORE
<img width="695" height="560" alt="Screenshot from 2025-11-03 11 02 47" src="https://github.com/user-attachments/assets/2b7c15cd-b650-4c90-8ec5-b3d46eb3b0e4" />

AFTER (ISO format)
<img width="791" height="532" alt="Screenshot from 2025-11-07 12 36 04" src="https://github.com/user-attachments/assets/1369cc46-6b5e-4fc5-816d-170c9e80ce23" />
.
