### PR TITLE
Regression: Fix drop onto breadcrumbs

### DIFF
--- a/src/View/Widgets/BreadcrumbsEntry.vala
+++ b/src/View/Widgets/BreadcrumbsEntry.vala
@@ -234,6 +234,7 @@ namespace Files.View.Chrome {
                 Gdk.Atom target = Gtk.drag_dest_find_target (this, context, list);
                 if (target != Gdk.Atom.NONE) {
                     Gtk.drag_get_data (this, context, target, time); /* emits "drag_data_received" */
+                    return false;
                 }
             }
 


### PR DESCRIPTION
At some point dropping file items onto a breadcrumb stopped working.

This fixes that.

Note that under Wayland the drag status emblem does not work properly - this appears to be an upstream issue.