### PR TITLE
Close window when closing the only remaining tab 

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -407,7 +407,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         tab_view.close_page_finish (page, true);
 
         if (tab_view.n_pages == 0) {
-            add_tab.begin (default_location, PREFERRED, false);
+            quit ();
         }
 
         return Gdk.EVENT_STOP;


### PR DESCRIPTION
This closes the Files window when the only tab in that window is closed:

https://github.com/user-attachments/assets/7fbab8c1-c65e-4e2c-9b72-8093bdee33e8

This makes the behavior consistent with other default apps like Terminal and Web, which also close their window when the last tab closes.

This also makes it possible to close a Files window using just the keyboard. Previously, one could only close tabs using `ctrl + W`, or close all windows using `ctrl + Q`, but not close just one window.