### PR TITLE
Fix IconView blank after cut/paste between parent-child folders

### DIFF
--- a/src/View/AbstractTreeView.vala
+++ b/src/View/AbstractTreeView.vala
@@ -20,6 +20,7 @@ namespace Files {
     /* Implement common features of ColumnView and ListView */
     public abstract class AbstractTreeView : AbstractDirectoryView {
         protected Files.TreeView tree;
+        private bool child_notify_frozen = false;
         protected Gtk.TreeViewColumn name_column;
 
         protected AbstractTreeView (View.Slot _slot) {
@@ -325,15 +326,17 @@ namespace Files {
 
         // For scrolling
         protected override void freeze_child_notify () {
-            tree.freeze_child_notify ();
+            if (!child_notify_frozen) {
+                tree.freeze_child_notify ();
+                child_notify_frozen = true;
+            }
         }
 
         protected override void thaw_child_notify () {
-            // Do not prematurely thaw tree when loading
-            if (!tree_frozen) {
+            if (child_notify_frozen) {
                 tree.thaw_child_notify ();
+                child_notify_frozen = false;
             }
-
         }
     }
 

--- a/src/View/IconView.vala
+++ b/src/View/IconView.vala
@@ -18,6 +18,7 @@
 
 public class Files.IconView : Files.AbstractDirectoryView {
     protected new Gtk.IconView tree;
+    private bool child_notify_frozen = false;
     /* support for linear selection mode in icon view, overriding native behaviour of Gtk.IconView */
     protected bool previous_selection_was_linear = false;
     protected Gtk.TreePath? previous_linear_selection_path = null;
@@ -333,13 +334,16 @@ public class Files.IconView : Files.AbstractDirectoryView {
 
     // For scrolling
     protected override void freeze_child_notify () {
-        tree.freeze_child_notify ();
+        if (!child_notify_frozen) {
+            tree.freeze_child_notify ();
+            child_notify_frozen = true;
+        }
     }
 
     protected override void thaw_child_notify () {
-        //Do not prematurely thaw tree while loading
-        if (!tree_frozen) {
+        if (child_notify_frozen) {
             tree.thaw_child_notify ();
+            child_notify_frozen = false;
         }
     }
 


### PR DESCRIPTION
Fixes #2801

Added `child_notify_frozen` boolean flag in `IconView.vala` and 
`AbstractTreeView.vala` to ensure `freeze_child_notify()` and 
`thaw_child_notify()` calls are always balanced, preventing IconView 
from going permanently blank after cut/paste operations.