### PR TITLE
Better preview behaviour with small window

### DIFF
--- a/src/View/DetailsColumn.vala
+++ b/src/View/DetailsColumn.vala
@@ -246,7 +246,7 @@ public class Files.View.DetailsColumn : Gtk.Bin {
         var scrolled = new Gtk.ScrolledWindow (null, null) {
             child = box,
             propagate_natural_height = true,
-            hscrollbar_policy = NEVER
+            hscrollbar_policy = AUTOMATIC
         };
 
         child = scrolled;

--- a/src/View/Miller.vala
+++ b/src/View/Miller.vala
@@ -157,7 +157,7 @@ namespace Files.View {
                 draw_file_details_timeout_id = Timeout.add (200, () => {
                     draw_file_details_timeout_id = 0;
                     details = new View.DetailsColumn (file, view);
-                    add_side_widget (details, false, true); // Shrink but not resize
+                    add_side_widget (details, true, false); // Resize (expand) but not shrink
                     // Preview pane not part of slot list so no need to update width
                     // but need to scroll according to new available space
                     schedule_scroll_to_slot (last_slot, true);


### PR DESCRIPTION
Fixes #2816 

With a window narrower than the miller column width and preview column width combined we have to compromise.  The paned pack parameters are tweaked so the available area is divided equally between the two (subject to manual positioning of divider) and horizontal scrolling is enabled in the preview window. 

The drawback of this is that it is true even for larger windows so the user may still need to adjust the divider or window size for best results.

Optimising the layout automatically will require more complicated code afaict.