### PR TITLE
Fix crash on unmount when busy with other processes

### DIFF
--- a/libcore/FileOperations/MountUtils.vala
+++ b/libcore/FileOperations/MountUtils.vala
@@ -273,7 +273,7 @@ namespace Files.FileOperations {
             primary_text = _("The resource '%s' is in use by other processes").printf (mount_name);
             secondary_text = _("Unmounting now might cause a process to fail or to lose data");
             var sb = new StringBuilder ("");
-            sb.append (_("Other processes using '%s' ...\n").printf (mount_name));
+            sb.append (_("Other processes using '%s'… \n").printf (mount_name));
             foreach (var pid in processes) {
                 sb.append (get_process_name_from_pid (pid));
                 sb.append ("\n");
@@ -284,7 +284,7 @@ namespace Files.FileOperations {
         }
 
         private string? get_process_name_from_pid (int pid) {
-            string process_path = "/proc/%d/exe".printf(pid);
+            string process_path = "/proc/%d/exe".printf (pid);
 
             try {
                 string path = GLib.FileUtils.read_link (process_path);

--- a/libcore/FileOperations/MountUtils.vala
+++ b/libcore/FileOperations/MountUtils.vala
@@ -274,11 +274,22 @@ namespace Files.FileOperations {
             secondary_text = _("Unmounting now might cause a process to fail or to lose data");
             var sb = new StringBuilder ("");
             foreach (var pid in processes) {
-                sb.append (pid.to_string ());
+                sb.append (get_process_name_from_pid (pid));
                 sb.append ("\n");
             }
             show_error_details (sb.str);
             show_all ();
+        }
+
+        private string? get_process_name_from_pid (int pid) {
+            string process_path = "/proc/%d/exe".printf(pid);
+
+            try {
+                string path = GLib.FileUtils.read_link (process_path);
+                return Path.get_basename (path);
+            } catch (FileError e) {
+                return _("Unknown");
+            }
         }
      }
 }

--- a/libcore/FileOperations/MountUtils.vala
+++ b/libcore/FileOperations/MountUtils.vala
@@ -19,15 +19,18 @@
 namespace Files.FileOperations {
     public static async bool unmount_mount (Mount mount, Gtk.Window? parent) {
         if (mount.can_unmount ()) {
-            var mount_op = new Gtk.MountOperation (parent);
+            var mount_op = new UnmountOperation (parent, mount.get_name ());
             try {
-                yield mount.unmount_with_operation (
+                var success = yield mount.unmount_with_operation (
                         GLib.MountUnmountFlags.NONE,
                         mount_op,
                         null
                 );
-                return true;
+                return success;
             } catch (GLib.Error e) {
+                if (e is IOError.FAILED_HANDLED) {
+                    return false;
+                }
                 PF.Dialogs.show_error_dialog (_("Unable to unmount '%s'").printf (mount.get_name ()),
                                               e.message,
                                               null);
@@ -40,15 +43,19 @@ namespace Files.FileOperations {
 
     public static async bool eject_mount (Mount mount, Gtk.Window? parent) {
         if (mount.can_eject ()) {
-            var mount_op = new Gtk.MountOperation (parent);
+            var mount_op = new UnmountOperation (parent, mount.get_name ());
             try {
-                yield mount.eject_with_operation (
+                var success = yield mount.eject_with_operation (
                         GLib.MountUnmountFlags.NONE,
                         mount_op,
                         null
                 );
-                return true;
+                return success;
             } catch (GLib.Error e) {
+                if (e is IOError.FAILED_HANDLED) {
+                    return false;
+                }
+
                 PF.Dialogs.show_error_dialog (_("Unable to eject '%s'").printf (mount.get_name ()),
                                               e.message,
                                               null);
@@ -215,4 +222,63 @@ namespace Files.FileOperations {
 
         return false;
     }
+
+    private class UnmountOperation : Gtk.MountOperation {
+
+        public string mount_name { get; construct; }
+        private Gtk.Dialog? dialog = null;
+
+        public UnmountOperation (Gtk.Window? _parent, string _mount_name) {
+            Object (
+                parent: _parent,
+                mount_name: _mount_name
+            );
+        }
+
+        public override void show_processes (string message, Array<Pid> processes, string[] choices) {
+            if (dialog != null) {
+                return;
+            }
+
+            dialog = new BusyDialog (mount_name, processes);
+            dialog.response.connect (() => {
+                dialog.destroy ();
+                dialog = null;
+                reply (MountOperationResult.ABORTED); // Results in IOError.FAILED_HANDLED
+            });
+
+            dialog.present ();
+        }
+
+        public override void aborted () {
+            // We do not want another dialog shown
+            return;
+        }
+     }
+
+     private class BusyDialog : Granite.MessageDialog {
+        public string mount_name { get; construct; }
+        public Array<Pid> processes { get; construct; }
+        public BusyDialog (string _mount_name, Array<Pid> _processes) {
+            Object (
+                mount_name: _mount_name,
+                processes: _processes,
+                buttons: Gtk.ButtonsType.CANCEL,
+                image_icon: new ThemedIcon ("dialog-warning")
+
+            );
+        }
+
+        construct {
+            primary_text = _("The resource '%s' is in use by other processes").printf (mount_name);
+            secondary_text = _("Unmounting now might cause a process to fail or to lose data");
+            var sb = new StringBuilder ("");
+            foreach (var pid in processes) {
+                sb.append (pid.to_string ());
+                sb.append ("\n");
+            }
+            show_error_details (sb.str);
+            show_all ();
+        }
+     }
 }

--- a/libcore/FileOperations/MountUtils.vala
+++ b/libcore/FileOperations/MountUtils.vala
@@ -273,10 +273,12 @@ namespace Files.FileOperations {
             primary_text = _("The resource '%s' is in use by other processes").printf (mount_name);
             secondary_text = _("Unmounting now might cause a process to fail or to lose data");
             var sb = new StringBuilder ("");
+            sb.append (_("Other processes using '%s' ...\n").printf (mount_name));
             foreach (var pid in processes) {
                 sb.append (get_process_name_from_pid (pid));
                 sb.append ("\n");
             }
+
             show_error_details (sb.str);
             show_all ();
         }

--- a/src/View/Sidebar/AbstractMountableRow.vala
+++ b/src/View/Sidebar/AbstractMountableRow.vala
@@ -204,7 +204,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
     }
 
     protected async bool unmount_mount () {
-        if (working || !valid || permanent) {
+        if (!can_unmount || working || !valid || permanent) {
             return false;
         }
 
@@ -216,7 +216,7 @@ public abstract class Sidebar.AbstractMountableRow : Sidebar.BookmarkRow, Sideba
     }
 
     protected async bool eject_mount () {
-        if (working || !valid || permanent) {
+        if (!can_eject || working || !valid || permanent) {
             return false;
         }
 


### PR DESCRIPTION
Fixes #2821 

 - Use a custom MountOperation
 - Show our own dialog for showing other processes
 - Always abort for now

For simplicity a Granite.MessageDialog is used for now.
<img width="597" height="268" alt="Screenshot from 2026-08-31 18 03 13" src="https://github.com/user-attachments/assets/4b85a7e8-abca-4034-944d-4503297583fd" />

A problem is that if the competing process is FlatPak'd which is likely, the name of the competing process may well be that of a portal, not the original process. Not sure how to get round that.

In principle we could offer additional choices such forcing the unmount or ending the competing processes but that is left for design input.

