### PR TITLE
Correct RTL accelerator arrow keys

### DIFF
--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -243,11 +243,21 @@ public class Files.IconView : Files.AbstractDirectoryView {
 
     /* Override native Gtk.IconView cursor handling */
     protected override bool move_cursor (uint keyval, bool only_shift_pressed, bool control_pressed) {
+        uint prev_key;
+        uint next_key;
+        if (Gtk.StateFlags.DIR_RTL in get_style_context ().get_state ()) {
+            prev_key = Gdk.Key.Right;
+            next_key = Gdk.Key.Left;
+        } else {
+            prev_key = Gdk.Key.Left;
+            next_key = Gdk.Key.Right;
+        }
+
         Gtk.TreePath? path = get_path_at_cursor ();
         if (path != null) {
-            if (keyval == Gdk.Key.Right) {
+            if (keyval == next_key) {
                 path.next (); /* Does not check if path is valid */
-            } else if (keyval == Gdk.Key.Left) {
+            } else if (keyval == prev_key) {
                 path.prev ();
             } else if (keyval == Gdk.Key.Up) {
                 path = up (path);

--- a/src/View/ListView.vala
+++ b/src/View/ListView.vala
@@ -160,36 +160,41 @@ namespace Files {
         }
 
         protected override bool on_view_key_press_event (uint keyval, uint keycode, Gdk.ModifierType state) {
+            uint up_key;
+            uint down_key;
+            if (Gtk.StateFlags.DIR_RTL in get_style_context ().get_state ()) {
+                up_key = Gdk.Key.Right;
+                down_key = Gdk.Key.Left;
+            } else {
+                up_key = Gdk.Key.Left;
+                down_key = Gdk.Key.Right;
+            }
+
             bool control_pressed = ((state & Gdk.ModifierType.CONTROL_MASK) != 0);
             bool shift_pressed = ((state & Gdk.ModifierType.SHIFT_MASK) != 0);
             if (!control_pressed && !shift_pressed) {
-                switch (keyval) {
-                    case Gdk.Key.Right:
-                        Gtk.TreePath? path = null;
-                        tree.get_cursor (out path, null);
+                if (keyval == down_key) {
+                    Gtk.TreePath? path = null;
+                    tree.get_cursor (out path, null);
 
-                        if (path != null) {
-                            tree.expand_row (path, false);
+                    if (path != null) {
+                        tree.expand_row (path, false);
+                    }
+
+                    return true;
+                } else if (keyval == up_key) {
+                    Gtk.TreePath? path = null;
+                    tree.get_cursor (out path, null);
+
+                    if (path != null) {
+                        if (tree.is_row_expanded (path)) {
+                            tree.collapse_row (path);
+                        } else if (path.up ()) {
+                            tree.collapse_row (path);
                         }
+                    }
 
-                        return true;
-
-                    case Gdk.Key.Left:
-                        Gtk.TreePath? path = null;
-                        tree.get_cursor (out path, null);
-
-                        if (path != null) {
-                            if (tree.is_row_expanded (path)) {
-                                tree.collapse_row (path);
-                            } else if (path.up ()) {
-                                tree.collapse_row (path);
-                            }
-                        }
-
-                        return true;
-
-                    default:
-                        break;
+                    return true;
                 }
             }
 

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -424,59 +424,61 @@ namespace Files.View {
 
             View.Slot? to_activate = null;
             var prefs = Files.Preferences.get_default ();
-            switch (keyval) {
-                case Gdk.Key.Left:
-                    if (current_position > 0) {
-                        if (prefs.show_file_preview) {
-                            clear_file_details ();
-                        }
 
-                        to_activate = slot_list.nth_data (current_position - 1);
+            uint up_key;
+            uint down_key;
+
+            // Determine which key is the "drill down" key based on the layout direction
+            if (Gtk.StateFlags.DIR_RTL in scrolled_window.get_style_context ().get_state ()) {
+                up_key = Gdk.Key.Right;
+                down_key = Gdk.Key.Left;
+            } else {
+                up_key = Gdk.Key.Left;
+                down_key = Gdk.Key.Right;
+            }
+
+            if (keyval == up_key) {
+                if (current_position > 0) {
+                    if (prefs.show_file_preview) {
+                        clear_file_details ();
                     }
 
-                    break;
+                    to_activate = slot_list.nth_data (current_position - 1);
+                }
 
-                case Gdk.Key.Right:
-                    if (current_slot.get_selected_files () == null) {
-                        return true;
-                    }
+            } else if (keyval == down_key) {
+                if (current_slot.get_selected_files () == null) {
+                    return true;
+                }
 
-                    Files.File? selected_file = current_slot.get_selected_files ().data;
-                    if (selected_file == null) {
-                        return true;
-                    }
+                Files.File? selected_file = current_slot.get_selected_files ().data;
+                if (selected_file == null) {
+                    return true;
+                }
 
-                    GLib.File current_location = selected_file.location;
-                    GLib.File? next_location = null;
-                    if (current_position < slot_list.length () - 1) { //Can be assumed to limited in length
-                        next_location = slot_list.nth_data (current_position + 1).location;
-                    }
+                GLib.File current_location = selected_file.location;
+                GLib.File? next_location = null;
+                if (current_position < slot_list.length () - 1) { //Can be assumed to limited in length
+                    next_location = slot_list.nth_data (current_position + 1).location;
+                }
 
-                    if (next_location != null && next_location.equal (current_location)) {
-                        to_activate = slot_list.nth_data (current_position + 1);
-                    } else if (selected_file.is_folder ()) {
-                        add_location (current_location, current_slot);
-                        return true;
-                    }
+                if (next_location != null && next_location.equal (current_location)) {
+                    to_activate = slot_list.nth_data (current_position + 1);
+                } else if (selected_file.is_folder ()) {
+                    add_location (current_location, current_slot);
+                    return true;
+                }
+            } else if (keyval == Gdk.Key.BackSpace) {
+                if (current_position > 0) {
+                    truncate_list_after_slot (slot_list.nth_data (current_position - 1));
+                } else {
+                    ctab.go_up ();
+                    return true;
+                }
 
-                    break;
-
-                case Gdk.Key.BackSpace:
-                        if (current_position > 0) {
-                            truncate_list_after_slot (slot_list.nth_data (current_position - 1));
-                        } else {
-                            ctab.go_up ();
-                            return true;
-                        }
-
-                        if (prefs.show_file_preview) {
-                            clear_file_details ();
-                        }
-
-                    break;
-
-                default:
-                    break;
+                if (prefs.show_file_preview) {
+                    clear_file_details ();
+                }
             }
 
             if (to_activate != null) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -158,12 +158,19 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             marlin_app.set_accels_for_action ("win.go-to::NETWORK", {"<Alt>N"});
             marlin_app.set_accels_for_action ("win.go-to::SERVER", {"<Alt>C"});
             marlin_app.set_accels_for_action ("win.go-to::UP", {"<Alt>Up"});
-            marlin_app.set_accels_for_action ("win.forward(1)", {"<Alt>Right", "XF86Forward"});
-            marlin_app.set_accels_for_action ("win.back(1)", {"<Alt>Left", "XF86Back"});
             marlin_app.set_accels_for_action ("win.tab::TAB", {"<Shift><Ctrl>K"});
             marlin_app.set_accels_for_action ("win.tab::WINDOW", {"<Ctrl><Alt>N"});
-            marlin_app.set_accels_for_action ("win.focus-sidebar", {"<Ctrl><Alt>Left"});
-            marlin_app.set_accels_for_action ("win.focus-current-container", {"<Ctrl><Alt>Right"});
+
+            // Make sure Left and Right arrow keys are mapped logically based on layout direction
+            if (Gtk.StateFlags.DIR_RTL in get_style_context ().get_state ()) {
+                marlin_app.set_accels_for_action ("win.focus-sidebar", {"<Ctrl><Alt>Right"});
+                marlin_app.set_accels_for_action ("win.focus-current-container", {"<Ctrl><Alt>Left"});
+                marlin_app.set_accels_for_action ("win.forward(1)", {"<Alt>Right", "XF86Forward"});
+            } else {
+                marlin_app.set_accels_for_action ("win.focus-sidebar", {"<Ctrl><Alt>Left"});
+                marlin_app.set_accels_for_action ("win.focus-current-container", {"<Ctrl><Alt>Right"});
+                marlin_app.set_accels_for_action ("win.back(1)", {"<Alt>Left", "XF86Back"});
+            }
         }
 
         build_window ();
@@ -190,14 +197,18 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
     private void build_window () {
         button_back = new View.Chrome.ButtonWithMenu ("go-previous-symbolic");
-
-        button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
         button_back.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         button_forward = new View.Chrome.ButtonWithMenu ("go-next-symbolic");
-
-        button_forward.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Right"}, _("Next"));
         button_forward.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
+        if (Gtk.StateFlags.DIR_RTL in get_style_context ().get_state ()) {
+            button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Right"}, _("Previous"));
+            button_forward.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Next"));
+        } else {
+            button_back.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, _("Previous"));
+            button_forward.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Right"}, _("Next"));
+        }
 
         view_switcher = new Chrome.ViewSwitcher ((SimpleAction)lookup_action ("view-mode")) {
             margin_end = 20


### PR DESCRIPTION
This corrects accelerators that include a Left or Right arrow key when using a Right-to-Left (RTL) language, where UI elements are draw from right to left.

This includes:

- switching focus between the sidebar and the main tab view (the sidebar is on the right side in an RTL situation); 
- the 'drill down' and 'drill up' keys when navigating in list or Miller views;
- the arrow keys for selecting the previous and next icon in icon view (the icons are also drawn right to left, with the 'next' icon being on the left of the 'previous' icon in an RTL situation;
- the 'back' and 'forward' actions that map to the buttons in the navigation bar (including the tooltips for these buttons)