### PR TITLE
Workflows: update release to noble

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
          GIT_USER_NAME: "elementaryBot"
          GIT_USER_EMAIL: "builds@elementary.io"
        with:
-         release_branch: 'horus'
+         release_branch: 'noble'


### PR DESCRIPTION
It looks like daily only builds for Noble and Resolute now? I'm not sure when this changed. The version number is 7.x which seems to indicate we didn't break API yet, but maybe that just didn't get bumped?