### PR TITLE
DndHandler & AbstractDirectoryView cleanup

### DIFF
--- a/libcore/DndHandler.vala
+++ b/libcore/DndHandler.vala
@@ -25,11 +25,12 @@ namespace Files {
 
         public DndHandler () {}
 
-        public bool dnd_perform (Gtk.Widget widget,
-                                 Files.File drop_target,
-                                 GLib.List<GLib.File> drop_file_list,
-                                 Gdk.DragAction action)
-        requires (drop_target != null && drop_file_list != null) {
+        public bool dnd_perform (
+            Gtk.Widget widget,
+            Files.File drop_target,
+            GLib.List<GLib.File> drop_file_list,
+            Gdk.DragAction action
+        ) requires (drop_target != null && drop_file_list != null) {
 
             if (drop_target.is_folder ()) {
                 Files.FileOperations.copy_move_link.begin (
@@ -57,9 +58,11 @@ namespace Files {
             return false;
         }
 
-        public Gdk.DragAction? drag_drop_action_ask (Gtk.Widget dest_widget,
-                                                     Gtk.ApplicationWindow win,
-                                                     Gdk.DragAction possible_actions) {
+        public Gdk.DragAction? drag_drop_action_ask (
+            Gtk.Widget dest_widget,
+            Gtk.ApplicationWindow win,
+            Gdk.DragAction possible_actions
+        ) {
 
             this.chosen = Gdk.DragAction.DEFAULT;
             add_action (win);
@@ -107,8 +110,12 @@ namespace Files {
             return menu;
         }
 
-        private void build_and_append_menu_item (Gtk.Menu menu, string label, Gdk.DragAction? action,
-                                                 Gdk.DragAction possible_actions) {
+        private void build_and_append_menu_item (
+            Gtk.Menu menu,
+            string label,
+            Gdk.DragAction? action,
+            Gdk.DragAction possible_actions
+        ) {
 
             if ((possible_actions & action) != 0) {
                 var item = new Gtk.MenuItem.with_label (label);
@@ -189,9 +196,12 @@ namespace Files {
                                  uri.length);
         }
 
-        public bool handle_xdnddirectsave (Gdk.Window source_window,
-                                           Files.File drop_target,
-                                           Gtk.SelectionData selection) {
+        public bool handle_xdnddirectsave (
+            Gdk.Window source_window,
+            Files.File drop_target,
+            Gtk.SelectionData selection
+        ) {
+
             bool success = false;
 
             if (selection != null &&
@@ -225,7 +235,12 @@ namespace Files {
             return success;
         }
 
-        public bool handle_netscape_url (Gdk.Window source_window, Files.File drop_target, Gtk.SelectionData selection) {
+        public bool handle_netscape_url (
+            Gdk.Window source_window,
+            Files.File drop_target,
+            Gtk.SelectionData selection
+        ) {
+
             string [] parts = (selection.get_text ()).split ("\n");
 
             /* _NETSCAPE_URL looks like this: "$URL\n$TITLE" - should be 2 parts */
@@ -237,13 +252,15 @@ namespace Files {
             return false;
         }
 
-        public bool handle_file_drag_actions (Gtk.Widget dest_widget,
-                                              Files.File drop_target,
-                                              GLib.List<GLib.File> drop_file_list,
-                                              Gdk.DragAction possible_actions,
-                                              Gdk.DragAction suggested_action,
-                                              Gtk.ApplicationWindow win,
-                                              uint32 timestamp) {
+        public bool handle_file_drag_actions (
+            Gtk.Widget dest_widget,
+            Files.File drop_target,
+            GLib.List<GLib.File> drop_file_list,
+            Gdk.DragAction possible_actions,
+            Gdk.DragAction suggested_action,
+            Gtk.ApplicationWindow win,
+            uint32 timestamp
+        ) {
 
             bool success = false;
             Gdk.DragAction action = suggested_action;
@@ -268,7 +285,12 @@ namespace Files {
         }
 
 
-        public static bool selection_data_is_uri_list (Gtk.SelectionData selection_data, uint info, out string? text) {
+        public static bool selection_data_is_uri_list (
+            Gtk.SelectionData selection_data,
+            uint info,
+            out string? text
+        ) {
+
             text = null;
 
             if (info == Files.TargetType.TEXT_URI_LIST &&
@@ -295,9 +317,11 @@ namespace Files {
         }
 
         // Used when TargetType is TEXT_URI_LIST
-        public static void set_selection_data_as_file_list (Gtk.SelectionData selection_data,
-                                                            GLib.List<Files.File> file_list,
-                                                            string prefix = "") {
+        public static void set_selection_data_as_file_list (
+            Gtk.SelectionData selection_data,
+            GLib.List<Files.File> file_list,
+            string prefix = ""
+        ) {
 
             GLib.StringBuilder sb = new GLib.StringBuilder (prefix);
             set_stringbuilder_from_file_list (
@@ -312,9 +336,11 @@ namespace Files {
         }
 
         // Used when TargetType is STRING
-        public static void set_selection_data_as_text (Gtk.SelectionData selection_data,
-                                                       GLib.List<Files.File> file_list,
-                                                       string prefix = "") {
+        public static void set_selection_data_as_text (
+            Gtk.SelectionData selection_data,
+            GLib.List<Files.File> file_list,
+            string prefix = ""
+        ) {
 
             GLib.StringBuilder sb = new GLib.StringBuilder (prefix);
             set_stringbuilder_from_file_list (
@@ -326,9 +352,11 @@ namespace Files {
             selection_data.set_text (sb.str, (int)(sb.len));
         }
 
-        private static void set_stringbuilder_from_file_list (GLib.StringBuilder sb,
-                                                              GLib.List<Files.File> file_list,
-                                                              TargetType type) {
+        private static void set_stringbuilder_from_file_list (
+            GLib.StringBuilder sb,
+            GLib.List<Files.File> file_list,
+            TargetType type
+        ) {
 
             if (file_list != null && file_list.data != null && file_list.data is Files.File) {
                 bool in_recent = file_list.data.is_recent_uri_scheme ();
@@ -349,11 +377,13 @@ namespace Files {
             }
         }
 
-        public static Gdk.DragAction file_accepts_drop (Files.File dest,
-                                                 GLib.List<GLib.File> drop_file_list, // read-only
-                                                 Gdk.DragAction selected_action,
-                                                 Gdk.DragAction possible_actions,
-                                                 out Gdk.DragAction suggested_action_return) {
+        public static Gdk.DragAction file_accepts_drop (
+            Files.File dest,
+            GLib.List<GLib.File> drop_file_list, // read-only
+            Gdk.DragAction selected_action, // may be null - ignore
+            Gdk.DragAction possible_actions,
+            out Gdk.DragAction suggested_action_return
+        ) {
 
             var actions = possible_actions;
             var suggested_action = selected_action;
@@ -404,9 +434,11 @@ namespace Files {
         }
 
         private const uint MAX_FILES_CHECKED = 100; // Max checked copied from gof_file.c version
-        private static Gdk.DragAction valid_actions_for_file_list (GLib.File target_location,
-                                                            GLib.List<GLib.File> drop_file_list,
-                                                            ref Gdk.DragAction suggested_action) {
+        private static Gdk.DragAction valid_actions_for_file_list (
+            GLib.File target_location,
+            GLib.List<GLib.File> drop_file_list,
+            ref Gdk.DragAction suggested_action
+        ) {
 
             var valid_actions = Gdk.DragAction.DEFAULT |
                                 Gdk.DragAction.COPY |

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1826,7 +1826,6 @@ namespace Files {
                         current_suggested_action = Gdk.DragAction.COPY;
                         current_actions = current_suggested_action;
                     } else {
-
                         current_actions = DndHandler.file_accepts_drop (
                             drop_target_file,
                             destination_drop_file_list,

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -1829,7 +1829,7 @@ namespace Files {
                         current_actions = DndHandler.file_accepts_drop (
                             drop_target_file,
                             destination_drop_file_list,
-                            context.get_selected_action (),
+                            context.get_selected_action (), // may return null
                             context.get_actions (),
                             out current_suggested_action
                         );

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -47,7 +47,7 @@ namespace Files {
             {"text/uri-list", Gtk.TargetFlags.OTHER_APP, Files.TargetType.TEXT_URI_LIST}
         };
 
-       private const Gtk.TargetEntry [] DROP_TARGETS = {
+        private const Gtk.TargetEntry [] DROP_TARGETS = {
             {"text/uri-list", Gtk.TargetFlags.SAME_APP, Files.TargetType.TEXT_URI_LIST},
             {"text/uri-list", Gtk.TargetFlags.OTHER_APP, Files.TargetType.TEXT_URI_LIST},
             {"XdndDirectSave0", Gtk.TargetFlags.OTHER_APP, Files.TargetType.XDND_DIRECT_SAVE0},
@@ -57,7 +57,7 @@ namespace Files {
        private const Gdk.DragAction FILE_DRAG_ACTIONS = (Gdk.DragAction.COPY | Gdk.DragAction.MOVE | Gdk.DragAction.LINK);
 
         /* Menu Handling */
-       private const GLib.ActionEntry [] SELECTION_ENTRIES = {
+        private const GLib.ActionEntry [] SELECTION_ENTRIES = {
             {"open", on_selection_action_open_executable},
             {"open-with-app", on_selection_action_open_with_app, "u"},
             {"open-with-default", on_selection_action_open_with_default},
@@ -72,14 +72,14 @@ namespace Files {
             {"invert-selection", invert_selection}
         };
 
-       private const GLib.ActionEntry [] BACKGROUND_ENTRIES = {
+        private const GLib.ActionEntry [] BACKGROUND_ENTRIES = {
             {"new", on_background_action_new, "s"},
             {"create-from", on_background_action_create_from, "s"},
             {"sort-by", on_background_action_sort_by_changed, "s", "'name'"},
             {"reverse", on_background_action_reverse_changed, null, "false"}
         };
 
-       private const GLib.ActionEntry [] COMMON_ENTRIES = {
+        private const GLib.ActionEntry [] COMMON_ENTRIES = {
             {"copy", on_common_action_copy},
             {"paste-into", on_common_action_paste_into}, // Paste into selected folder
             {"paste", on_common_action_paste}, // Paste into background folder

--- a/src/View/AbstractDirectoryView.vala
+++ b/src/View/AbstractDirectoryView.vala
@@ -38,26 +38,26 @@ namespace Files {
             INVALID
         }
 
-        const int MAX_TEMPLATES = 2048;
+        private const int MAX_TEMPLATES = 2048;
 
-        const Gtk.TargetEntry [] DRAG_TARGETS = {
+        private const Gtk.TargetEntry [] DRAG_TARGETS = {
             {"text/plain", Gtk.TargetFlags.SAME_APP, Files.TargetType.STRING},
             {"text/plain", Gtk.TargetFlags.OTHER_APP, Files.TargetType.STRING},
             {"text/uri-list", Gtk.TargetFlags.SAME_APP, Files.TargetType.TEXT_URI_LIST},
             {"text/uri-list", Gtk.TargetFlags.OTHER_APP, Files.TargetType.TEXT_URI_LIST}
         };
 
-        const Gtk.TargetEntry [] DROP_TARGETS = {
+       private const Gtk.TargetEntry [] DROP_TARGETS = {
             {"text/uri-list", Gtk.TargetFlags.SAME_APP, Files.TargetType.TEXT_URI_LIST},
             {"text/uri-list", Gtk.TargetFlags.OTHER_APP, Files.TargetType.TEXT_URI_LIST},
             {"XdndDirectSave0", Gtk.TargetFlags.OTHER_APP, Files.TargetType.XDND_DIRECT_SAVE0},
             {"_NETSCAPE_URL", Gtk.TargetFlags.OTHER_APP, Files.TargetType.NETSCAPE_URL}
         };
 
-        const Gdk.DragAction FILE_DRAG_ACTIONS = (Gdk.DragAction.COPY | Gdk.DragAction.MOVE | Gdk.DragAction.LINK);
+       private const Gdk.DragAction FILE_DRAG_ACTIONS = (Gdk.DragAction.COPY | Gdk.DragAction.MOVE | Gdk.DragAction.LINK);
 
         /* Menu Handling */
-        const GLib.ActionEntry [] SELECTION_ENTRIES = {
+       private const GLib.ActionEntry [] SELECTION_ENTRIES = {
             {"open", on_selection_action_open_executable},
             {"open-with-app", on_selection_action_open_with_app, "u"},
             {"open-with-default", on_selection_action_open_with_default},
@@ -72,14 +72,14 @@ namespace Files {
             {"invert-selection", invert_selection}
         };
 
-        const GLib.ActionEntry [] BACKGROUND_ENTRIES = {
+       private const GLib.ActionEntry [] BACKGROUND_ENTRIES = {
             {"new", on_background_action_new, "s"},
             {"create-from", on_background_action_create_from, "s"},
             {"sort-by", on_background_action_sort_by_changed, "s", "'name'"},
             {"reverse", on_background_action_reverse_changed, null, "false"}
         };
 
-        const GLib.ActionEntry [] COMMON_ENTRIES = {
+       private const GLib.ActionEntry [] COMMON_ENTRIES = {
             {"copy", on_common_action_copy},
             {"paste-into", on_common_action_paste_into}, // Paste into selected folder
             {"paste", on_common_action_paste}, // Paste into background folder
@@ -91,9 +91,9 @@ namespace Files {
             {"set-wallpaper", action_set_wallpaper}
         };
 
-        GLib.SimpleActionGroup common_actions;
-        GLib.SimpleActionGroup selection_actions;
-        GLib.SimpleActionGroup background_actions;
+        private GLib.SimpleActionGroup common_actions;
+        private GLib.SimpleActionGroup selection_actions;
+        private GLib.SimpleActionGroup background_actions;
 
         private ZoomLevel _zoom_level = ZoomLevel.NORMAL;
         public ZoomLevel zoom_level {
@@ -124,22 +124,22 @@ namespace Files {
         protected ZoomLevel maximum_zoom = ZoomLevel.LARGEST;
 
         /* Used only when acting as drag source */
-        double drag_x = 0;
-        double drag_y = 0;
+        private double drag_x = 0;
+        private double drag_y = 0;
         protected GLib.List<Files.File> source_drag_file_list = null;
         protected Gdk.Atom current_target_type = Gdk.Atom.NONE;
 
         /* Used only when acting as drag destination */
-        uint drag_scroll_timer_id = 0;
-        uint drag_enter_timer_id = 0;
+        private uint drag_scroll_timer_id = 0;
+        private uint drag_enter_timer_id = 0;
         private bool destination_data_ready = false; /* whether the drop data was received already */
         private bool drop_occurred = false; /* whether the data was dropped */
-        Files.File? drop_target_file = null;
+        private Files.File? drop_target_file = null;
         private GLib.List<GLib.File> destination_drop_file_list = null; /* the list of URIs that are contained in the drop data */
-        Gdk.DragAction current_suggested_action = Gdk.DragAction.DEFAULT;
-        Gdk.DragAction current_actions = Gdk.DragAction.DEFAULT;
-        bool _drop_highlight;
-        bool drop_highlight {
+        private Gdk.DragAction current_suggested_action = Gdk.DragAction.DEFAULT;
+        private Gdk.DragAction current_actions = Gdk.DragAction.DEFAULT;
+        private bool _drop_highlight;
+        private bool drop_highlight {
             get {
                 return _drop_highlight;
             }
@@ -164,14 +164,14 @@ namespace Files {
         private void* drag_data;
 
         /* support for generating thumbnails */
-        int thumbnail_request = -1;
-        uint thumbnail_source_id = 0;
-        uint freeze_source_id = 0;
-        Thumbnailer thumbnailer = null;
+        private int thumbnail_request = -1;
+        private uint thumbnail_source_id = 0;
+        private uint freeze_source_id = 0;
+        private Thumbnailer thumbnailer = null;
 
         /* Free space signal support */
-        uint add_remove_file_timeout_id = 0;
-        bool signal_free_space_change = false;
+        private uint add_remove_file_timeout_id = 0;
+        private bool signal_free_space_change = false;
 
         /* Rename support */
         protected Files.TextRenderer? name_renderer = null;


### PR DESCRIPTION
Extracted from #2771 

 - Make all member and property scopes explicit in AbstractDirectory View
 - Make format of method parameter indentation consistent in DnDHandler

No functional changes.

