### PR TITLE
MarlinFileOperations simplify: Lose unused "debuting_files"

### DIFF
--- a/libcore/FileOperations/CopyMoveJob.vala
+++ b/libcore/FileOperations/CopyMoveJob.vala
@@ -20,7 +20,6 @@ public class Files.FileOperations.CopyMoveJob : CommonJob {
     protected bool is_move = false;
     protected GLib.List<GLib.File> files;
     protected GLib.File? destination;
-    protected GLib.HashTable<GLib.File,bool> debuting_files = new GLib.HashTable<GLib.File,bool> (GLib.File.hash, GLib.File.equal);
     protected bool replace_all = false;
     protected bool merge_all = false;
     protected bool keep_all_newest = false;

--- a/libcore/marlin-file-operations.c
+++ b/libcore/marlin-file-operations.c
@@ -876,7 +876,6 @@ static void copy_move_file (FilesFileOperationsCopyMoveJob *job,
                             char **dest_fs_type,
                             SourceInfo *source_info,
                             TransferInfo *transfer_info,
-                            GHashTable *debuting_files,
                             gboolean overwrite,
                             gboolean *skipped_file,
                             gboolean readonly_source_fs);
@@ -1006,7 +1005,6 @@ copy_move_directory (FilesFileOperationsCopyMoveJob *copy_job,
                      char **parent_dest_fs_type,
                      SourceInfo *source_info,
                      TransferInfo *transfer_info,
-                     GHashTable *debuting_files,
                      gboolean *skipped_file,
                      gboolean readonly_source_fs)
 {
@@ -1040,9 +1038,6 @@ copy_move_directory (FilesFileOperationsCopyMoveJob *copy_job,
             break;
         }
 
-        if (debuting_files) {
-            g_hash_table_replace (debuting_files, g_object_ref (*dest), GINT_TO_POINTER (TRUE));
-        }
 
     }
 
@@ -1065,7 +1060,7 @@ retry:
             src_file = g_file_get_child (src,
                                          g_file_info_get_name (info));
             copy_move_file (copy_job, src_file, *dest, same_fs, FALSE, &dest_fs_type,
-                            source_info, transfer_info, NULL, FALSE, &local_skipped_file,
+                            source_info, transfer_info, FALSE, &local_skipped_file,
                             readonly_source_fs);
             g_object_unref (src_file);
             g_object_unref (info);
@@ -1123,9 +1118,6 @@ retry:
         transfer_info->num_files ++;
         marlin_file_operations_copy_move_job_report_copy_progress (copy_job, source_info, transfer_info);
 
-        if (debuting_files) {
-            g_hash_table_replace (debuting_files, g_object_ref (*dest), GINT_TO_POINTER (create_dest));
-        }
     } else if (IS_IO_ERROR (error, CANCELLED)) {
         g_error_free (error);
     } else {
@@ -1526,7 +1518,6 @@ copy_move_file (FilesFileOperationsCopyMoveJob *copy_job,
                 char **dest_fs_type,
                 SourceInfo *source_info,
                 TransferInfo *transfer_info,
-                GHashTable *debuting_files,
                 gboolean overwrite,
                 gboolean *skipped_file,
                 gboolean readonly_source_fs)
@@ -1677,15 +1668,7 @@ retry:
         transfer_info->num_files ++;
         marlin_file_operations_copy_move_job_report_copy_progress (copy_job, source_info, transfer_info);
 
-        if (debuting_files) {
-            /*if (position) {
-                //files_file_changes_queue_schedule_position_set (dest, *position, job->screen_num);
-            } else {
-                //files_file_changes_queue_schedule_position_remove (dest);
-            }*/
 
-            g_hash_table_replace (debuting_files, g_object_ref (dest), GINT_TO_POINTER (TRUE));
-        }
         if (copy_job->is_move) {
             files_file_changes_queue_file_moved (src, dest);
         } else {
@@ -1905,7 +1888,7 @@ retry:
         if (!copy_move_directory (copy_job, src, &dest, same_fs,
                                   would_recurse, dest_fs_type,
                                   source_info, transfer_info,
-                                  debuting_files, skipped_file,
+                                  skipped_file,
                                   readonly_source_fs)) {
             /* destination changed, since it was an invalid file name */
             g_assert (*dest_fs_type != NULL);
@@ -2022,7 +2005,6 @@ copy_files (FilesFileOperationsCopyMoveJob *job,
                             same_fs, unique_names,
                             &dest_fs_type,  //dest_fs_type always null?
                             source_info, transfer_info,
-                            job->debuting_files,
                             FALSE, &skipped_file,
                             readonly_source_fs);
             g_object_unref (dest);
@@ -2164,7 +2146,6 @@ move_file_prepare (FilesFileOperationsCopyMoveJob *move_job,
                    GFile *dest_dir,
                    gboolean same_fs,
                    char **dest_fs_type,
-                   GHashTable *debuting_files,
                    GList **fallback_files,
                    int files_left)
 {
@@ -2231,9 +2212,6 @@ retry:
                      NULL,
                      &error)) {
 
-        if (debuting_files) {
-            g_hash_table_replace (debuting_files, g_object_ref (dest), GINT_TO_POINTER (TRUE));
-        }
 
         files_file_changes_queue_file_moved (src, dest);
 
@@ -2417,7 +2395,6 @@ move_files_prepare (FilesFileOperationsCopyMoveJob *job,
 
         move_file_prepare (job, src, job->destination,
                            same_fs, dest_fs_type,
-                           job->debuting_files,
                            fallbacks,
                            left);
         marlin_file_operations_copy_move_job_report_move_progress (job, total, --left);
@@ -2465,7 +2442,6 @@ move_files (FilesFileOperationsCopyMoveJob *job,
         copy_move_file (job, src, job->destination,
                         same_fs, FALSE, dest_fs_type,
                         source_info, transfer_info,
-                        job->debuting_files,
                         fallback->overwrite, &skipped_file, FALSE);
         i++;
     }
@@ -2584,7 +2560,6 @@ static void
 link_file (FilesFileOperationsCopyMoveJob *job,
            GFile *src, GFile *dest_dir,
            char **dest_fs_type,
-           GHashTable *debuting_files,
            int files_left)
 {
     GFile *src_dir, *dest, *new_dest;
@@ -2628,9 +2603,6 @@ retry:
 
         g_free (path);
 
-        if (debuting_files) {
-            g_hash_table_replace (debuting_files, g_object_ref (dest), GINT_TO_POINTER (TRUE));
-        }
        files_file_changes_queue_file_added (dest, TRUE);
 
         g_object_unref (dest);
@@ -2758,7 +2730,7 @@ link_job (GTask *task,
 
 
         link_file (job, src, job->destination,
-                   &dest_fs_type, job->debuting_files,
+                   &dest_fs_type,
                    left);
         marlin_file_operations_copy_move_job_report_link_progress (job, total, --left);
         i++;


### PR DESCRIPTION
A small step towards simplifying/porting `marlin-file-operations.c`