### PR TITLE
SidebarWindow: Use class static settings object

### DIFF
--- a/src/View/Sidebar/SidebarWindow.vala
+++ b/src/View/Sidebar/SidebarWindow.vala
@@ -119,9 +119,15 @@ public class Sidebar.SidebarWindow : Gtk.Box, Files.SidebarInterface {
             "sidebar-cat-network-expander", network_expander, "active", DEFAULT
         );
 
-        bookmark_expander.bind_property ("active", bookmark_revealer, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
-        device_expander.bind_property ("active", device_revealer, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
-        network_expander.bind_property ("active", network_revealer, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
+        bookmark_expander.bind_property (
+            "active", bookmark_revealer, "reveal-child", SYNC_CREATE
+        );
+        device_expander.bind_property (
+            "active", device_revealer, "reveal-child", SYNC_CREATE
+        );
+        network_expander.bind_property (
+            "active", network_revealer, "reveal-child", SYNC_CREATE
+        );
     }
 
     private void refresh (bool bookmarks = true, bool devices = true, bool network = true) {


### PR DESCRIPTION
Continuing towards losing Application static settings objects and replacing with either class static objects or creating temporarily on demand.

Used a different name in order to easily distinguish from previous global object.