### PR TITLE
Allow drop file list onto tab

### DIFF
--- a/libcore/AbstractSlot.vala
+++ b/libcore/AbstractSlot.vala
@@ -111,4 +111,5 @@ public abstract class Files.AbstractSlot : GLib.Object {
     public virtual string? get_root_uri () { return directory.file.uri; }
     public virtual string? get_tip_uri () { return null; }
     public virtual bool get_realized () { return content_box.get_realized (); }
+    public virtual void handle_drop_on_tab (Gdk.DragContext ctx, Gtk.SelectionData data, uint info, uint time) {}
 }

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1628,6 +1628,18 @@ namespace Files {
             return true;
         }
 
+        public void handle_drop_on_tab (
+            Gdk.DragContext ctx,
+            Gtk.SelectionData data,
+            uint info,
+            uint time
+        ) {
+            drop_occurred = true;
+            drop_target_file = slot.file;
+            current_actions = Gdk.DragAction.COPY;
+            current_suggested_action = Gdk.DragAction.COPY;
+            on_drag_data_received (ctx, 0, 0, data, info, time);
+        }
 
         /* Signal emitted on destination when selection data received from source
          * either during drag motion or on dropping */

--- a/src/View/Slot.vala
+++ b/src/View/Slot.vala
@@ -423,5 +423,14 @@ namespace Files.View {
 
             return msg;
         }
+
+        public override void handle_drop_on_tab (
+            Gdk.DragContext ctx,
+            Gtk.SelectionData data,
+            uint info,
+            uint time) {
+
+            dir_view.handle_drop_on_tab (ctx, data, info, time);
+        }
     }
 }

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -256,6 +256,11 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             view = tab_view
         };
 
+        Gtk.TargetEntry uris = {"text/uri-list", 0, Files.TargetType.TEXT_URI_LIST};
+        // Handle Drag-and-drop of directory files onto tab to open in that tab
+        tab_bar.extra_drag_dest_targets = new Gtk.TargetList ({uris});
+        tab_bar.extra_drag_data_received.connect (on_extra_drag_data_received);
+
         var tab_box = new Gtk.Box (VERTICAL, 0);
         tab_box.add (tab_bar);
         tab_box.add (tab_view);
@@ -410,6 +415,22 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         });
 
         sidebar.path_change_request.connect (uri_path_change_request);
+    }
+
+    private void on_extra_drag_data_received (
+        Hdy.TabBar tab_bar,
+        Hdy.TabPage page,
+        Gdk.DragContext ctx,
+        Gtk.SelectionData data,
+        uint info,
+        uint time) {
+
+        var child = page.get_child ();
+        if (child is ViewContainer) {
+            ((ViewContainer)child).slot.handle_drop_on_tab (ctx, data, info, time);
+        }
+
+        Gtk.drag_finish (ctx, true, false, time);
     }
 
     private bool tab_view_close_page (Hdy.TabPage page) {


### PR DESCRIPTION
Fixes #1623 

Terminal allows dropping files onto tabs to navigate.  Here we use it to copy/move files.

TODO

  - [ ] Use correct suggested action depending on source/destination
 -  [ ] Implement other Files.TargetType

