### PR TITLE
Show NextCloud account status in sidebar

### DIFF
--- a/libcore/View/Sidebar/SidebarPluginItem.vala
+++ b/libcore/View/Sidebar/SidebarPluginItem.vala
@@ -30,6 +30,7 @@ public class Files.SidebarPluginItem : Object {
     public bool can_eject { get; set; }
     public string? tooltip { get; set; }
     public Icon? action_icon { get; set; }
+    public string action_tooltip { get; set; }
     public bool show_spinner { get; set; default = false; }
     public uint64 free_space { get; set; default = 0; }
     public uint64 disk_size { get; set; default = 0; }

--- a/plugins/pantheon-files-cloud/plugin.vala
+++ b/plugins/pantheon-files-cloud/plugin.vala
@@ -118,7 +118,8 @@ public class Files.Plugins.Cloud.Plugin : Files.Plugins.Base {
             action_group = account.action_group,
             action_group_namespace = "cloudprovider",
             menu_model = account.menu_model,
-            action_icon = get_icon (account.get_status ())
+            action_icon = get_icon (account.get_status ()),
+            action_tooltip = account.status_details
         };
 
         return item;
@@ -132,9 +133,21 @@ public class Files.Plugins.Cloud.Plugin : Files.Plugins.Base {
      * @return a error icon if status is error else returns null
      */
     static Icon? get_icon (CloudProviders.AccountStatus status) {
-        return status == CloudProviders.AccountStatus.ERROR ?
-                         new ThemedIcon.with_default_fallbacks ("dialog-error-symbolic") :
-                         null;
+        warning ("get icon for status %s", status.to_string ());
+        switch (status) {
+            case CloudProviders.AccountStatus.ERROR:
+                return new ThemedIcon.with_default_fallbacks ("dialog-error-symbolic");
+            case CloudProviders.AccountStatus.IDLE:
+                return new ThemedIcon ("process-completed");
+            case CloudProviders.AccountStatus.INVALID:
+                return new ThemedIcon ("process-error");
+            case CloudProviders.AccountStatus.SYNCING:
+                return new ThemedIcon ("process-working");
+            default:
+                warning ("return null icon");
+                return null;
+
+        }
     }
 }
 

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -43,6 +43,8 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
 
     public Mount? mount { get; set construct; default = null; }
     public Drive? drive { get; construct; default = null; }
+    public Icon status_icon { get; set; default = null; }
+    public string status_tooltip { get; set; default = ""; }
 
     protected bool valid = true;
     public string? uuid { get; set construct; }
@@ -134,6 +136,11 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
 
         content_grid.attach (unmount_eject_working_stack, 1, 0);
 
+        var status_image = new Gtk.Image ();
+        bind_property ("status-icon", status_image, "gicon");
+        bind_property ("status-tooltip", status_image, "tooltip-text");
+        content_grid.attach (status_image, 2, 0);
+
         storage_levelbar = new Gtk.LevelBar () {
             value = 0.5,
             hexpand = true,
@@ -201,6 +208,10 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
     protected override void update_plugin_data (Files.SidebarPluginItem item) {
         base.update_plugin_data (item);
         working = item.show_spinner;
+        if (this is NetworkRow) {
+            status_icon = item.action_icon;
+            status_tooltip = item.action_tooltip;
+        }
     }
 
     protected async bool unmount_mount () {


### PR DESCRIPTION
Partially fixes #1158 

This shows the overall status of an account in the sidebar.  I don't think libcloudproviders allows for getting the status of individual files unfortunately and we rely on that.