### PR TITLE
Cleanup: Update headerbar

### DIFF
--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -41,8 +41,6 @@ namespace Files.View {
                 _window = value;
                 _window.folder_deleted.connect (on_folder_deleted);
                 _window.connect_content_signals (this);
-                _window.loading_uri (slot.location.get_uri ());
-                load_directory ();
             }
         }
 
@@ -274,7 +272,7 @@ namespace Files.View {
 
         }
 
-        private void load_directory () {
+        public void load_directory () {
             directory_is_loading (slot.location);
             slot.initialize_directory ();
         }
@@ -365,6 +363,7 @@ namespace Files.View {
 
         public void on_slot_directory_loaded (Directory dir) {
             can_show_folder = dir.can_load;
+            warning ("%s can load %s", this.uri, dir.can_load.to_string ());
             /* First deal with all cases where directory could not be loaded */
             if (!can_show_folder) {
                 if (dir.is_recent && !Files.Preferences.get_default ().remember_history) {

--- a/src/View/ViewContainer.vala
+++ b/src/View/ViewContainer.vala
@@ -233,6 +233,7 @@ namespace Files.View {
 
             if (mode == ViewMode.MILLER_COLUMNS) {
                 this.view = new Miller (loc, this);
+                ((Miller)view).active.connect (on_miller_slot_active);
             } else {
                 this.view = new Slot (loc, this, mode);
             }
@@ -241,7 +242,6 @@ namespace Files.View {
                 no_show_all = true
             };
 
-            view.active.connect (on_slot_active);
             view.path_changed.connect (on_slot_path_changed);
             view.new_container_request.connect (on_slot_new_container_request);
             view.selection_changed.connect (on_slot_selection_changed);
@@ -269,9 +269,6 @@ namespace Files.View {
             /* Make sure async loading and thumbnailing are cancelled and signal handlers disconnected */
             disconnect_slot_signals (view);
             add_view (mode, loc ?? location);
-            /* Slot is created inactive so we activate now since we must be the current tab
-             * to have received a change mode instruction */
-            set_active_state (true);
             /* Do not update top menu (or record uri) unless folder loads successfully */
             load_directory ();
 
@@ -283,14 +280,17 @@ namespace Files.View {
         }
 
         private void disconnect_slot_signals (Files.AbstractSlot aslot) {
-            aslot.active.disconnect (on_slot_active);
+            if (aslot is Miller) {
+                ((Miller)aslot).active.disconnect (on_miller_slot_active);
+            }
+
             aslot.path_changed.disconnect (on_slot_path_changed);
             aslot.new_container_request.disconnect (on_slot_new_container_request);
             aslot.selection_changed.disconnect (on_slot_selection_changed);
             aslot.directory_loaded.disconnect (on_slot_directory_loaded);
         }
 
-        private void on_slot_active (Files.AbstractSlot aslot, bool scroll, bool animate) {
+        private void on_miller_slot_active (Files.AbstractSlot aslot, bool scroll, bool animate) {
             refresh_slot_info (slot.location);
         }
 
@@ -461,18 +461,6 @@ namespace Files.View {
 
         public unowned Files.AbstractSlot? get_view () {
            return this.view != null ? this.view : null;
-        }
-
-        public void set_active_state (bool is_active, bool animate = true) {
-            var aslot = get_current_slot ();
-            if (aslot != null) {
-                aslot.grab_focus ();
-                /* Since async loading it may not have been determined whether slot is loadable */
-                aslot.set_active_state (is_active, animate);
-                if (is_active) {
-                    active ();
-                }
-            }
         }
 
         private void set_all_selected (bool select_all) {

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -1236,8 +1236,16 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         restoring_tabs = 0; // Required for update_headerbar to work when we select active tab
 
         int active_tab_position = app_preferences.get_int ("active-tab-position");
-        if (active_tab_position < 0 || active_tab_position >= restoring_tabs) {
+        if (active_tab_position < 0 || active_tab_position >= n_tabs_restored) {
             active_tab_position = 0;
+        }
+
+        // Select a page - will also trigger headerbar update via notify selected-page
+        var active_page = tab_view.get_nth_page (active_tab_position);
+        if (tab_view.selected_page == active_page) {
+            update_headerbar (); // setting the same page does not trigger notify selected-page
+        } else {
+            tab_view.selected_page = active_page;
         }
 
         string path = "";

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -510,7 +510,6 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         }
 
         loading_uri (current_container.uri);
-        current_container.set_active_state (true, false); /* changing tab should not cause animated scrolling */
         sidebar.sync_uri (current_container.uri);
         save_active_tab_position ();
     }
@@ -527,12 +526,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         ) {
             // Open a tab pointing at the default location if no tabs restored and none provided
             // Duplicates are not ignored
-            add_tab.begin (default_location, mode, false, () => {
-                // We can assume adding default tab always succeeds
-                // Ensure default tab's slot is active so it can be focused
-                current_container.set_active_state (true, false);
-            });
-
+            add_tab.begin (default_location, mode, false);
         } else {
             /* Open tabs at each requested location */
             /* As files may be derived from commandline, we use a new sanitized one */

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -369,7 +369,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
         tab_view.close_page.connect (tab_view_close_page);
 
-        tab_view.notify["selected-page"].connect (change_tab);
+        tab_view.notify["selected-page"].connect (after_change_tab);
 
         tab_view.create_window.connect (() => {
             return new Window (marlin_app).tab_view;
@@ -503,7 +503,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         });
     }
 
-    private void change_tab () {
+    private void after_change_tab () {
         //Ignore if some restored tabs still loading
         if (restoring_tabs > 0) {
             return;
@@ -1079,7 +1079,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         headerbar.destroy (); /* stop unwanted signals if quit while pathbar in focus */
 
         // Prevent saved focused tab changing
-        tab_view.notify["selected-page"].disconnect (change_tab);
+        tab_view.notify["selected-page"].disconnect (after_change_tab);
 
         for (int i = 0; i < tab_view.n_pages; i++) {
             var tab_page = (Hdy.TabPage) tab_view.get_nth_page (i);

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -509,7 +509,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             return;
         }
 
-        loading_uri (current_container.uri);
+        update_headerbar ();
         sidebar.sync_uri (current_container.uri);
         save_active_tab_position ();
     }
@@ -598,6 +598,9 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
         mode = real_mode (mode);
         var content = new View.ViewContainer ();
+        var page = tab_view.append (content); // This sets the window property on the content as well
+        tab_view.selected_page = page;
+        connect_content_signals (content);
 
         if (!location.equal (_location)) {
             content.add_view (mode, location, {_location});
@@ -605,11 +608,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             content.add_view (mode, location);
         }
 
-        var page = tab_view.append (content);
-        tab_view.selected_page = page;
-
-        connect_content_signals (content);
-
+        content.load_directory ();
         return true;
     }
 
@@ -628,22 +627,23 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
     private void on_content_loading (ViewContainer content, bool is_loading) {
         if (restoring_tabs > 0 && !is_loading) {
-            restoring_tabs--;
             /* Each restored tab must signal with is_loading false once */
             assert (restoring_tabs >= 0);
             if (!content.can_show_folder) {
                 warning ("Cannot restore %s, ignoring", content.uri);
                 /* remove_tab function uses Idle loop to close tab */
                 remove_content (content);
+                restoring_tabs--;
             }
         }
 
         tab_view.get_page (content).loading = is_loading;
 
         check_for_tabs_with_same_name ();
-        update_headerbar ();
 
         if (restoring_tabs == 0 && !is_loading) {
+        // Need to update after loading to set mode buttons correctly
+            update_headerbar ();
             save_tabs ();
         }
     }
@@ -1200,8 +1200,8 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                 continue;
             }
 
+            restoring_tabs++; // Ensure update headerbar ignored during initial tab creation
             if (yield add_tab_by_uri (root_uri, mode)) {
-                restoring_tabs++;
                 var tab = tab_view.selected_page;
                 if (tab != null &&
                     tab.child != null &&
@@ -1213,6 +1213,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
                     }
                 }
             } else {
+                restoring_tabs--;
                 debug ("Failed to restore tab %s", root_uri);
             }
 
@@ -1231,6 +1232,9 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             return 0;
         }
 
+        var n_tabs_restored = restoring_tabs; // Keep for later use and return value
+        restoring_tabs = 0; // Required for update_headerbar to work when we select active tab
+
         int active_tab_position = app_preferences.get_int ("active-tab-position");
         if (active_tab_position < 0 || active_tab_position >= restoring_tabs) {
             active_tab_position = 0;
@@ -1245,7 +1249,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             }
         }
 
-        return restoring_tabs;
+        return n_tabs_restored;
     }
 
     private void expand_miller_view (Miller miller_view, string tip_uri, string unescaped_root_uri) {
@@ -1294,7 +1298,8 @@ public class Files.View.Window : Hdy.ApplicationWindow {
     }
 
     private void update_headerbar () {
-        if (restoring_tabs > 0 || current_container == null) {
+        if (restoring_tabs > 0 || current_container == null || current_container.uri == "") {
+            // Do not update headerbar during initial tab creation
             return;
         }
 

--- a/src/View/Window.vala
+++ b/src/View/Window.vala
@@ -191,7 +191,7 @@ public class Files.View.Window : Hdy.ApplicationWindow {
             }
         }
 
-        loading_uri.connect (update_labels);
+        loading_uri.connect (update_headerbar);
         present ();
     }
 
@@ -1306,6 +1306,12 @@ public class Files.View.Window : Hdy.ApplicationWindow {
 
         location_bar.set_display_path (current_container.uri);
 
+        /* Update labels */
+        if (current_container != null) { /* Can happen during restore */
+            title = current_container.tab_name; /* Not actually visible on elementaryos */
+            sidebar.sync_uri (current_container.uri);
+        }
+
         /* Update viewmode switch, action state and settings */
         var mode = current_container.view_mode;
         view_switcher.set_mode (mode);
@@ -1350,12 +1356,6 @@ public class Files.View.Window : Hdy.ApplicationWindow {
         button_forward.menu = forward_menu;
     }
 
-    private void update_labels (string uri) {
-        if (current_container != null) { /* Can happen during restore */
-            title = current_container.tab_name; /* Not actually visible on elementaryos */
-            sidebar.sync_uri (uri);
-        }
-    }
 
     public void mount_removed (Mount mount) {
         debug ("Mount %s removed", mount.get_name ());


### PR DESCRIPTION
Start to simplify keeping the headerbar in sync without calling update_headerbar many times unnecessarily.

 - Merge another related function into update headerbar
 - Only necessary to connect to the active signal for Miller views as only these can change location without loading
 - Fixed keeping track of `restoring_tabs` and added another condition for ignoring `update_headerbar`
 - Stop triggering a load (and update) when a window is associated with a view container - it is unnecessary and overloads the function
 - Add some explanatory comments

In passing restoration of the active tab position was fixed. Fixes #2811 

Hopefully the rather complicated interface between Window and ViewContainer can be be further simplified in later PRs.