### PR TITLE
Change the shortcut for Focus Sidebar to not interfere with text editing

### DIFF
--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -68,7 +68,8 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         {"tabhistory-restore", action_tabhistory_restore, "s" },
         {"forward", action_forward, "i"},
         {"back", action_back, "i"},
-        {"focus-sidebar", action_focus_sidebar}
+        {"focus-sidebar", action_focus_sidebar},
+        {"focus-current-container", action_focus_current_container}
     };
 
     private static uint window_id = 0;
@@ -162,6 +163,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             marlin_app.set_accels_for_action ("win.tab::TAB", {"<Shift><Ctrl>K"});
             marlin_app.set_accels_for_action ("win.tab::WINDOW", {"<Ctrl><Alt>N"});
             marlin_app.set_accels_for_action ("win.focus-sidebar", {"<Ctrl><Alt>Left"});
+            marlin_app.set_accels_for_action ("win.focus-current-container", {"<Ctrl><Alt>Right"});
         }
 
         build_window ();
@@ -1004,6 +1006,10 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
     private void action_focus_sidebar () {
         sidebar.focus ();
+    }
+
+    private void action_focus_current_container () {
+        grab_focus ();
     }
 
     private void before_undo_redo () {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -161,7 +161,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             marlin_app.set_accels_for_action ("win.back(1)", {"<Alt>Left", "XF86Back"});
             marlin_app.set_accels_for_action ("win.tab::TAB", {"<Shift><Ctrl>K"});
             marlin_app.set_accels_for_action ("win.tab::WINDOW", {"<Ctrl><Alt>N"});
-            marlin_app.set_accels_for_action ("win.focus-sidebar", {"<Ctrl>Left"});
+            marlin_app.set_accels_for_action ("win.focus-sidebar", {"<Ctrl><Alt>Left"});
         }
 
         build_window ();


### PR DESCRIPTION
The existing `<Ctrl> + Left` would interfere when editing a filename.

Closes #2677.