### PR TITLE
Systemd optional

### DIFF
--- a/filechooser-portal/meson.build
+++ b/filechooser-portal/meson.build
@@ -22,13 +22,12 @@ conf_data = configuration_data()
 conf_data.set('libexecdir', libexec_dir)
 
 systemd_systemduserunitdir = get_option('systemduserunitdir')
-if systemd_systemduserunitdir != 'no'
+systemd_dep = dependency('systemd', version: '>= 206', required: false)
 
-  if systemd_systemduserunitdir == ''
-    systemd_dep = dependency('systemd', version: '>= 206', required: false)
-    assert(systemd_dep.found(), 'systemd required but not found, please provide a valid systemd user unit dir or disable it')
-    systemd_systemduserunitdir = systemd_dep.get_variable('systemduserunitdir', pkgconfig_define: ['prefix', get_option('prefix')])
-  endif
+if (systemd_dep.found () and systemd_systemduserunitdir != 'no')
+    if systemd_systemduserunitdir == ''
+        systemd_systemduserunitdir = systemd_dep.get_variable('systemduserunitdir', pkgconfig_define: ['prefix', get_option('prefix')])
+    endif
 
   configure_file(
       input: 'io.elementary.files.xdg-desktop-portal.service.in',


### PR DESCRIPTION
Systemd dependency is not required so build should not fail if it is absent.

In` main` the systemd dependency is marked as optional but is followed by an assert that it must be found which seems contradictory.

With this PR absence of the systemd dependency has the same effect as building with the option `'systemduserunitdir'` set to `'no'` .

For some reason the `development-target` CI was failing to find the `systemd` dependency.  Is this expected?  With this PR the development target CI passes.