### PR TITLE
Fix regression: Crash if too many templates

### DIFF
--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -2378,7 +2378,7 @@ namespace Files {
                     if (total_item_count > 0) {
                         menu_model.append_submenu (_("Template"), template_submenu);
                         if (total_item_count > MAX_TEMPLATES) {
-                            template_submenu.append (_("…too many templates"), "");
+                            template_submenu.append (_("…too many templates"), null); // Does not accept empty string for action name.
                         }
                     }
                 }


### PR DESCRIPTION
After commit 1d6672a08d606a32b5c55c602cdec0dbabc575a2 Files crashes if there are too many templates. The fix is simple and implemented here.

Marked as critical but should not affect most users who have a templates folder with less than 2048 templates.
