### PR TITLE
LibCore: compile gresource

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -75,7 +75,6 @@ i18n.merge_file(
     type: 'xml'
 )
 
-
 install_data(
     join_paths(meson.current_source_dir(),'schemas', meson.project_name() + '.gschema.xml'),
     install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')

--- a/libcore/meson.build
+++ b/libcore/meson.build
@@ -1,5 +1,11 @@
 pantheon_files_core_name = 'pantheon-files-core'
 
+resources = gnome.compile_resources(
+    'files-resources',
+    meson.project_source_root() / 'data' / 'files.gresource.xml',
+    source_dir: meson.project_source_root() / 'data'
+)
+
 pantheon_files_core_deps = [
     common_deps,
     posix_dep,
@@ -79,6 +85,7 @@ pantheon_file_core_c_dep = vala.find_library('pantheon-files-core-C', dirs: join
 pantheon_files_core_library = shared_library(
     pantheon_files_core_name,
     pantheon_files_core_files,
+    resources,
     dependencies : [ pantheon_files_core_deps, pantheon_file_core_c_dep ],
     install: true,
     install_dir: [true, join_paths(get_option('prefix'), get_option('includedir'), pantheon_files_core_name), true],

--- a/meson.build
+++ b/meson.build
@@ -103,11 +103,6 @@ project_config_dep = declare_dependency(
 )
 
 gnome = import('gnome')
-resources = gnome.compile_resources(
-    'files-resources', 'data/files.gresource.xml',
-    source_dir: 'data',
-    c_name: 'files'
-)
 
 subdir('libcore')
 subdir('src')

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,7 +10,6 @@ pantheon_files_deps = [
 
 pantheon_files_exec = executable (
     meson.project_name (),
-    resources,
 
     'Application.vala',
     'ClipboardManager.vala',


### PR DESCRIPTION
builds resources into the library instead of just the files app. Should make resources available to the file chooser portal